### PR TITLE
fix(test): fix the problem about deliverTxSimulate in test app/ante/cosmos/min_price_test.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (evm) [#1801](https://github.com/evmos/evmos/pull/1801) Fixed the problem gas_used is 0 when using evm type tx to transfer token to module account.
 - (evm) [#1943](https://github.com/evmos/evmos/pull/1943) Fix gas estimation (`eth_estimateGas`) to be consistent with gas used in EVM extensions transactions.
+- (test) [#1989](https://github.com/evmos/evmos/pull/1989) Fix the problem about deliverTxSimulate in test app/ante/cosmos/min_price_test.go
 
 ## [v15.0.0] - 2023-10-31
 

--- a/app/ante/cosmos/min_price_test.go
+++ b/app/ante/cosmos/min_price_test.go
@@ -56,7 +56,7 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 			},
 			true,
 			"",
-			false,
+			true,
 		},
 		{
 			"valid cosmos tx with MinGasPrices = 0, gasPrice > 0",
@@ -71,7 +71,7 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 			},
 			true,
 			"",
-			false,
+			true,
 		},
 		{
 			"valid cosmos tx with MinGasPrices = 10, gasPrice = 10",
@@ -86,7 +86,7 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 			},
 			true,
 			"",
-			false,
+			true,
 		},
 		{
 			"invalid cosmos tx with MinGasPrices = 10, gasPrice = 0",
@@ -128,7 +128,7 @@ func (suite *AnteTestSuite) TestMinGasPriceDecorator() {
 				dec := cosmosante.NewMinGasPriceDecorator(suite.app.FeeMarketKeeper, suite.app.EvmKeeper)
 				_, err := dec.AnteHandle(ctx, tc.malleate(), et.simulate, testutil.NextFn)
 
-				if tc.expPass || (et.simulate && tc.allowPassOnSimulate) {
+				if (et.name == "deliverTx" && tc.expPass) || (et.name == "deliverTxSimulate" && et.simulate && tc.allowPassOnSimulate) {
 					suite.Require().NoError(err, tc.name)
 				} else {
 					suite.Require().Error(err, tc.name)


### PR DESCRIPTION
## Description
I saw some tests in it, deliverTx can pass, but deliverTxSimulate cannot. This is obviously wrong. Because the former has stricter inspections than the latter