### PR TITLE
imp (docs): add remark about restarting a node after changes to mempool config

### DIFF
--- a/docs/validators/setup/mempool.md
+++ b/docs/validators/setup/mempool.md
@@ -43,7 +43,10 @@ Even though the transaction processing can be ordered by priority, the gossiping
 
 To use the a prioritized mempool, adjust `version = "v1"` in the node configuration at `~/.evmosd/config/config.toml`.
 The default value `"v0"` indicates the traditional FIFO mempool.
-Remember to **restart** a running node for the changes to take effect.
+
+::: tip
+Remember to **restart** the node for the changes to take effect.
+:::
 
 See the relevant excerpt from `config.toml` here:
 

--- a/docs/validators/setup/mempool.md
+++ b/docs/validators/setup/mempool.md
@@ -43,6 +43,7 @@ Even though the transaction processing can be ordered by priority, the gossiping
 
 To use the a prioritized mempool, adjust `version = "v1"` in the node configuration at `~/.evmosd/config/config.toml`.
 The default value `"v0"` indicates the traditional FIFO mempool.
+Remember to **restart** a running node for the changes to take effect.
 
 See the relevant excerpt from `config.toml` here:
 


### PR DESCRIPTION
This PR will add a hint for developers to the mempool docs, that it is necessary to restart a running node after changing the `config.toml` file.