### PR TITLE
imp: remove create_empty_blocks and create_empty_blocks_interval

### DIFF
--- a/local_node.sh
+++ b/local_node.sh
@@ -88,16 +88,8 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	# 0xA61808Fe40fEb8B3433778BBC2ecECCAA47c8c47 || evmos15cvq3ljql6utxseh0zau9m8ve2j8erz89m5wkz
 	jq -r --arg amount_to_claim "$amount_to_claim" '.app_state["bank"]["balances"] += [{"address":"evmos15cvq3ljql6utxseh0zau9m8ve2j8erz89m5wkz","coins":[{"denom":"aevmos", "amount":$amount_to_claim}]}]' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
-	# disable produce empty block
-	if [[ "$OSTYPE" == "darwin"* ]]; then
-		sed -i '' 's/create_empty_blocks = true/create_empty_blocks = false/g' "$CONFIG"
-	else
-		sed -i 's/create_empty_blocks = true/create_empty_blocks = false/g' "$CONFIG"
-	fi
-
 	if [[ $1 == "pending" ]]; then
 		if [[ "$OSTYPE" == "darwin"* ]]; then
-			sed -i '' 's/create_empty_blocks_interval = "0s"/create_empty_blocks_interval = "30s"/g' "$CONFIG"
 			sed -i '' 's/timeout_propose = "3s"/timeout_propose = "30s"/g' "$CONFIG"
 			sed -i '' 's/timeout_propose_delta = "500ms"/timeout_propose_delta = "5s"/g' "$CONFIG"
 			sed -i '' 's/timeout_prevote = "1s"/timeout_prevote = "10s"/g' "$CONFIG"
@@ -107,7 +99,6 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 			sed -i '' 's/timeout_commit = "5s"/timeout_commit = "150s"/g' "$CONFIG"
 			sed -i '' 's/timeout_broadcast_tx_commit = "10s"/timeout_broadcast_tx_commit = "150s"/g' "$CONFIG"
 		else
-			sed -i 's/create_empty_blocks_interval = "0s"/create_empty_blocks_interval = "30s"/g' "$CONFIG"
 			sed -i 's/timeout_propose = "3s"/timeout_propose = "30s"/g' "$CONFIG"
 			sed -i 's/timeout_propose_delta = "500ms"/timeout_propose_delta = "5s"/g' "$CONFIG"
 			sed -i 's/timeout_prevote = "1s"/timeout_prevote = "10s"/g' "$CONFIG"


### PR DESCRIPTION
## Description

removed `create_empty_blocks` and `create_empty_blocks_interval` config in `./local_node.sh` script because those options does not works in cosmos-sdk

Source: [cosmos/cosmos-sdk#746](https://github.com/cosmos/cosmos-sdk/issues/746)

> Currently the appHash changes every block, since the CommitMultiStore encodes the version and that version changes on every block. Due to that --consensus.create_empty_blocks = false does not work, with the current sdk. Tendermint expects that the appHash doesn't change and only then stops producing blocks.
@#jaekwon @#ebuchman What was the outcome of your discussion around the constantly changing appHash with the MultiStore? Also, do we want the functionality of no_empty_blocks? I think it would be nice to have the ability to only produce blocks every minute or so.

_Originally posted by @adrianbrink in https://github.com/cosmos/cosmos-sdk/issues/746#issuecomment-377498937_

> Unfortunately it's not supported yet for the new Cosmos SDK since the app hash changes with every block.
I just opened a new issue to track it in Tendermint: https://github.com/tendermint/tendermint/issues/1392
I'll close this for now, and we can revisit once the functionality is available in Tendermint to support this.

_Originally posted by @ebuchman in https://github.com/cosmos/cosmos-sdk/issues/746#issuecomment-377499384_

Closes: #961 

______

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
