### PR TITLE
deps(go): Bump to go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.1
         id: git_diff

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
+          check-latest: true
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6.1.1
         with:
@@ -27,7 +28,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46.2
+          version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         # Check only if there are differences in the source code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6.1.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           check-latest: true
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6.1.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
 linters:
   enable:
     # - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -32,7 +31,6 @@ linters:
     - unconvert
     # - unparam
     - unused
-    - varcheck
     # - nolintlint
     - asciicheck
     # - exhaustive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,7 @@ linters-settings:
     require-explanation: false
     require-specific: false
   gofumpt:
-    lang-version: "1.18"
+    lang-version: "1.19"
   gomodguard:
     blocked:
       versions: # List of blocked module version constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+- (go) [\#1039](https://github.com/evmos/evmos/pull/1039) Bump go v1.19
 - (deps) [\#1033](https://github.com/evmos/evmos/pull/1033) Bump Cosmos SDK to [`v0.46.4`](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4)
 - (ante) [\#993](https://github.com/evmos/evmos/pull/993) Re-order AnteHandlers for better performance
 - (docs) [\#883](https://github.com/evmos/evmos/pull/883) Add Ethereum tx indexer documentation.

--- a/Makefile
+++ b/Makefile
@@ -436,7 +436,7 @@ lint-fix-contracts:
 .PHONY: lint lint-fix
 
 format:
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' | xargs gofumpt -w -l 
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' | xargs gofumpt -w -l
 
 .PHONY: format
 
@@ -554,7 +554,7 @@ localnet-show-logstream:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/evmos/evmos
-GOLANG_CROSS_VERSION  = v1.18
+GOLANG_CROSS_VERSION  = v1.19
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ parent:
 Evmos is a scalable, high-throughput Proof-of-Stake blockchain that is fully compatible and
 interoperable with Ethereum. It's built using the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk/) which runs on top of [Tendermint Core](https://github.com/tendermint/tendermint) consensus engine.
 
-**Note**: Requires [Go 1.18+](https://golang.org/dl/)
+**Note**: Requires [Go 1.19+](https://golang.org/dl/)
 
 ## Installation
 

--- a/docs/validators/quickstart/installation.md
+++ b/docs/validators/quickstart/installation.md
@@ -8,13 +8,13 @@ Build and install the Evmos binaries from source or using Docker. {synopsis}
 
 ## Pre-requisites
 
-- [Install Go 1.18.5+](https://golang.org/dl/) {prereq}
+- [Install Go 1.19+](https://golang.org/dl/) {prereq}
 - [Install jq](https://stedolan.github.io/jq/download/) {prereq}
 
 ## Install Go
 
 ::: warning
-Evmos is built using [Go](https://golang.org/dl/) version `1.18+`
+Evmos is built using [Go](https://golang.org/dl/) version `1.19+`
 :::
 
 ```bash

--- a/docs/validators/upgrades/manual.md
+++ b/docs/validators/upgrades/manual.md
@@ -40,7 +40,7 @@ server_name: evmosd
 version: 3.0.0
 commit: fe9df43332800a74a163c014c69e62765d8206e3
 build_tags: netgo,ledger
-go: go version go1.18 darwin/amd64
+go: go version go1.19 darwin/amd64
 ...
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evmos/evmos/v10
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7

--- a/networks/local/evmos/Dockerfile
+++ b/networks/local/evmos/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-bullseye as build-env
+FROM golang:1.19-bullseye as build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc
@@ -15,7 +15,7 @@ COPY . .
 RUN make build-linux
 
 # Final image
-FROM golang:1.18.5-bullseye as final
+FROM golang:1.19-bullseye as final
 
 WORKDIR /
 


### PR DESCRIPTION
## Description

Bumping to gov1.19 to gain parity with ethermint and support comment by @faddat (https://github.com/evmos/evmos/pull/1023)

Part of https://linear.app/evmos/issue/ENG-953/create-release-candidate-v10-rc1-on-evmos