### PR TITLE
release: v4.0.2 changelog and bump ethermint version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
 
-(erc20) [\#592](https://github.com/tharsis/evmos/pull/592) Completeness audit
+## [v4.0.2] - 2022-07-13
+
+- (deps) [\#770](https://github.com/evmos/evmos/pull/770) Bump Ethermint version to [`v0.15.1`](https://github.com/evmos/ethermint/releases/tag/v0.15.1)
+
 
 ## [v4.0.1] - 2022-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v4.0.2] - 2022-07-13
 
-- (deps) [\#770](https://github.com/evmos/evmos/pull/770) Bump Ethermint version to [`v0.15.1`](https://github.com/evmos/ethermint/releases/tag/v0.15.1)
+- (deps) [\#771](https://github.com/evmos/evmos/pull/771) Bump Ethermint version to [`v0.15.1`](https://github.com/evmos/ethermint/releases/tag/v0.15.1)
 
 
 ## [v4.0.1] - 2022-05-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-
 ## [v4.0.2] - 2022-07-13
 
 - (deps) [\#771](https://github.com/evmos/evmos/pull/771) Bump Ethermint version to [`v0.15.1`](https://github.com/evmos/ethermint/releases/tag/v0.15.1)
-
 
 ## [v4.0.1] - 2022-05-10
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.7
-	github.com/tharsis/ethermint v0.15.0
+	github.com/tharsis/ethermint v0.15.1
 	go.opencensus.io v0.23.0
 	google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e
 	google.golang.org/grpc v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8
 github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
 github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
 github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
-github.com/tharsis/ethermint v0.15.0 h1:fgvQAGQtZSY1irTUwNgEuEpDvmlrZ6CJGDJIkMgh3C0=
-github.com/tharsis/ethermint v0.15.0/go.mod h1:iSfKPtakU/uF9qp7VGW9/1UbSh6nm0INvFGlf448DY0=
+github.com/tharsis/ethermint v0.15.1 h1:/+UyXZfVz7DM/OMFsfySFvICMsLAQihMGh85EcR53b0=
+github.com/tharsis/ethermint v0.15.1/go.mod h1:iSfKPtakU/uF9qp7VGW9/1UbSh6nm0INvFGlf448DY0=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
## Description

This PR bumps the Ethermint version that includes a backport patch for the `eth_getBalance` JSON-RPC endpoint in order to query historical archive nodes:

[- fix(rpc): optimize `eth_getBalance` endpoint (#1169)
](https://github.com/evmos/ethermint/pull/1169/files)
Related issue: https://linear.app/evmos/issue/ENG-577/release-ethermint-and-evmos-patches-for-historical-archive-nodes