### PR TITLE
danburck/release v701

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v7.0.1] - 2002-08-08
+
+### Improvements
+
+- (Upgrade) [\#831](https://github.com/evmos/evmos/pull/831) Set Testnet v7 upgrade height
+
 ## [v7.0.0] - 2002-08-04
 
 ### State Machine Breaking

--- a/app/upgrades/v7/constants.go
+++ b/app/upgrades/v7/constants.go
@@ -6,7 +6,7 @@ const (
 	// MainnetUpgradeHeight defines the Evmos mainnet block height on which the upgrade will take place
 	MainnetUpgradeHeight = 2_476_000
 	// TestnetUpgradeHeight defines the Evmos testnet block height on which the upgrade will take place
-	TestnetUpgradeHeight = 2_176_500 // TODO:
+	TestnetUpgradeHeight = 4_190_000
 	// UpgradeInfo defines the binaries that will be used for the upgrade
 	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Darwin_arm64.tar.gz","darwin/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Darwin_x86_64.tar.gz","linux/arm64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Linux_arm64.tar.gz","linux/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Linux_x86_64.tar.gz","windows/x86_64":"https://github.com/evmos/evmos/releases/download/v7.0.0/evmos_7.0.0_Windows_x86_64.zip"}}'`
 


### PR DESCRIPTION
## Description

This PR sets the v7 upgrade height on Testnet to https://testnet.mintscan.io/evmos-testnet/blocks/4190000

Closes ENG-668 https://linear.app/evmos/issue/ENG-668/schedule-testnet-to-v7-upgrade