### PR TITLE
audit(feesplit): completeness audit

### DIFF
--- a/x/README.md
+++ b/x/README.md
@@ -11,7 +11,7 @@ Here are some production-grade modules that can be used in Evmos applications, a
 - [erc20](erc20/spec/README.md) - Trustless, on-chain bidirectional internal conversion of tokens between Evmos' EVM and Cosmos runtimes.
 - [evm](https://docs.evmos.org/modules/evm/) - Smart Contract deployment and execution on Cosmos
 - [feemarket](https://docs.evmos.org/modules/feemarket/) - Fee market implementation based on the EIP1559 specification.
-- [fees](fees/spec/README.md) - Split EVM transaction fees between block proposer and smart contract developers.
+- [feesplit](feesplit/spec/README.md) - Split EVM transaction fees between block proposer and smart contract developers.
 - [incentives](incentives/spec/README.md) - Incentivize user interaction with governance-approved smart contracts.
 - [inflation](inflation/spec/README.md) - Mint tokens and allocate them to staking rewards, usage incentives and community pool.
 - [vesting](vesting/spec/README.md) - Vesting accounts with lockup and clawback capabilities.

--- a/x/feesplit/client/cli/tx.go
+++ b/x/feesplit/client/cli/tx.go
@@ -40,7 +40,7 @@ func NewTxCmd() *cobra.Command {
 func NewRegisterFeeSplit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "register [contract_hex] [nonces] [withdraw_bech32]",
-		Short: "Register a contract for fee distribution",
+		Short: "Register a contract for fee distribution. **NOTE** Please ensure, that the deployer of the contract (or the factory that deployes the contract) is an account that is owned by your project, to avoid that an individual deployer who leaves your project becomes malicious.",
 		Long:  "Register a contract for fee distribution.\nOnly the contract deployer can register a contract.\nProvide the account nonce(s) used to derive the contract address. E.g.: you have an account nonce of 4 when you send a deployment transaction for a contract A; you use this contract as a factory, to create another contract B. If you register A, the nonces value is \"4\". If you register B, the nonces value is \"4,1\" (B is the first contract created by A). \nThe withdraw address defaults to the deployer address if not provided.",
 		Args:  cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/feesplit/genesis_test.go
+++ b/x/feesplit/genesis_test.go
@@ -1,0 +1,118 @@
+package feesplit_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/crypto/tmhash"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
+	"github.com/tendermint/tendermint/version"
+
+	"github.com/evmos/ethermint/tests"
+	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+
+	"github.com/evmos/evmos/v6/app"
+	"github.com/evmos/evmos/v6/x/feesplit"
+	"github.com/evmos/evmos/v6/x/feesplit/types"
+)
+
+type GenesisTestSuite struct {
+	suite.Suite
+
+	ctx sdk.Context
+
+	app     *app.Evmos
+	genesis types.GenesisState
+}
+
+func (suite *GenesisTestSuite) SetupTest() {
+	// consensus key
+	consAddress := sdk.ConsAddress(tests.GenerateAddress().Bytes())
+
+	suite.app = app.Setup(false, feemarkettypes.DefaultGenesisState())
+	suite.ctx = suite.app.BaseApp.NewContext(false, tmproto.Header{
+		Height:          1,
+		ChainID:         "evmos_9000-1",
+		Time:            time.Now().UTC(),
+		ProposerAddress: consAddress.Bytes(),
+
+		Version: tmversion.Consensus{
+			Block: version.BlockProtocol,
+		},
+		LastBlockId: tmproto.BlockID{
+			Hash: tmhash.Sum([]byte("block_id")),
+			PartSetHeader: tmproto.PartSetHeader{
+				Total: 11,
+				Hash:  tmhash.Sum([]byte("partset_header")),
+			},
+		},
+		AppHash:            tmhash.Sum([]byte("app")),
+		DataHash:           tmhash.Sum([]byte("data")),
+		EvidenceHash:       tmhash.Sum([]byte("evidence")),
+		ValidatorsHash:     tmhash.Sum([]byte("validators")),
+		NextValidatorsHash: tmhash.Sum([]byte("next_validators")),
+		ConsensusHash:      tmhash.Sum([]byte("consensus")),
+		LastResultsHash:    tmhash.Sum([]byte("last_result")),
+	})
+
+	suite.genesis = *types.DefaultGenesisState()
+}
+
+func TestGenesisTestSuite(t *testing.T) {
+	suite.Run(t, new(GenesisTestSuite))
+}
+
+func (suite *GenesisTestSuite) TestFeesplitInitGenesis() {
+	testCases := []struct {
+		name     string
+		genesis  types.GenesisState
+		expPanic bool
+	}{
+		{
+			"default genesis",
+			suite.genesis,
+			false,
+		},
+		{
+			"custom genesis - feesplit disabled",
+			types.GenesisState{
+				Params: types.Params{
+					EnableFeeSplit:           false,
+					DeveloperShares:          types.DefaultDeveloperShares,
+					AddrDerivationCostCreate: types.DefaultAddrDerivationCostCreate,
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest() // reset
+
+			if tc.expPanic {
+				suite.Require().Panics(func() {
+					feesplit.InitGenesis(suite.ctx, suite.app.FeesplitKeeper, tc.genesis)
+				})
+			} else {
+				suite.Require().NotPanics(func() {
+					feesplit.InitGenesis(suite.ctx, suite.app.FeesplitKeeper, tc.genesis)
+				})
+
+				params := suite.app.FeesplitKeeper.GetParams(suite.ctx)
+				suite.Require().Equal(tc.genesis.Params, params)
+			}
+		})
+	}
+}
+
+func (suite *GenesisTestSuite) TestFeesplitExportGenesis() {
+	feesplit.InitGenesis(suite.ctx, suite.app.FeesplitKeeper, suite.genesis)
+
+	genesisExported := feesplit.ExportGenesis(suite.ctx, suite.app.FeesplitKeeper)
+	suite.Require().Equal(genesisExported.Params, suite.genesis.Params)
+}

--- a/x/feesplit/spec/01_concepts.md
+++ b/x/feesplit/spec/01_concepts.md
@@ -12,6 +12,11 @@ The Evmos dApp store is a revenue-per-transaction model, which allows developers
 
 Developers register their application in the dApp store by registering their application's smart contracts. Any contract can be registered by a developer by submitting a signed transaction. The signer of this transaction must match the address of the deployer of the contract in order for the registration to succeed. After the transaction is executed successfully, the developer will start receiving a portion of the transaction fees paid when a user interacts with the registered contract.
 
+::: tip
+ **NOTE**: If your contract is part of a developer project, please ensure that the deployer of the contract (or the factory that deployes the contract) is an account that is owned by that project. THis avoids that an individual deployer who leaves your project becomes malicious.
+:::
+
+
 ## Fee Distribution
 
 As described above, developers will earn a portion of the transaction fee after registering their contracts. To understand how transaction fees are distributed, we look at the following two things in detail:

--- a/x/feesplit/spec/01_concepts.md
+++ b/x/feesplit/spec/01_concepts.md
@@ -16,7 +16,6 @@ Developers register their application in the dApp store by registering their app
  **NOTE**: If your contract is part of a developer project, please ensure that the deployer of the contract (or the factory that deployes the contract) is an account that is owned by that project. THis avoids that an individual deployer who leaves your project becomes malicious.
 :::
 
-
 ## Fee Distribution
 
 As described above, developers will earn a portion of the transaction fee after registering their contracts. To understand how transaction fees are distributed, we look at the following two things in detail:


### PR DESCRIPTION
## Description

This PR adds missing genesis import export tests and a notes for projects to deploy their contracts from a project owned account, rather than from the account of an individual contributor. 

Closes: ENG-453 https://linear.app/evmos/issue/ENG-453/completeness-audit  and ENG-522 https://linear.app/evmos/issue/ENG-522/fee-deployer-could-be-malicious