### PR TITLE
chore: update version to v10.0.0-rc3 in upgrade name and links

### DIFF
--- a/app/upgrades/v10/constants.go
+++ b/app/upgrades/v10/constants.go
@@ -2,7 +2,7 @@ package v10
 
 const (
 	// UpgradeName is the shared upgrade plan name for mainnet
-	UpgradeName = "v10.0.0-rc2"
+	UpgradeName = "v10.0.0-rc3"
 	// UpgradeInfo defines the binaries that will be used for the upgrade
-	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc2/evmos_10.0.0-rc2_Darwin_arm64.tar.gz","darwin/amd64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc2/evmos_10.0.0-rc2_Darwin_amd64.tar.gz","linux/arm64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc2/evmos_10.0.0-rc2_Linux_arm64.tar.gz","linux/amd64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc2/evmos_10.0.0-rc2_Linux_amd64.tar.gz","windows/x86_64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc2/evmos_10.0.0-rc2_Windows_x86_64.zip"}}'`
+	UpgradeInfo = `'{"binaries":{"darwin/arm64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc3/evmos_10.0.0-rc3_Darwin_arm64.tar.gz","darwin/amd64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc3/evmos_10.0.0-rc3_Darwin_amd64.tar.gz","linux/arm64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc3/evmos_10.0.0-rc3_Linux_arm64.tar.gz","linux/amd64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc3/evmos_10.0.0-rc3_Linux_amd64.tar.gz","windows/x86_64":"https://github.com/evmos/evmos/releases/download/v10.0.0-rc3/evmos_10.0.0-rc3_Windows_x86_64.zip"}}'`
 )


### PR DESCRIPTION
This PR updates the version used in constants.go to v10.0.0-rc3