### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/evmos/evmos
 
 COPY go.mod go.sum ./
 
-RUN set -eux; apk add --no-cache ca-certificates build-base=0.5-r3; apk add git=2.40.1-r0 linux-headers=6.3-r0
+RUN set -eux; apk add --no-cache ca-certificates=20230506-r0 build-base=0.5-r3 git=2.40.1-r0 linux-headers=6.3-r0
 
 RUN --mount=type=bind,target=. --mount=type=secret,id=GITHUB_TOKEN \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
@@ -23,7 +23,7 @@ WORKDIR /root
 COPY --from=build-env /go/src/github.com/evmos/evmos/build/evmosd /usr/bin/evmosd
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
-RUN apk add --no-cache ca-certificates jq=1.6-r3 curl=8.1.2-r0 bash=5.2.15-r5 vim=9.0.1568-r0 lz4=1.9.4-r4 \
+RUN apk add --no-cache ca-certificates=20230506-r0 jq=1.6-r3 curl=8.1.2-r0 bash=5.2.15-r5 vim=9.0.1568-r0 lz4=1.9.4-r4 \
     && addgroup -g 1000 evmos \
     && adduser -S -h /home/evmos -D evmos -u 1000 -G evmos
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,34 @@
-FROM golang:1.20.5-bullseye AS build-env
+FROM golang:1.20.5-alpine3.18 AS build-env
 
 WORKDIR /go/src/github.com/evmos/evmos
+
+COPY go.mod go.sum ./
+
+RUN set -eux; apk add --no-cache ca-certificates build-base=0.5-r3; apk add git=2.40.1-r0 linux-headers=6.3-r0
+
+RUN --mount=type=bind,target=. --mount=type=secret,id=GITHUB_TOKEN \
+    git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
+    go mod download
 
 COPY . .
 
 RUN make build
 
-FROM golang:1.20.5-bullseye
+RUN go install github.com/MinseokOh/toml-cli@latest
 
-RUN apt-get update  \ 
-&& apt-get install ca-certificates jq=1.6-2.1 -y --no-install-recommends
+FROM alpine:3.18
 
 WORKDIR /root
 
 COPY --from=build-env /go/src/github.com/evmos/evmos/build/evmosd /usr/bin/evmosd
+COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
+
+RUN apk add --no-cache ca-certificates jq=1.6-r3 curl=8.1.2-r0 bash=5.2.15-r5 vim=9.0.1568-r0 lz4=1.9.4-r4 \
+    && addgroup -g 1000 evmos \
+    && adduser -S -h /home/evmos -D evmos -u 1000 -G evmos
+
+USER 1000
+WORKDIR /home/evmos
 
 EXPOSE 26656 26657 1317 9090 8545 8546
 


### PR DESCRIPTION
## Description

Updated Dockerfile to use a minimal [alpine](https://www.alpinelinux.org/) image, this change should reduce docker image size from ~800M to ~150M

- [x] Docker image based on `alpine:3.18`
- [x] Added an ability to mount GITHUB_TOKEN via docker secrets for access to private repositories:
```
export GITHUB_TOKEN=github_pat_xxxx
docker build -t tag --secret id=GITHUB_TOKEN .
```
- [x] Added a cache layer for `go mod download` for local development
- [x] Added `toml-cli` binary for `*.toml` files manipulation
- [x] Introduced unprivileged user with UID 1000 within the container
- [x] Added `lz4` binary to unpack archives during the state sync 