### PR TITLE
fix(rpc): wrong block number in debug trace related api (cherry-pick)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (rpc) [#1650](https://github.com/evmos/evmos/pull/1650) Fix racing conditions on RPC PubSub logic
 - (rpc) [#1655](https://github.com/evmos/evmos/pull/1655) Avoid channel get changed when concurrent subscribe happens.
 - (revenue) [#1659](https://github.com/evmos/evmos/pull/1659) Check if DevelopersShares are set to 0
+- (rpc) [#1663](https://github.com/evmos/evmos/pull/1663) Fix block number returned in opcode for debug trace related api.
 
 ## [v13.0.2] - 2023-07-05
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -467,8 +467,8 @@ func (k Keeper) TraceBlock(c context.Context, req *types.QueryTraceBlockRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "output limit cannot be negative, got %d", req.TraceConfig.Limit)
 	}
 
-	// minus one to get the context of block beginning
-	contextHeight := req.BlockNumber - 1
+	// get the context of block beginning
+	contextHeight := req.BlockNumber
 	if contextHeight < 1 {
 		// 0 is a special value in `ContextWithHeight`
 		contextHeight = 1

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -390,8 +390,8 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		return nil, status.Errorf(codes.InvalidArgument, "output limit cannot be negative, got %d", req.TraceConfig.Limit)
 	}
 
-	// minus one to get the context of block beginning
-	contextHeight := req.BlockNumber - 1
+	// get the context of block beginning
+	contextHeight := req.BlockNumber
 	if contextHeight < 1 {
 		// 0 is a special value in `ContextWithHeight`
 		contextHeight = 1


### PR DESCRIPTION
## Description

Cherry-pick bug fixed in ethermint but missing on evmos https://github.com/evmos/ethermint/pull/1591
Look [here in evmos](https://github.com/evmos/evmos/blob/9c7def2f2468294d8defe7ed218215f77448509d/x/evm/keeper/grpc_query.go#L394) and [here in ethermint](https://github.com/evmos/ethermint/blob/07cf2bd2b1ce9bdb2e44ec42a39e7239292a14af/x/evm/keeper/grpc_query.go#L406), both referenced from their `main` branch

### Reference discussion 1
> > block height already minus by one in rpc
> >
> > https://github.com/evmos/ethermint/blob/57ed355c985d9f3116aba6aabfa2ee0f3f38e966/rpc/backend/tracing.go#L110-L114
> > 
> > Oh no, so currently it keep minus by one in grpc so actually minus by 2? If calling via API debug_traceTransaction?

> Fixing BlockNumber from [request](https://github.com/evmos/ethermint/blob/57ed355c985d9f3116aba6aabfa2ee0f3f38e966/rpc/backend/tracing.go#L98), no need minus 1

_Originally posted by `mmsqe` in https://github.com/evmos/ethermint/issues/1591#issuecomment-1373363076_

### Reference discussion 2
> The `contextHeight` is minus one to get to the state of block beginning, but the block number pass to evm context should not minus one.

_Originally posted by `yihuang` in https://github.com/evmos/ethermint/issues/1591#issuecomment-1375004878_

## PR review checkboxes:

I have...

- [x] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [x] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link in the PR description to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->