### PR TITLE
ci(goreleaser): revert to make command

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,26 +4,25 @@ on:
   push:
     tags:
       - "v*.*.*"
-permissions:
-  contents: read
-
 jobs:
   goreleaser:
-    permissions:
-      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: ubuntu-latest
+    environment: release
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
-      - name: Install Go
+          submodules: true
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: Create release
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          args: release --rm-dist
+          check-latest: true
+      - name: release dry run
+        run: make release-dry-run
+      - name: setup release environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+      - name: release publish
+        run: make release

--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,43 @@ localnet-show-logstream:
 .PHONY: build-docker-local-evmos localnet-start localnet-stop
 
 ###############################################################################
+###                                Releasing                                ###
+###############################################################################
+
+PACKAGE_NAME:=github.com/evmos/evmos
+GOLANG_CROSS_VERSION  = v1.18
+GOPATH ?= '$(HOME)/go'
+release-dry-run:
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-v ${GOPATH}/pkg:/go/pkg \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate --skip-publish --snapshot
+
+release:
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		release --rm-dist --skip-validate
+
+.PHONY: release-dry-run release
+
+###############################################################################
 ###                        Compile Solidity Contracts                       ###
 ###############################################################################
 


### PR DESCRIPTION
## Description

This PR changes the release github action to use the original make script that was replaced [here](https://github.com/evmos/evmos/commit/bd2a9a569dd4a385676029d2d6aae307db54eaa2) using, but now using go v.18