### PR TITLE
fix: testnet start cmd for multiple validators

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -278,6 +278,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 		tmCfg.RPC.ListenAddress = ""
 		appCfg.GRPC.Enable = false
 		appCfg.GRPCWeb.Enable = false
+		appCfg.JSONRPC.Enable = false
 		apiListenAddr := ""
 		if i == 0 {
 			if cfg.APIAddress != "" {


### PR DESCRIPTION
Fixes a previously closed issue: https://github.com/evmos/evmos/issues/378

The solution mentioned in the issue of running v=1 validators does not address the problem.

Currently the `evmosd testnet start` cmd fails with the default option of 4 validators. This is because it tries to bind multiple times to the JSON RPC 8545 port. Defaulting the `JSONRPC.Enable` flag to `false` solves the problem, leaving just 1 node  exposing the endpoint.

