### PR TITLE
When the genesis parameter feemarket sets no_base_fee=true and min_gas_price=0, the user send a evm transaction with a gasPrice of 0 will fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#1693](https://github.com/evmos/evmos/pull/1703) Prevent panic on uint64 conversion in EVM keeper `ApplyMessageWithConfig` function.
 - (deps) [#1718](https://github.com/evmos/evmos/pull/1718) Update rosetta types import.
 - (consensus) [#1740](https://github.com/evmos/evmos/pull/1740) Enable setting block gas limit to max by specifying it as -1 in the genesis file.
+- (ante) [#1752](https://github.com/evmos/evmos/pull/1752) If the user sends a evm transaction with a gas price of 0, skip the steps of staking rewards and tx cost deduct.
 
 ## [v13.0.2] - 2023-07-05
 


### PR DESCRIPTION
## Description
When the genesis parameter feemarket sets no_base_fee=true and min_gas_price=0, the user send a evm transaction with a gasPrice of 0 will fail.

Below is the params configuration for feemarket.

```go
{
        "no_base_fee": true,
        "base_fee_change_denominator": 8,
        "elasticity_multiplier": 2,
        "enable_height": "0",
        "base_fee": "1000000000",
        "min_gas_price": "0.000000000000000000",
        "min_gas_multiplier": "0.500000000000000000"
}
```

At this point, since no_base_fee is set to 0 and min_gas_price is also 0, it means that users can send transactions with a gasPrice of 0.

Send a transaction of type Cosmos with gasPrice of 0, and make sure the fee amount is 0aevmos. Transaction was successful. The results are consistent with expectations. 

```json
{
    "body":{
        "messages":[
            {
                "@type":"/cosmos.bank.v1beta1.MsgSend",
                "from_address":"evmos1qqqqhe5pnaq5qq39wqkn957aydnrm45sdn8583",
                "to_address":"evmos1zyg3qtwny9stqe8j55fvmmm5hldk48uk5wqpd3",
                "amount":[
                    {
                        "denom":"aevmos",
                        "amount":"1"
                    }
                ]
            }
        ]
    },
    "auth_info":{
        "fee":{
            "amount":[
                {
                    "denom":"aevmos",
                    "amount":"0"
                }
            ],
            "gas_limit":"1000000"
        }
    }
}

```

However, when sending the following transaction of evm type and gasPrice of 0, note that the gasPrice is 0x0.

```json
{
    "from":"0x00000be6819f41400225702d32d3dd23663dd690",
    "to":"0x1111102dd32160b064f2a512cdef74bfdb6a9f96",
    "value":"0xde0b6b3a7640000",
    "gas":"0x401640",
    "gasPrice":"0x0",
    "data":"0x"
}
```
the transaction fails and the error message is: `wrong fee denomination; got: ; required: aevmos: insufficient fee: insufficient fee`。The code where the error occurred：[https://github.com/evmos/evmos/blob/24256533bdeca291452db10d58953379f162b1f0/app/ante/evm/eth.go#L195](https://github.com/evmos/evmos/blob/24256533bdeca291452db10d58953379f162b1f0/app/ante/evm/eth.go#L195)

The error occurs because when the gasPrice is set to 0, the calculated fees result in an empty array. When an empty array is attempted to be used in the `ClaimStakingRewardsIfNecessary` function for input param, it leads to an error: `wrong fee denomination; got: ; required: aevmos`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->