### PR TITLE
post v601 release updates

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,28 +4,25 @@ on:
   push:
     tags:
       - "v*.*.*"
-permissions:
-  contents: read
-
 jobs:
   goreleaser:
-    permissions:
-      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: ubuntu-latest
+    environment: release
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
-      - name: Install Go
+          submodules: true
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-      - name: Create release
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          args: release --rm-dist
+          check-latest: true
+      - name: release dry run
+        run: make release-dry-run
+      - name: setup release environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+      - name: release publish
+        run: make release

--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,43 @@ localnet-show-logstream:
 .PHONY: build-docker-local-evmos localnet-start localnet-stop
 
 ###############################################################################
+###                                Releasing                                ###
+###############################################################################
+
+PACKAGE_NAME:=github.com/evmos/evmos
+GOLANG_CROSS_VERSION  = v1.18
+GOPATH ?= '$(HOME)/go'
+release-dry-run:
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-v ${GOPATH}/pkg:/go/pkg \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate --skip-publish --snapshot
+
+release:
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		release --rm-dist --skip-validate
+
+.PHONY: release-dry-run release
+
+###############################################################################
 ###                        Compile Solidity Contracts                       ###
 ###############################################################################
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -62,7 +62,7 @@ module.exports = {
       rpc_url_local: 'http://localhost:8545/',
       chain_id: '9001',
       testnet_chain_id: '9000',
-      latest_version: 'v5.0.0',
+      latest_version: 'v6.0.1',
       version_number: '2',
       testnet_version_number: '4',
       testnet_evm_explorer_url: 'https://evm.evmos.dev',
@@ -202,7 +202,7 @@ module.exports = {
               title: 'IBC Channels',
               directory: false,
               path: '/protocol/ibc'
-            }, 
+            },
             {
               title: 'Evmos Go API',
               path: 'https://pkg.go.dev/github.com/evmos/evmos'

--- a/docs/validators/upgrades/upgrades.md
+++ b/docs/validators/upgrades/upgrades.md
@@ -9,20 +9,22 @@ Check the details and requirements for each mainnet and testnet upgrade. {synops
 :::: tabs
 ::: tab Mainnet
 
-| Version                                                                    | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                         |
-| -------------------------------------------------------------------------- | :-----: | :------: | :--------: | :-----------------: | ------------------------------------------------------ |
-| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [837,500](https://www.mintscan.io/evmos/blocks/837500) |
-| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)           |   ❌    |    ✅    |     ❌     |         ❌          | [257,850](https://www.mintscan.io/evmos/blocks/257850) |
-| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)           |   ❌    |    ✅    |     ✅     |         ✅          | [58,701](https://www.mintscan.io/evmos/blocks/58701)   |
-| [`v2.0.1`](https://github.com/evmos/evmos/releases/tag/v2.0.1)           |   ❌    |    ❌    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)   |
-| [`v2.0.0`](https://github.com/evmos/evmos/releases/tag/v2.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)   |
-| [`v1.0.0`](https://github.com/evmos/evmos/releases/tag/v1.0.0) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |         ❌          | [1](https://www.mintscan.io/evmos/blocks/1)            |
+| Version                                                                  | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                            |
+| ------------------------------------------------------------------------ | :-----: | :------: | :--------: | :-----------------: | --------------------------------------------------------- |
+| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)           |   ✅    |    ✅    |     ❌     |         ❌          | [1,042,000](https://www.mintscan.io/evmos/blocks/1042000) |
+| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [837,500](https://www.mintscan.io/evmos/blocks/837500)    |
+| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)           |   ❌    |    ✅    |     ❌     |         ❌          | [257,850](https://www.mintscan.io/evmos/blocks/257850)    |
+| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)           |   ❌    |    ✅    |     ✅     |         ✅          | [58,701](https://www.mintscan.io/evmos/blocks/58701)      |
+| [`v2.0.1`](https://github.com/evmos/evmos/releases/tag/v2.0.1)           |   ❌    |    ❌    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
+| [`v2.0.0`](https://github.com/evmos/evmos/releases/tag/v2.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
+| [`v1.0.0`](https://github.com/evmos/evmos/releases/tag/v1.0.0) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |         ❌          | [1](https://www.mintscan.io/evmos/blocks/1)               |
 
 :::
 ::: tab Testnet
 
-| Version                                                                                | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                                        |
-| -------------------------------------------------------------------------------------- | :-----: | :------: | :--------: | :-----------------: | --------------------------------------------------------------------- |
+| Version                                                                              | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                                        |
+| ------------------------------------------------------------------------------------ | :-----: | :------: | :--------: | :-----------------: | --------------------------------------------------------------------- |
+| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)                       |   ✅    |    ✅    |     ❌     |         ❌          | [2,176,500](https://testnet.mintscan.io/evmos-testnet/blocks/2176500) |
 | [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)                       |   ✅    |    ✅    |     ❌     |         ❌          | [1,762,500](https://testnet.mintscan.io/evmos-testnet/blocks/1762500) |
 | [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)                       |   ✅    |    ✅    |     ❌     |         ❌          | [1,200,000](https://testnet.mintscan.io/evmos-testnet/blocks/1200000) |
 | [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)                       |   ✅    |    ✅    |     ❌     |         ❌          |                                                                       |


### PR DESCRIPTION
- spec(post-release): update v5.0.0 to v6.0.1`
- ci(post-release): fix goreleaser workflow
