### PR TITLE
migration(testnet): add v7 migration for moving inacessible faucet address

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -112,6 +112,7 @@ import (
 	v4 "github.com/evmos/evmos/v6/app/upgrades/v4"
 	v5 "github.com/evmos/evmos/v6/app/upgrades/v5"
 	v6 "github.com/evmos/evmos/v6/app/upgrades/v6"
+	v7 "github.com/evmos/evmos/v6/app/upgrades/v7"
 	"github.com/evmos/evmos/v6/x/claims"
 	claimskeeper "github.com/evmos/evmos/v6/x/claims/keeper"
 	claimstypes "github.com/evmos/evmos/v6/x/claims/types"
@@ -1072,6 +1073,15 @@ func (app *Evmos) setupUpgradeHandlers() {
 		),
 	)
 
+	// v7 upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v7.UpgradeName,
+		v7.CreateUpgradeHandler(
+			app.mm, app.configurator,
+			app.BankKeeper,
+		),
+	)
+
 	// When a planned update height is reached, the old binary will panic
 	// writing on disk the height and name of the update that triggered it
 	// This will read that value, and execute the preparations for the upgrade.
@@ -1095,6 +1105,8 @@ func (app *Evmos) setupUpgradeHandlers() {
 		// no store upgrades in v5
 	case v6.UpgradeName:
 		// no store upgrades in v6
+	case v7.UpgradeName:
+		// no store upgrades in v7
 	}
 
 	if storeUpgrades != nil {

--- a/app/upgrades/v6/upgrades.go
+++ b/app/upgrades/v6/upgrades.go
@@ -19,7 +19,7 @@ import (
 	claimskeeper "github.com/evmos/evmos/v6/x/claims/keeper"
 )
 
-// CreateUpgradeHandler creates an SDK upgrade handler for v5
+// CreateUpgradeHandler creates an SDK upgrade handler for v6
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,

--- a/app/upgrades/v7/constants.go
+++ b/app/upgrades/v7/constants.go
@@ -1,0 +1,17 @@
+package v7
+
+const (
+	// UpgradeName is the shared upgrade plan name for mainnet and testnet
+	UpgradeName = "v7.0.0"
+	// TODO MainnetUpgradeHeight defines the Evmos mainnet block height on which the upgrade will take place
+	MainnetUpgradeHeight = 1_042_000
+	// TODO TestnetUpgradeHeight defines the Evmos testnet block height on which the upgrade will take place
+	TestnetUpgradeHeight = 2_176_500
+	// UpgradeInfo defines the binaries that will be used for the upgrade
+	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Darwin_arm64.tar.gz","darwin/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Darwin_x86_64.tar.gz","linux/arm64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Linux_arm64.tar.gz","linux/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Linux_x86_64.tar.gz","windows/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Windows_x86_64.zip"}}'`
+
+	// FaucetAddressFrom is the inaccessible secp address of the Testnet Faucet
+	FaucetAddressFrom = "evmos1z4ya98ga2xnffn2mhjym7tzlsm49ec23890sze"
+	// FaucetAddressTo is the new eth_secp address of the Testnet Faucet
+	FaucetAddressTo = "evmos1ujm4z5v9zkdqm70xnptr027gqu90f7lxjr0fch"
+)

--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -1,0 +1,45 @@
+package v7
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/evmos/evmos/v6/types"
+)
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v7
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bk bankkeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		// Refs:
+		// - https://docs.cosmos.network/master/building-modules/upgrade.html#registering-migrations
+		// - https://docs.cosmos.network/master/migrations/chain-upgrade-guide-044.html#chain-upgrade
+
+		if types.IsTestnet(ctx.ChainID()) {
+			logger.Debug("migrating inaccessible balance of secp faucet account...")
+			MigrateFaucetBalance(ctx, bk)
+		}
+
+		// Leave modules are as-is to avoid running InitGenesis.
+		logger.Debug("running module migrations ...")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}
+
+// MigrateFaucetBalance transfers all balances of the inaccessible secp256k1
+// Faucet address to a eth_secp256k1 address.
+func MigrateFaucetBalance(ctx sdk.Context, bk bankkeeper.Keeper) {
+	from := sdk.MustAccAddressFromBech32(FaucetAddressTo)
+	to := sdk.MustAccAddressFromBech32(FaucetAddressTo)
+	balances := bk.GetAllBalances(ctx, from)
+	if err := bk.SendCoins(ctx, from, to, balances); err != nil {
+		panic(err)
+	}
+}

--- a/app/upgrades/v7/upgrades_test.go
+++ b/app/upgrades/v7/upgrades_test.go
@@ -1,0 +1,123 @@
+package v7_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/tendermint/tendermint/crypto/tmhash"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
+	"github.com/tendermint/tendermint/version"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+
+	"github.com/evmos/evmos/v6/app"
+	v7 "github.com/evmos/evmos/v6/app/upgrades/v7"
+	"github.com/evmos/evmos/v6/testutil"
+	evmostypes "github.com/evmos/evmos/v6/types"
+)
+
+type UpgradeTestSuite struct {
+	suite.Suite
+
+	ctx         sdk.Context
+	app         *app.Evmos
+	consAddress sdk.ConsAddress
+}
+
+func (suite *UpgradeTestSuite) SetupTest(chainID string) {
+	checkTx := false
+
+	// consensus key
+	priv, err := ethsecp256k1.GenerateKey()
+	suite.Require().NoError(err)
+	suite.consAddress = sdk.ConsAddress(priv.PubKey().Address())
+
+	// NOTE: this is the new binary, not the old one.
+	suite.app = app.Setup(checkTx, feemarkettypes.DefaultGenesisState())
+	suite.ctx = suite.app.BaseApp.NewContext(checkTx, tmproto.Header{
+		Height:          1,
+		ChainID:         chainID,
+		Time:            time.Date(2022, 5, 9, 8, 0, 0, 0, time.UTC),
+		ProposerAddress: suite.consAddress.Bytes(),
+
+		Version: tmversion.Consensus{
+			Block: version.BlockProtocol,
+		},
+		LastBlockId: tmproto.BlockID{
+			Hash: tmhash.Sum([]byte("block_id")),
+			PartSetHeader: tmproto.PartSetHeader{
+				Total: 11,
+				Hash:  tmhash.Sum([]byte("partset_header")),
+			},
+		},
+		AppHash:            tmhash.Sum([]byte("app")),
+		DataHash:           tmhash.Sum([]byte("data")),
+		EvidenceHash:       tmhash.Sum([]byte("evidence")),
+		ValidatorsHash:     tmhash.Sum([]byte("validators")),
+		NextValidatorsHash: tmhash.Sum([]byte("next_validators")),
+		ConsensusHash:      tmhash.Sum([]byte("consensus")),
+		LastResultsHash:    tmhash.Sum([]byte("last_result")),
+	})
+
+	cp := suite.app.BaseApp.GetConsensusParams(suite.ctx)
+	suite.ctx = suite.ctx.WithConsensusParams(cp)
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	s := new(UpgradeTestSuite)
+	suite.Run(t, s)
+}
+
+func (suite *UpgradeTestSuite) TestMigrateFaucetBalance() {
+	testCases := []struct {
+		name              string
+		chainID           string
+		malleate          func()
+		expectedMigration bool
+	}{
+		{
+			"Testnet - sucess",
+			evmostypes.TestnetChainID + "-4",
+			func() {
+			},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.SetupTest(tc.chainID) // reset
+
+			from := sdk.MustAccAddressFromBech32(v7.FaucetAddressTo)
+			to := sdk.MustAccAddressFromBech32(v7.FaucetAddressTo)
+			coins := sdk.NewCoins(sdk.NewCoin(suite.app.StakingKeeper.BondDenom(suite.ctx), sdk.NewInt(1000)))
+			err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, from, coins)
+			suite.Require().Nil(err)
+
+			tc.malleate()
+
+			suite.Require().NotPanics(func() {
+				v7.MigrateFaucetBalance(suite.ctx, suite.app.BankKeeper)
+				suite.app.Commit()
+			})
+
+			balancesFrom := suite.app.BankKeeper.GetAllBalances(suite.ctx, from)
+			balancesTo := suite.app.BankKeeper.GetAllBalances(suite.ctx, to)
+
+			if tc.expectedMigration {
+				suite.Require().True(balancesFrom.IsZero())
+				suite.Require().Equal(coins, balancesTo)
+			} else {
+				suite.Require().Equal(coins, balancesFrom)
+				suite.Require().Nil(balancesTo)
+			}
+		})
+	}
+}

--- a/app/upgrades/v7/upgrades_test.go
+++ b/app/upgrades/v7/upgrades_test.go
@@ -76,17 +76,17 @@ func TestUpgradeTestSuite(t *testing.T) {
 }
 
 func (suite *UpgradeTestSuite) TestMigrateFaucetBalance() {
+	from := sdk.MustAccAddressFromBech32(v7.FaucetAddressFrom)
+	to := sdk.MustAccAddressFromBech32(v7.FaucetAddressTo)
+
 	testCases := []struct {
 		name              string
 		chainID           string
-		malleate          func()
 		expectedMigration bool
 	}{
 		{
 			"Testnet - sucess",
 			evmostypes.TestnetChainID + "-4",
-			func() {
-			},
 			true,
 		},
 	}
@@ -95,16 +95,12 @@ func (suite *UpgradeTestSuite) TestMigrateFaucetBalance() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest(tc.chainID) // reset
 
-			from := sdk.MustAccAddressFromBech32(v7.FaucetAddressTo)
-			to := sdk.MustAccAddressFromBech32(v7.FaucetAddressTo)
 			coins := sdk.NewCoins(sdk.NewCoin(suite.app.StakingKeeper.BondDenom(suite.ctx), sdk.NewInt(1000)))
 			err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, from, coins)
 			suite.Require().Nil(err)
 
-			tc.malleate()
-
 			suite.Require().NotPanics(func() {
-				v7.MigrateFaucetBalance(suite.ctx, suite.app.BankKeeper)
+				v7.MigrateFaucetBalances(suite.ctx, suite.app.BankKeeper)
 				suite.app.Commit()
 			})
 

--- a/app/upgrades/v7/upgrades_test.go
+++ b/app/upgrades/v7/upgrades_test.go
@@ -97,7 +97,7 @@ func (suite *UpgradeTestSuite) TestMigrateFaucetBalance() {
 
 			coins := sdk.NewCoins(sdk.NewCoin(suite.app.StakingKeeper.BondDenom(suite.ctx), sdk.NewInt(1000)))
 			err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, from, coins)
-			suite.Require().Nil(err)
+			suite.Require().NoError(err)
 
 			suite.Require().NotPanics(func() {
 				v7.MigrateFaucetBalances(suite.ctx, suite.app.BankKeeper)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/tendermint/tendermint v0.34.20-0.20220517115723-e6f071164839
 	github.com/tendermint/tm-db v0.6.7
 	go.opencensus.io v0.23.0
-	google.golang.org/genproto v0.0.0-20220630174209-ad1d48641aa7
+	google.golang.org/genproto v0.0.0-20220711132622-b6f31b0ceb50
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1706,8 +1706,8 @@ google.golang.org/genproto v0.0.0-20220304144024-325a89244dc8/go.mod h1:kGP+zUP2
 google.golang.org/genproto v0.0.0-20220310185008-1973136f34c6/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
 google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
-google.golang.org/genproto v0.0.0-20220630174209-ad1d48641aa7 h1:q4zUJDd0+knPFB9x20S3vnxzlYNBbt8Yd7zBMVMteeM=
-google.golang.org/genproto v0.0.0-20220630174209-ad1d48641aa7/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220711132622-b6f31b0ceb50 h1:gyHXMCq6jOxTS4ywai4Ht8kjJcDRxkmtCJERlZ3nGms=
+google.golang.org/genproto v0.0.0-20220711132622-b6f31b0ceb50/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=


### PR DESCRIPTION
## Description

This PR migrates the testnet faucet balance.

Closes ENG-151: https://linear.app/evmos/issue/ENG-151/migrate-inaccessible-balance-of-secp-faucet-account-to-new-address