### PR TITLE
feat(gasprice): ignore the check for mini gas price in the genutil module genesis block (blockHeight 0) transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#1693](https://github.com/evmos/evmos/pull/1703) Prevent panic on uint64 conversion in EVM keeper `ApplyMessageWithConfig` function.
 - (deps) [#1718](https://github.com/evmos/evmos/pull/1718) Update rosetta types import.
 - (consensus) [#1740](https://github.com/evmos/evmos/pull/1740) Enable setting block gas limit to max by specifying it as -1 in the genesis file.
+- (gasprice) [#1760](https://github.com/evmos/evmos/pull/1760) Ignore the check for mini gas price in the genutil module genesis block transaction
 
 ## [v13.0.2] - 2023-07-05
 

--- a/app/ante/cosmos/min_price.go
+++ b/app/ante/cosmos/min_price.go
@@ -35,8 +35,8 @@ func (mpd MinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 
 	minGasPrice := mpd.feesKeeper.GetParams(ctx).MinGasPrice
 
-	// Short-circuit if min gas price is 0 or if simulating
-	if minGasPrice.IsZero() || simulate {
+	// Short-circuit if min gas price is 0 or if simulating or genesis tx
+	if minGasPrice.IsZero() || simulate || ctx.BlockHeight() == 0 {
 		return next(ctx, tx, simulate)
 	}
 	evmParams := mpd.evmKeeper.GetParams(ctx)

--- a/app/ante/evm/fees.go
+++ b/app/ante/evm/fees.go
@@ -52,8 +52,8 @@ func NewEthMempoolFeeDecorator(ek EVMKeeper) EthMempoolFeeDecorator {
 func (empd EthMinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	minGasPrice := empd.feesKeeper.GetParams(ctx).MinGasPrice
 
-	// short-circuit if min gas price is 0
-	if minGasPrice.IsZero() {
+	// short-circuit if min gas price is 0 or genesis tx
+	if minGasPrice.IsZero() || ctx.BlockHeight() == 0 {
 		return next(ctx, tx, simulate)
 	}
 

--- a/app/ante/evm/fees_test.go
+++ b/app/ante/evm/fees_test.go
@@ -30,11 +30,27 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 	emptyAccessList := ethtypes.AccessList{}
 
 	testCases := []struct {
-		name     string
-		malleate func() sdk.Tx
-		expPass  bool
-		errMsg   string
+		name        string
+		malleate    func() sdk.Tx
+		blockHeight int64 // -1 means that the block height of ctx does not need to be modified
+		expPass     bool
+		errMsg      string
 	}{
+		{
+			"ignore the check for mini gas price in block height 0 transaction",
+			func() sdk.Tx {
+				params := suite.app.FeeMarketKeeper.GetParams(suite.ctx)
+				params.MinGasPrice = sdk.NewDec(10)
+				err := suite.app.FeeMarketKeeper.SetParams(suite.ctx, params)
+				suite.Require().NoError(err)
+
+				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(0), nil, nil, nil)
+				return suite.CreateTestTx(msg, privKey, 1, false)
+			},
+			0,
+			true,
+			"",
+		},
 		{
 			"invalid tx type",
 			func() sdk.Tx {
@@ -45,6 +61,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 
 				return &testutiltx.InvalidTx{}
 			},
+			-1,
 			false,
 			"invalid message type",
 		},
@@ -63,6 +80,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				txBuilder := suite.CreateTestCosmosTxBuilder(sdkmath.NewInt(0), denom, &testMsg)
 				return txBuilder.GetTx()
 			},
+			-1,
 			false,
 			"invalid message type",
 		},
@@ -75,6 +93,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				suite.Require().NoError(err)
 				return &testutiltx.InvalidTx{}
 			},
+			-1,
 			true,
 			"",
 		},
@@ -89,6 +108,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(0), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -103,6 +123,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(10), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -117,6 +138,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(10), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -131,6 +153,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), big.NewInt(0), nil, nil, nil)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			false,
 			"provided fee < minimum global fee",
 		},
@@ -145,6 +168,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(0), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -159,6 +183,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(100), big.NewInt(50), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -173,6 +198,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(100), big.NewInt(100), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -187,6 +213,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(0), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			false,
 			"provided fee < minimum global fee",
 		},
@@ -206,6 +233,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(1000), big.NewInt(0), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			false,
 			"provided fee < minimum global fee",
 		},
@@ -225,6 +253,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(1000), big.NewInt(101), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			true,
 			"",
 		},
@@ -239,6 +268,7 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 				msg := suite.BuildTestEthTx(from, to, nil, make([]byte, 0), nil, big.NewInt(math.MaxInt64), big.NewInt(100), &emptyAccessList)
 				return suite.CreateTestTx(msg, privKey, 1, false)
 			},
+			-1,
 			false,
 			"provided fee < minimum global fee",
 		},
@@ -249,6 +279,9 @@ func (suite *AnteTestSuite) TestEthMinGasPriceDecorator() {
 			suite.Run(et.name+"_"+tc.name, func() {
 				// s.SetupTest(et.isCheckTx)
 				suite.SetupTest()
+				if tc.blockHeight >= 0 {
+					suite.ctx = suite.ctx.WithBlockHeight(tc.blockHeight)
+				}
 				dec := evmante.NewEthMinGasPriceDecorator(suite.app.FeeMarketKeeper, suite.app.EvmKeeper)
 				_, err := dec.AnteHandle(suite.ctx, tc.malleate(), et.simulate, testutil.NextFn)
 


### PR DESCRIPTION
## Description
When generating a node using the command `evmosd testnet init-files --v 1 --output-dir ./nodes --chain-id evmos_9000-1 --keyring-backend test`, the genesis.json file will have the following configuration for `feemarket`:

```json
{
    "no_base_fee":false,
    "base_fee_change_denominator":8,
    "elasticity_multiplier":2,
    "enable_height":"0",
    "base_fee":"1000000000",
    "min_gas_price":"0.000000000000000000",
    "min_gas_multiplier":"0.500000000000000000"
}
```

In practical scenarios, we do not want a min_gas_price is 0. Let's assume we manually modify min_gas_price to 1 gwei `"min_gas_price":"1000000000.000000000000000000"`

In the genesis.json file, `gen_txs` will generate a transaction for creating a validator, and the transaction content may look like the following (trimmed for readability):

```json
{
    "body":{
        "messages":[
            {
                "@type":"/cosmos.staking.v1beta1.MsgCreateValidator",
                "delegator_address":"evmos1trd8....xeej",
                "validator_address":"evmosvaloper1trd8...ffc0"
            }
        ]
    },
    "auth_info":{
        "fee":{
            "amount":[],
            "gas_limit":"0"
        }
    }
}
```

We can see that the generated `MsgCreateValidator` message has an empty array for the `amount` field in the fee. Therefore, the gas price for this transaction is 0.

When we start the node, it will encounter the following error:

```json
panic: failed to execute DeliverTx for '{
    "body":{
        "messages":[
            {
                "@type":"/cosmos.staking.v1beta1.MsgCreateValidator",
                "delegator_address":"evmos1trd8....xeej",
                "validator_address":"evmosvaloper1trd8...ffc0"
            }
        ]
    },
    "auth_info":{
        "fee":{
            "amount":[],
            "gas_limit":"0"
        }
    }
}': fee not provided. Please use the --fees flag or the --gas-price flag along with the --gas flag to estimate the fee. The minimun global fee for this tx is: : insufficient fee
```

The reason is that the gas price in this transaction is 0, which does not satisfy the min gas price configuration set in feemarket.

We can modify `evmosd testnet init-files` to change the amount in `MsgCreateValidator` so that it meets the min gas price set in feemarket.

However, I think that the transactions in the genesis block are special and we should ignore the min gas price check, allowing the node to start and participate in consensus block creation smoothly. Thus, we should ignore the min gas price check when the block height is 0.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->