### PR TITLE
bug(MAKEFILE): fix `evmosd version` cmd to show either tag or last commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (ibc/erc20) [\#1085](https://github.com/evmos/evmos/pull/1085) Added wrapper for ibc transfer to automatically convert erc20 tokens to cosmos coins.
 - (vesting) [\#1087](https://github.com/evmos/evmos/pull/1087) Add new `MsgUpdateVestingFunder` that updates the `Funder` field of a given clawback vesting account
 - (docs) [\#1090](https://github.com/evmos/evmos/pull/1090) Add audits page to documentation.
+- (cmd) [\#1121](https://github.com/evmos/evmos/pull/1121) Fix evmosd version to show either tag or last commit.
 
 ### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
-DIFF_TAG=$(shell git rev-list --tags="v*" --max-count=1 --not $(shell git rev-list --tags="v*" "HEAD..origin"))
-DEFAULT_TAG=$(shell git rev-list --tags="v*" --max-count=1)
 VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')
 TMVERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')
 COMMIT := $(shell git log -1 --format='%H')

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 DIFF_TAG=$(shell git rev-list --tags="v*" --max-count=1 --not $(shell git rev-list --tags="v*" "HEAD..origin"))
 DEFAULT_TAG=$(shell git rev-list --tags="v*" --max-count=1)
-VERSION ?= $(shell echo $(shell git describe --tags $(or $(DIFF_TAG), $(DEFAULT_TAG))) | sed 's/^v//')
+VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')
 TMVERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
@@ -457,7 +457,7 @@ format:
 ###############################################################################
 
 # ------
-# NOTE: Link to the tendermintdev/sdk-proto-gen docker images: 
+# NOTE: Link to the tendermintdev/sdk-proto-gen docker images:
 #       https://hub.docker.com/r/tendermintdev/sdk-proto-gen/tags
 #
 protoVer=v0.7
@@ -482,7 +482,7 @@ protolintImage=$(DOCKER) run --network host --rm -v $(CURDIR):/workspace --workd
 
 
 # ------
-# NOTE: If you are experiencing problems running these commands, try deleting 
+# NOTE: If you are experiencing problems running these commands, try deleting
 #       the docker images and execute the desired command again.
 #
 proto-all: proto-format proto-lint proto-gen

--- a/cmd/evmosd/root.go
+++ b/cmd/evmosd/root.go
@@ -186,6 +186,7 @@ func txCommand() *cobra.Command {
 		authcmd.GetBroadcastCommand(),
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
+		authcmd.GetAuxToFeeCommand(),
 	)
 
 	app.ModuleBasics.AddTxCommands(cmd)


### PR DESCRIPTION
## Description

The `evmosd version` currently always shows the latest tag. This fix changes the behaviour to show the version of the currently installed binary