### PR TITLE
fix: remove duplicated upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1106,15 +1106,6 @@ func (app *Evmos) setupUpgradeHandlers() {
 		),
 	)
 
-	// v9 upgrade handler
-	app.UpgradeKeeper.SetUpgradeHandler(
-		v9.UpgradeName,
-		v9.CreateUpgradeHandler(
-			app.mm, app.configurator,
-			app.DistrKeeper,
-		),
-	)
-
 	// v9.1 upgrade handler
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v91.UpgradeName,


### PR DESCRIPTION
## Description

Removing duplication from `main`. This doesn't occur on the release branch.