### PR TITLE
fix(cmd) change evmos coin denom regex for proper validation in commands

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -83,8 +83,8 @@ func GetEvmosAddressFromBech32(address string) (sdk.AccAddress, error) {
 	return sdk.AccAddress(addressBz), nil
 }
 
-// Include the possibility to use an ERC-20 contract address as coin Denom
+// Include the possibility to use an ERC-20 contract address as coin Denom (allow to start with 0x)
 // Otherwise Coin Denom validation will fail in some cases (e.g.: transfer ERC-20 tokens through IBC)
 func EvmosCoinDenomRegex() string {
-	return `^0x[a-fA-F0-9]{40}$|^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}`
+	return `[a-zA-Z0][a-zA-Z0-9/:._-]{2,127}`
 }

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -162,23 +162,13 @@ func TestEvmosCoinDenom(t *testing.T) {
 			true,
 		},
 		{
-			"invalid denom - starts with 0 but not followed by 'x'",
-			"0a52908400098527886E0F7030069857D2E4169EE7",
+			"invalid denom - starts with a number that's not zero",
+			"10000000000aevmos",
 			true,
 		},
 		{
-			"invalid denom - hex address but 19 bytes long",
-			"0x52908400098527886E0F7030069857D2E4169E",
-			true,
-		},
-		{
-			"invalid denom - hex address but 21 bytes long",
-			"0x52908400098527886e0f7030069857D2E4169EE738",
-			true,
-		},
-		{
-			"invalid denom - invalid hex, has a 'g'",
-			"0x52908400098527886e0f7030069857D2E4169gE7",
+			"invalid denom - starts with invalid character",
+			"-aevmos",
 			true,
 		},
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

### Problem:
Initially, to support passing Ethereum hex addresses as coin denominations, the `EvmosCoinDenomRegex` was updated to be
```
^0x[a-fA-F0-9]{40}$|^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}
```
instead of the default CoinDenomRegex defined in the SDK:
```
[a-zA-Z][a-zA-Z0-9/:._-]{2,127}
```
For most of the use cases, this change provided the support needed. However, input validation for decimal coin expression fail. This type of validation is triggered when passing one or many coin amounts on a cmd command in the format `{amount}{denom}`, for example:
```
evmosd add-genesis-account mykey 100000000000000000000000000aevmos --keyring-backend test
```
The decimal coin expression is the `100000000000000000000000000aevmos`

Validation fails because when calling the `sdk.SetCoinDenomRegex(EvmosCoinDenomRegex)`, some modifications to the original regex occur. Inside this function, two regex expressions are defined:

- `reDnm`: the regex defined by the user is wrapped with a `^` at the beginning and a `$` at the end of the expression, changing the original regular expression
- `reDecCoin`: this is used to validate decimal coin expressions. The user-defined regular expression is modified also to define this variable.

For more details, here is [the code I'm referring to](https://github.com/cosmos/cosmos-sdk/blob/eb1e3ebf6fcfd56e1f1d8f4c0a6192740bd8a6c1/types/coin.go#L850-L857).

When validating the decimal coin expressions on the call to `sdk.ParseCoinsNormalized()` uses the `recDecCoin`. As a result, we get an error that the decimal coin expression is invalid.

### Solution: 
Use the default CoinDenomRegex regex as reference and update the `EvmosCoinDenomRegex` to allow denominations start with a `0`. The resulting regex is:
```
[a-zA-Z0][a-zA-Z0-9/:._-]{2,127}
```
This is needed to support passing Ethereum hex addresses as coin denominations. A use case of this is transfer ERC-20 tokens through IBC. In addition, this does not introduce issues in the `reDecCoin` regular expression.

Closes: #XXX

______

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
