### PR TITLE
fix(rpc): handle case when node is not persisting abci responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (ante) [#1753](https://github.com/evmos/evmos/pull/1753) Handle zero fee case on evm transactions.
 - (rpc) [#1829](https://github.com/evmos/evmos/pull/1829) Bump IAVL to v0.20.1 to fix concurrency issue
 - (testnet) [#1857](https://github.com/evmos/evmos/pull/1857) Remove the crisis module causing an error when using the `evmosd testnet init-files` command.
+- (rpc) [#1863](https://github.com/evmos/evmos/pull/1863) Handle error gracefully on RPC calls when node is not persisting ABCI responses.
 
 ## [v14.0.0] - 2023-09-19
 

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -94,7 +94,7 @@ type EVMBackend interface {
 	ChainConfig() *params.ChainConfig
 	GlobalMinGasPrice() (sdk.Dec, error)
 	BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, error)
-	CurrentHeader() *ethtypes.Header
+	CurrentHeader() (*ethtypes.Header, error)
 	PendingTransactions() ([]*sdk.Tx, error)
 	GetCoinbase() (sdk.AccAddress, error)
 	FeeHistory(blockCount rpc.DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*rpctypes.FeeHistoryResult, error)

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -301,7 +301,7 @@ func (b *Backend) HeaderByNumber(blockNum rpctypes.BlockNumber) (*ethtypes.Heade
 
 	blockRes, err := b.TendermintBlockResultByNumber(&resBlock.Block.Height)
 	if err != nil {
-		return nil, fmt.Errorf("block result not found for height %d", resBlock.Block.Height)
+		return nil, fmt.Errorf("block result not found for height %d. %w", resBlock.Block.Height, err)
 	}
 
 	bloom, err := b.BlockBloom(blockRes)

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -170,7 +170,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return args, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 
-	head := b.CurrentHeader()
+	head, _ := b.CurrentHeader()
 	if head == nil {
 		return args, errors.New("latest header is nil")
 	}
@@ -388,7 +388,13 @@ func (b *Backend) GasPrice() (*hexutil.Big, error) {
 		result *big.Int
 		err    error
 	)
-	if head := b.CurrentHeader(); head.BaseFee != nil {
+
+	head, err := b.CurrentHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	if head.BaseFee != nil {
 		result, err = b.SuggestGasTipCap(head.BaseFee)
 		if err != nil {
 			return nil, err

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -170,7 +170,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return args, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 
-	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check if err != nil cause we're already checking that head == nil
+	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check error cause we're already checking that head == nil
 	if head == nil {
 		return args, errors.New("latest header is nil")
 	}

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -170,7 +170,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return args, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 
-	head, _ := b.CurrentHeader()
+	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check if err != nil cause we0re already checking that head == nil
 	if head == nil {
 		return args, errors.New("latest header is nil")
 	}

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -170,7 +170,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return args, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 
-	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check if err != nil cause we0re already checking that head == nil
+	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check if err != nil cause we're already checking that head == nil
 	if head == nil {
 		return args, errors.New("latest header is nil")
 	}

--- a/rpc/backend/call_tx.go
+++ b/rpc/backend/call_tx.go
@@ -170,7 +170,7 @@ func (b *Backend) SetTxDefaults(args evmtypes.TransactionArgs) (evmtypes.Transac
 		return args, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 
-	head, _ := b.CurrentHeader() // #nosec G701 -- no need to check error cause we're already checking that head == nil
+	head, _ := b.CurrentHeader() // #nosec G703 -- no need to check error cause we're already checking that head == nil
 	if head == nil {
 		return args, errors.New("latest header is nil")
 	}

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -92,7 +92,7 @@ func (b *Backend) BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, er
 }
 
 // CurrentHeader returns the latest block header
-// This will return error as per node configuration 
+// This will return error as per node configuration
 // if the ABCI responses are discarded ('discard_abci_responses' config param)
 func (b *Backend) CurrentHeader() (*ethtypes.Header, error) {
 	return b.HeaderByNumber(rpctypes.EthLatestBlockNumber)

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -92,9 +92,10 @@ func (b *Backend) BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, er
 }
 
 // CurrentHeader returns the latest block header
-func (b *Backend) CurrentHeader() *ethtypes.Header {
-	header, _ := b.HeaderByNumber(rpctypes.EthLatestBlockNumber) // #nosec G703
-	return header
+// This will return error as per node configuration 
+// if the ABCI responses are discarded ('discard_abci_responses' config param)
+func (b *Backend) CurrentHeader() (*ethtypes.Header, error) {
+	return b.HeaderByNumber(rpctypes.EthLatestBlockNumber)
 }
 
 // PendingTransactions returns the transactions that are in the transaction pool

--- a/rpc/backend/utils.go
+++ b/rpc/backend/utils.go
@@ -121,7 +121,11 @@ func (b *Backend) processBlock(
 	targetOneFeeHistory.BaseFee = blockBaseFee
 	cfg := b.ChainConfig()
 	if cfg.IsLondon(big.NewInt(blockHeight + 1)) {
-		targetOneFeeHistory.NextBaseFee = misc.CalcBaseFee(cfg, b.CurrentHeader())
+		header, err := b.CurrentHeader()
+		if err != nil {
+			return err
+		}
+		targetOneFeeHistory.NextBaseFee = misc.CalcBaseFee(cfg, header)
 	} else {
 		targetOneFeeHistory.NextBaseFee = new(big.Int)
 	}

--- a/rpc/namespaces/ethereum/eth/api.go
+++ b/rpc/namespaces/ethereum/eth/api.go
@@ -321,7 +321,10 @@ func (e *PublicAPI) FeeHistory(blockCount rpc.DecimalOrHex,
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.
 func (e *PublicAPI) MaxPriorityFeePerGas() (*hexutil.Big, error) {
 	e.logger.Debug("eth_maxPriorityFeePerGas")
-	head := e.backend.CurrentHeader()
+	head, err := e.backend.CurrentHeader()
+	if err != nil {
+		return nil, err
+	}
 	tipcap, err := e.backend.SuggestGasTipCap(head.BaseFee)
 	if err != nil {
 		return nil, err

--- a/tests/nix_tests/configs/discard-abci-resp.jsonnet
+++ b/tests/nix_tests/configs/discard-abci-resp.jsonnet
@@ -1,0 +1,11 @@
+local config = import 'default.jsonnet';
+
+config {
+  'evmos_9000-1'+: {
+    config+: {
+      storage: {
+        discard_abci_responses: true,
+      },
+    },
+  },
+}

--- a/tests/nix_tests/test_no_abci_resp.py
+++ b/tests/nix_tests/test_no_abci_resp.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+
 import pytest
 
-from .utils import w3_wait_for_new_blocks
 from .network import setup_custom_evmos
+from .utils import w3_wait_for_new_blocks
 
 
 @pytest.fixture(scope="module")

--- a/tests/nix_tests/test_no_abci_resp.py
+++ b/tests/nix_tests/test_no_abci_resp.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import pytest
+
+from .utils import w3_wait_for_new_blocks
+from .network import setup_custom_evmos
+
+
+@pytest.fixture(scope="module")
+def evmos(tmp_path_factory):
+    path = tmp_path_factory.mktemp("no-abci-resp")
+    yield from setup_custom_evmos(
+        path,
+        26660,
+        Path(__file__).parent / "configs/discard-abci-resp.jsonnet",
+    )
+
+
+def test_gas_eth_tx(evmos):
+    """
+    When node does not persist ABCI responses
+    eth_gasPrice should return an error instead of crashing
+    """
+    w3_wait_for_new_blocks(evmos.w3, 3)
+    try:
+        evmos.w3.eth.gas_price
+        raise Exception("This query should have failed")
+    except Exception as error:
+        assert "node is not persisting abci responses" in error.args[0]["message"]


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When setting the configuration parameter `discard_abci_responses = true`, all JSON-RPC methods that rely on `TendermintBlockResult` (e.g.: `eth_gasPrice`, `eth_getBlockByNumber`, `eth_getBlockByHash`,  `eth_getTransactionByHash`,  `eth_getTransactionReceipt`, `eth_getTransactionLogs`, `eth_feeHistory`) will not return the expected result (usually `null`) and in some cases cause a panic.

For example, in  `eth_gasPrice` the error logs are:

```
4:48PM INF Served eth_gasPrice conn=10.100.1.9:40160 duration=594.644458 err="method handler crashed" module=geth reqid=2231
4:48PM ERR RPC method eth_gasPrice crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 109462359 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/service.go:200 +0x85
panic({0x2c07660?, 0x59fa270?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/evmos/evmos/v14/rpc/backend.(*Backend).GasPrice(0x1?)
	/go/src/github.com/evmos/evmos/rpc/backend/call_tx.go:391 +0x2e
github.com/evmos/evmos/v14/rpc/namespaces/ethereum/eth.(*PublicAPI).GasPrice(0xc1a7ac8120)
	/go/src/github.com/evmos/evmos/rpc/namespaces/ethereum/eth/api.go:304 +0x4d
reflect.Value.call({0xc0128ec7d0?, 0xc01e1108c8?, 0x7efc27a56370?}, {0x308f76e, 0x4}, {0xc4ea675410, 0x1, 0x0?})
	/usr/local/go/src/reflect/value.go:596 +0xce7
reflect.Value.Call({0xc0128ec7d0?, 0xc01e1108c8?, 0x0?}, {0xc4ea675410?, 0xc06c69acb0?, 0x53e005?})
	/usr/local/go/src/reflect/value.go:380 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc014c7da40, {0x3fbc150?, 0xc4d9003b80}, {0xc4aeabec80, 0xc}, {0x5d82240, 0x0, 0x4f54cf?})
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/service.go:206 +0x37c
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc4aeabec90?, {0x3fbc150?, 0xc4d9003b80?}, 0xc4da7ad030, 0x0?, {0x5d82240?, 0x2dd3700?, 0xc06c69ae08?})
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:388 +0x3c
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc4daf22240, 0xc4ea6753b0, 0xc4da7ad030)
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:336 +0x22f
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc4daf22240, 0x30?, 0xc4da7ad030)
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:297 +0xbd
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc4ea6753b0)
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:138 +0x2f
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:225 +0xbe
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc in goroutine 109099080
	/go/pkg/mod/github.com/evmos/go-ethereum@v1.10.26-evmos-rc2/rpc/handler.go:221 +0x79
 module=geth
4:48PM INF Served eth_gasPrice conn=10.100.1.8:47380 duration=600.599497 err="method handler crashed" module=geth reqid=2232
4:48PM INF Served eth_getLogs conn=10.100.1.8:43508 duration=497.484693 err="failed to fetch header by number (latest): block result not found for height 16461313" module=geth reqid=2
```

This PR adds the corresponding changes to handle this gracefully and avoid the panic. 
As a result, the user will get the following response:

```
{"jsonrpc":"2.0","id":73,"error":{"code":-32000,"message":"block result not found for height 22. node is not persisting abci responses"}}
```

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->