### PR TITLE
docs(upgrades): add missing mainnet and testnet upgrades to list of upgrades

### DIFF
--- a/docs/validators/upgrades/upgrades.md
+++ b/docs/validators/upgrades/upgrades.md
@@ -11,26 +11,35 @@ Check the details and requirements for each mainnet and testnet upgrade. {synops
 
 | Version                                                                  | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                            |
 | ------------------------------------------------------------------------ | :-----: | :------: | :--------: | :-----------------: | --------------------------------------------------------- |
-| [`v6.0.2`](https://github.com/evmos/evmos/releases/tag/v6.0.2)           |   ✅    |    ❌    |     ❌     |         ✅          |                                                           |
-| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)           |   ✅    |    ✅    |     ❌     |         ❌          | [1,042,000](https://www.mintscan.io/evmos/blocks/1042000) |
-| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [837,500](https://www.mintscan.io/evmos/blocks/837500)    |
-| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)           |   ❌    |    ✅    |     ❌     |         ❌          | [257,850](https://www.mintscan.io/evmos/blocks/257850)    |
-| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)           |   ❌    |    ✅    |     ✅     |         ✅          | [58,701](https://www.mintscan.io/evmos/blocks/58701)      |
-| [`v2.0.1`](https://github.com/evmos/evmos/releases/tag/v2.0.1)           |   ❌    |    ❌    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
-| [`v2.0.0`](https://github.com/evmos/evmos/releases/tag/v2.0.0)           |   ✅    |    ✅    |     ❌     |         ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
-| [`v1.0.0`](https://github.com/evmos/evmos/releases/tag/v1.0.0) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |         ❌          | [1](https://www.mintscan.io/evmos/blocks/1)               |
+| [`v9.1.0`](https://github.com/evmos/evmos/releases/tag/v9.1.0)           |    ✅    |    ✅     |     ❌      |          ❌          | [6,654,000](https://www.mintscan.io/evmos/blocks/6654000) |
+| [`v8.2.0`](https://github.com/evmos/evmos/releases/tag/v8.2.0)           |    ✅    |    ✅     |     ❌      |          ✅          | [4,888,000](https://www.mintscan.io/evmos/blocks/4888000) |
+| [`v8.1.0`](https://github.com/evmos/evmos/releases/tag/v8.1.0)           |    ✅    |    ✅     |     ❌      |          ❌          | [4,655,500](https://www.mintscan.io/evmos/blocks/4655500) |
+| [`v7.0.0`](https://github.com/evmos/evmos/releases/tag/v7.0.0)           |    ✅    |    ✅     |     ❌      |          ✅          | [2,476,000](https://www.mintscan.io/evmos/blocks/2476000) |
+| [`v6.0.2`](https://github.com/evmos/evmos/releases/tag/v6.0.2)           |    ✅    |    ❌     |     ❌      |          ✅          |                                                           |
+| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)           |    ✅    |    ✅     |     ❌      |          ❌          | [1,042,000](https://www.mintscan.io/evmos/blocks/1042000) |
+| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)           |    ✅    |    ✅     |     ❌      |          ❌          | [837,500](https://www.mintscan.io/evmos/blocks/837500)    |
+| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)           |    ❌    |    ✅     |     ❌      |          ❌          | [257,850](https://www.mintscan.io/evmos/blocks/257850)    |
+| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)           |    ❌    |    ✅     |     ✅      |          ✅          | [58,701](https://www.mintscan.io/evmos/blocks/58701)      |
+| [`v2.0.1`](https://github.com/evmos/evmos/releases/tag/v2.0.1)           |    ❌    |    ❌     |     ❌      |          ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
+| [`v2.0.0`](https://github.com/evmos/evmos/releases/tag/v2.0.0)           |    ✅    |    ✅     |     ❌      |          ❌          | [58,700](https://www.mintscan.io/evmos/blocks/58700)      |
+| [`v1.0.0`](https://github.com/evmos/evmos/releases/tag/v1.0.0) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |          ❌          | [1](https://www.mintscan.io/evmos/blocks/1)               |
 
 :::
 ::: tab Testnet
 
 | Version                                                                              | Planned | Breaking | Data Reset | Manual Upgrade Only | Upgrade Height                                                        |
 | ------------------------------------------------------------------------------------ | :-----: | :------: | :--------: | :-----------------: | --------------------------------------------------------------------- |
-| [`v6.0.2`](https://github.com/evmos/evmos/releases/tag/v6.0.2)                       |   ✅    |    ❌    |     ❌     |         ✅          |                                                                       |
-| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)                       |   ✅    |    ✅    |     ❌     |         ❌          | [2,176,500](https://testnet.mintscan.io/evmos-testnet/blocks/2176500) |
-| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)                       |   ✅    |    ✅    |     ❌     |         ❌          | [1,762,500](https://testnet.mintscan.io/evmos-testnet/blocks/1762500) |
-| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)                       |   ✅    |    ✅    |     ❌     |         ❌          | [1,200,000](https://testnet.mintscan.io/evmos-testnet/blocks/1200000) |
-| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)                       |   ✅    |    ✅    |     ❌     |         ❌          |                                                                       |
-| [`v3.0.0-beta1`](https://github.com/evmos/evmos/releases/tag/v3.0.0-beta1)           |   ❌    |    ✅    |     ✅     |         ✅          |                                                                       |
-| [`v1.0.0-beta1`](https://github.com/evmos/evmos/releases/tag/v1.0.0-beta1) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |         ❌          | [1](https://testnet.mintscan.io/evmos-testnet/blocks/1)               |
+| [`v9.1.0`](https://github.com/evmos/evmos/releases/tag/v9.1.0)                       |    ✅    |    ✅     |     ❌      |          ❌          | [8,310,000](https://testnet.mintscan.io/evmos-testnet/blocks/8310000) |
+| [`v8.2.3`](https://github.com/evmos/evmos/releases/tag/v8.2.3)                       |    ✅    |    ✅     |     ❌      |          ❌          | [8,037,000](https://testnet.mintscan.io/evmos-testnet/blocks/8037000) |
+| [`v8.1.0`](https://github.com/evmos/evmos/releases/tag/v8.1.0)                       |    ✅    |    ✅     |     ❌      |          ❌          | [5,320,000](https://testnet.mintscan.io/evmos-testnet/blocks/5320000) |
+| [`v8.0.0`](https://github.com/evmos/evmos/releases/tag/v8.0.0)                       |    ✅    |    ✅     |     ❌      |          ❌          | [4,600,000](https://testnet.mintscan.io/evmos-testnet/blocks/4600000) |
+| [`v7.0.0`](https://github.com/evmos/evmos/releases/tag/v7.0.0)                       |    ✅    |    ✅     |     ❌      |          ❌          | [4,190,000](https://testnet.mintscan.io/evmos-testnet/blocks/4190000) |
+| [`v6.0.2`](https://github.com/evmos/evmos/releases/tag/v6.0.2)                       |    ✅    |    ❌     |     ❌      |          ✅          |                                                                       |
+| [`v6.0.1`](https://github.com/evmos/evmos/releases/tag/v6.0.1)                       |    ✅    |    ✅     |     ❌      |          ❌          | [2,176,500](https://testnet.mintscan.io/evmos-testnet/blocks/2176500) |
+| [`v5.0.0`](https://github.com/evmos/evmos/releases/tag/v5.0.0)                       |    ✅    |    ✅     |     ❌      |          ❌          | [1,762,500](https://testnet.mintscan.io/evmos-testnet/blocks/1762500) |
+| [`v4.0.1`](https://github.com/evmos/evmos/releases/tag/v4.0.1)                       |    ✅    |    ✅     |     ❌      |          ❌          | [1,200,000](https://testnet.mintscan.io/evmos-testnet/blocks/1200000) |
+| [`v3.0.0`](https://github.com/evmos/evmos/releases/tag/v3.0.0)                       |    ✅    |    ✅     |     ❌      |          ❌          |                                                                       |
+| [`v3.0.0-beta1`](https://github.com/evmos/evmos/releases/tag/v3.0.0-beta1)           |    ❌    |    ✅     |     ✅      |          ✅          |                                                                       |
+| [`v1.0.0-beta1`](https://github.com/evmos/evmos/releases/tag/v1.0.0-beta1) (genesis) |  `N/A`  |  `N/A`   |   `N/A`    |          ❌          | [1](https://testnet.mintscan.io/evmos-testnet/blocks/1)               |
 :::
 ::::


### PR DESCRIPTION
## Description

This PR adds missing upgrades to docs. This task should be performed after every release, as described in the post-release items in the release guide. 

Closes: https://linear.app/evmos/issue/ENG-958/add-missing-upgrades-to-docs