### PR TITLE
docs(upgrades): update cosmovisor command

### DIFF
--- a/docs/validators/upgrades/automated.md
+++ b/docs/validators/upgrades/automated.md
@@ -45,7 +45,7 @@ cp $GOPATH/bin/evmosd ~/.evmosd/cosmovisor/genesis/bin
 To check that you did this correctly, ensure your versions of `cosmovisor` and `evmosd` are the same:
 
 ```bash
-cosmovisor version
+cosmovisor run version
 evmosd version
 ```
 
@@ -106,7 +106,7 @@ echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=true" >> ~/.profile
 Now that everything is setup and ready to go, you can start your node.
 
 ```bash
-cosmovisor start
+cosmovisor run start
 ```
 
 You will need some way to keep the process always running. If you're on linux, you can do this by creating a service.


### PR DESCRIPTION
## Description

Updates the cosmovisor command as described [here](https://docs.cosmos.network/main/tooling/cosmovisor):

> `run` - Run the configured binary using the rest of the provided arguments.


Closes: https://linear.app/evmos/issue/ENG-955/test-upgrading-to-release-candidates-rc-with-cosmovisor
