### PR TITLE
imp(staking): implement the `CreateValidator` function for staking precompiled contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (osmosis-outpost) [#2017](https://github.com/evmos/evmos/pull/2017) Refactor types, errors and precompile struct.
 - (erc20) [#2023](https://github.com/evmos/evmos/pull/2023) Add tests for ERC20 precompile queries.
 - (osmosis-outpost) [#2025](https://github.com/evmos/evmos/pull/2025) Use a struct to wrap parsed parameters from Solidity.
+- (staking) [#2030](https://github.com/evmos/evmos/pull/2030) Implement the `CreateValidator` function for staking precompiled contract.
 
 ### Bug Fixes
 

--- a/precompiles/common/abi.go
+++ b/precompiles/common/abi.go
@@ -131,6 +131,23 @@ func PackNum(value reflect.Value) []byte {
 	}
 }
 
+// packBytesSlice packs the given bytes as [L, V] as the canonical representation
+// bytes slice.
+func packBytesSlice(bytes []byte, l int) []byte {
+	len := PackNum(reflect.ValueOf(l))
+	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
+}
+
+// PackElement packs the given reflect value according to the abi specification type
+func PackElement(value reflect.Value) []byte {
+	switch kind := value.Kind(); kind {
+	case reflect.String:
+		return packBytesSlice([]byte(value.String()), value.Len())
+	default:
+		panic("abi: fatal error")
+	}
+}
+
 // LoadABI read the ABI file described by the path and parse it as JSON.
 func LoadABI(fs embed.FS, path string) (abi.ABI, error) {
 	abiBz, err := fs.ReadFile(path)

--- a/precompiles/common/abi.go
+++ b/precompiles/common/abi.go
@@ -134,8 +134,8 @@ func PackNum(value reflect.Value) []byte {
 // packBytesSlice packs the given bytes as [L, V] as the canonical representation
 // bytes slice.
 func packBytesSlice(bytes []byte, l int) []byte {
-	len := PackNum(reflect.ValueOf(l))
-	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
+	length := PackNum(reflect.ValueOf(l))
+	return append(length, common.RightPadBytes(bytes, (l+31)/32*32)...)
 }
 
 // PackElement packs the given reflect value according to the abi specification type

--- a/precompiles/staking/StakingI.sol
+++ b/precompiles/staking/StakingI.sol
@@ -284,7 +284,7 @@ interface StakingI is authorization.AuthorizationI {
         uint256 commissionMaxRate,
         uint256 commissionMaxChangeRate,
         uint256 minSelfDelegation,
-        string pubkey,
+//        string pubkey, // TODO: how to pack string value into events in go code ?
         uint256 value
     );
 

--- a/precompiles/staking/StakingI.sol
+++ b/precompiles/staking/StakingI.sol
@@ -11,10 +11,21 @@ address constant STAKING_PRECOMPILE_ADDRESS = 0x00000000000000000000000000000000
 StakingI constant STAKING_CONTRACT = StakingI(STAKING_PRECOMPILE_ADDRESS);
 
 /// @dev Define all the available staking methods.
+string constant MSG_CREATE_VALIDATOR = "/cosmos.staking.v1beta1.MsgCreateValidator";
 string constant MSG_DELEGATE = "/cosmos.staking.v1beta1.MsgDelegate";
 string constant MSG_UNDELEGATE = "/cosmos.staking.v1beta1.MsgUndelegate";
 string constant MSG_REDELEGATE = "/cosmos.staking.v1beta1.MsgBeginRedelegate";
 string constant MSG_CANCEL_UNDELEGATION = "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation";
+
+/// @dev Defines the initial description to be used for creating
+/// a validator.
+struct Description {
+    string moniker;
+    string identity;
+    string website;
+    string securityContact;
+    string details;
+}
 
 /// @dev Defines the initial commission rates to be used for creating
 /// a validator.
@@ -114,6 +125,25 @@ enum BondStatus {
 /// wraps the pallet.
 /// @custom:address 0x0000000000000000000000000000000000000800
 interface StakingI is authorization.AuthorizationI {
+    /// @dev Defines a method for creating a new validator.
+    /// @param description The initial description
+    /// @param commissionRates The initial commissionRates
+    /// @param minSelfDelegation The
+    /// @param delegatorAddress The
+    /// @param validatorAddress The
+    /// @param pubkey The
+    /// @param value The
+    /// @return success Whether or not the create validator was successful
+    function createValidator(
+        Description calldata description,
+        CommissionRates calldata commissionRates,
+        string memory minSelfDelegation,
+        address delegatorAddress,
+        string memory validatorAddress,
+        string memory pubkey,
+        uint256 value
+    ) external returns (bool success);
+
     /// @dev Defines a method for performing a delegation of coins from a delegator to a validator.
     /// @param delegatorAddress The address of the delegator
     /// @param validatorAddress The address of the validator

--- a/precompiles/staking/StakingI.sol
+++ b/precompiles/staking/StakingI.sol
@@ -128,16 +128,16 @@ interface StakingI is authorization.AuthorizationI {
     /// @dev Defines a method for creating a new validator.
     /// @param description The initial description
     /// @param commissionRates The initial commissionRates
-    /// @param minSelfDelegation The
-    /// @param delegatorAddress The
-    /// @param validatorAddress The
-    /// @param pubkey The
-    /// @param value The
+    /// @param minSelfDelegation The validator's self declared minimum self delegation
+    /// @param delegatorAddress The delegator address
+    /// @param validatorAddress The validator address
+    /// @param pubkey The consensus public key of the validator
+    /// @param value The amount of the coin to be self delegated to the validator
     /// @return success Whether or not the create validator was successful
     function createValidator(
         Description calldata description,
         CommissionRates calldata commissionRates,
-        string memory minSelfDelegation,
+        uint256 minSelfDelegation,
         address delegatorAddress,
         string memory validatorAddress,
         string memory pubkey,
@@ -267,6 +267,26 @@ interface StakingI is authorization.AuthorizationI {
             RedelegationResponse[] calldata response,
             PageResponse calldata pageResponse
         );
+
+    /// @dev CreateValidator defines an Event emitted when a create a new validator.
+    /// @param delegatorAddress The address of the delegator
+    /// @param validatorAddress The address of the validator
+    /// @param commissionRate The commission rate charged to delegators, as a fraction
+    /// @param commissionMaxRate The commission max rate charged to delegators, as a fraction
+    /// @param commissionMaxChangeRate The commission max change rate charged to delegators, as a fraction
+    /// @param minSelfDelegation The validator's self declared minimum self delegation
+    /// @param pubkey The consensus public key of the validator
+    /// @param value The amount of coin being self delegated
+    event CreateValidator(
+        address indexed delegatorAddress,
+        string indexed validatorAddress,
+        uint256 commissionRate,
+        uint256 commissionMaxRate,
+        uint256 commissionMaxChangeRate,
+        uint256 minSelfDelegation,
+        string pubkey,
+        uint256 value
+    );
 
     /// @dev Delegate defines an Event emitted when a given amount of tokens are delegated from the
     /// delegator address to the validator address.

--- a/precompiles/staking/abi.json
+++ b/precompiles/staking/abi.json
@@ -110,6 +110,61 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "commissionRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commissionMaxRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commissionMaxChangeRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minSelfDelegation",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "pubkey",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "CreateValidator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegatorAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "validatorAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
       },
@@ -365,9 +420,9 @@
         "type": "tuple"
       },
       {
-        "internalType": "string",
+        "internalType": "uint256",
         "name": "minSelfDelegation",
-        "type": "string"
+        "type": "uint256"
       },
       {
         "internalType": "address",

--- a/precompiles/staking/abi.json
+++ b/precompiles/staking/abi.json
@@ -133,12 +133,6 @@
       },
       {
         "indexed": false,
-        "internalType": "string",
-        "name": "pubkey",
-        "type": "string"
-      },
-      {
-        "indexed": false,
         "internalType": "uint256",
         "name": "value",
         "type": "uint256"

--- a/precompiles/staking/abi.json
+++ b/precompiles/staking/abi.json
@@ -311,6 +311,99 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "moniker",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "identity",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "securityContact",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "details",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct Description",
+        "name": "description",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "rate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxRate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxChangeRate",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CommissionRates",
+        "name": "commissionRates",
+        "type": "tuple"
+      },
+      {
+        "internalType": "string",
+        "name": "minSelfDelegation",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "delegatorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "validatorAddress",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "pubkey",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "createValidator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "grantee",
         "type": "address"

--- a/precompiles/staking/events.go
+++ b/precompiles/staking/events.go
@@ -139,7 +139,7 @@ func (p Precompile) EmitCreateValidatorEvent(ctx sdk.Context, stateDB vm.StateDB
 	b.Write(cmn.PackNum(reflect.ValueOf(msg.Commission.MaxRate.BigInt())))
 	b.Write(cmn.PackNum(reflect.ValueOf(msg.Commission.MaxChangeRate.BigInt())))
 	b.Write(cmn.PackNum(reflect.ValueOf(msg.MinSelfDelegation.BigInt())))
-	b.Write(cmn.PackElement(reflect.ValueOf(msg.Pubkey.String())))
+	// b.Write(cmn.PackElement(reflect.ValueOf(msg.Pubkey.String()))) // TODO: how to pack string into events?
 	b.Write(cmn.PackNum(reflect.ValueOf(msg.Value.Amount.BigInt())))
 
 	stateDB.AddLog(&ethtypes.Log{

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -109,6 +109,8 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	case authorization.DecreaseAllowanceMethod:
 		bz, err = p.DecreaseAllowance(ctx, evm.Origin, stateDB, method, args)
 	// Staking transactions
+	case CreateValidatorMethod:
+		bz, err = p.CreateValidator(ctx, evm.Origin, contract, stateDB, method, args)
 	case DelegateMethod:
 		bz, err = p.Delegate(ctx, evm.Origin, contract, stateDB, method, args)
 	case UndelegateMethod:

--- a/precompiles/staking/tx.go
+++ b/precompiles/staking/tx.go
@@ -56,6 +56,80 @@ func (p Precompile) CreateValidator(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
+	msg, delegatorHexAddr, err := NewMsgCreateValidator(args, p.stakingKeeper.BondDenom(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	p.Logger(ctx).Debug(
+		"tx called",
+		"method", method.Name,
+		"args", fmt.Sprintf(
+			"{ min_self_delegation: %s, delegator_address: %s, validator_address: %s, pubkey: %s, value: %s }",
+			msg.MinSelfDelegation.String(),
+			delegatorHexAddr,
+			msg.ValidatorAddress,
+			msg.Pubkey.String(),
+			msg.Value.Amount.String(),
+		),
+	)
+
+	var (
+		// stakeAuthz is the authorization grant for the caller and the delegator address
+		stakeAuthz *stakingtypes.StakeAuthorization
+		// expiration is the expiration time of the authorization grant
+		expiration *time.Time
+
+		// isCallerOrigin is true when the contract caller is the same as the origin
+		isCallerOrigin = contract.CallerAddress == origin
+		// isCallerDelegator is true when the contract caller is the same as the delegator
+		isCallerDelegator = contract.CallerAddress == delegatorHexAddr
+	)
+
+	// The provided delegator address should always be equal to the origin address.
+	// In case the contract caller address is the same as the delegator address provided,
+	// update the delegator address to be equal to the origin address.
+	// Otherwise, if the provided delegator address is different from the origin address,
+	// return an error because is a forbidden operation
+	if isCallerDelegator {
+		delegatorHexAddr = origin
+	} else if origin != delegatorHexAddr {
+		return nil, fmt.Errorf(ErrDifferentOriginFromDelegator, origin.String(), delegatorHexAddr.String())
+	}
+
+	// no need to have authorization when the contract caller is the same as origin (owner of funds)
+	if !isCallerOrigin {
+		// Check if the authorization grant exists for the caller and the origin
+		stakeAuthz, expiration, err = authorization.CheckAuthzAndAllowanceForGranter(ctx, p.AuthzKeeper, contract.CallerAddress, delegatorHexAddr, &msg.Value, DelegateMsg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Execute the transaction using the message server
+	msgSrv := stakingkeeper.NewMsgServerImpl(&p.stakingKeeper)
+	if _, err = msgSrv.CreateValidator(sdk.WrapSDKContext(ctx), msg); err != nil {
+		return nil, err
+	}
+
+	// Only update the authorization if the contract caller is different from the origin
+	if !isCallerOrigin {
+		if err := p.UpdateStakingAuthorization(ctx, contract.CallerAddress, delegatorHexAddr, stakeAuthz, expiration, DelegateMsg, msg); err != nil {
+			return nil, err
+		}
+	}
+
+	// Emit the event for the delegate transaction
+	if err = p.EmitCreateValidatorEvent(ctx, stateDB, msg, delegatorHexAddr); err != nil {
+		return nil, err
+	}
+
+	// NOTE: This ensures that the changes in the bank keeper are correctly mirrored to the EVM stateDB.
+	// This prevents the stateDB from overwriting the changed balance in the bank keeper when committing the EVM state.
+	if isCallerDelegator {
+		stateDB.(*statedb.StateDB).SubBalance(contract.CallerAddress, msg.Value.Amount.BigInt())
+	}
+
 	return method.Outputs.Pack(true)
 }
 

--- a/precompiles/staking/tx.go
+++ b/precompiles/staking/tx.go
@@ -30,6 +30,8 @@ const (
 	// CancelUnbondingDelegationMethod defines the ABI method name for the staking
 	// CancelUnbondingDelegation transaction.
 	CancelUnbondingDelegationMethod = "cancelUnbondingDelegation"
+	// CreateValidatorMethod defines the ABI method name for the staking create validator transaction
+	CreateValidatorMethod = "createValidator"
 )
 
 const (
@@ -41,7 +43,21 @@ const (
 	RedelegateAuthz = stakingtypes.AuthorizationType_AUTHORIZATION_TYPE_REDELEGATE
 	// CancelUnbondingDelegationAuthz defines the authorization type for the staking
 	CancelUnbondingDelegationAuthz = stakingtypes.AuthorizationType_AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION
+	// CreateValidatorAuthz defines the authorization type for the create validator
+	CreateValidatorAuthz = 5 // TODO: define cosmos sdk
 )
+
+// CreateValidator performs create validator.
+func (p Precompile) CreateValidator(
+	ctx sdk.Context,
+	origin common.Address,
+	contract *vm.Contract,
+	stateDB vm.StateDB,
+	method *abi.Method,
+	args []interface{},
+) ([]byte, error) {
+	return method.Outputs.Pack(true)
+}
 
 // Delegate performs a delegation of coins from a delegator to a validator.
 func (p Precompile) Delegate(

--- a/precompiles/staking/types.go
+++ b/precompiles/staking/types.go
@@ -4,11 +4,12 @@
 package staking
 
 import (
-	"cosmossdk.io/math"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
+
+	"cosmossdk.io/math"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"


### PR DESCRIPTION
## Description

I noticed that evmos have already implemented functions like `delegate`, `undelegate`, and `redelegate` in the precompiled contract. However, I think the important `createValidator` function is missing. Additionally, the `createValidator` function is not currently implemented in evmosjs either, so the only way to create a validator is through the CLI command `evmosd tx staking create-validator`. Due to these reasons, I have implemented the `createValidator` function in the precompiled contract.

## Prerequisites

Start two nodes, named node0 and node1. Node0 is a validator node and node1 is a non-validator node. Node0 and node1 have already been linked via p2p.

Currently, there is only one validator with a signature.
<img width="2296" alt="1" src="https://github.com/evmos/evmos/assets/9688029/c886b27b-81c5-4ddb-ae68-0f1e494c2734">

Check the list of validators, which currently has only one validator.
<img width="2282" alt="2" src="https://github.com/evmos/evmos/assets/9688029/094800cb-1b81-4d69-bc6f-e7a86bcf1aa6">

## Objective

Call the `createValidator` method in the Staking precompiled contract make node1 become a validator node.

## Steps

### Step 1

Use the command `evmosd tendermint show-validator --home=./nodes/node1/evmosd` to obtain the node public key for node1. Let's assume the obtained content is as follows:

```json
{
    "@type":"/cosmos.crypto.ed25519.PubKey",
    "key":"OD/HHcEPGg9z+sGO1OCFItC1oup2pHUVbyXZKxOtI/o="
}
```

The **key** is the node1 public key.

### Step 2

Use Remix to connect to node1. Note: Be sure to connect to node1 using Remix's External HTTP Provider method, as calling the contract requires online signing. 

Then, call the `createValidator` method in the Staking precompiled contract with the following parameters:

- `description`: ["node1","I'm identity","[http://www.lucq.fun](http://www.lucq.fun/)","0x0000000000000000000000000000000000000800","I'm details"]
- `commissionRates`: [100000000000000000,100000000000000000,100000000000000000]
- `minSelfDelegation`: 1
- `delegatorAddress`: 0xC79b690bA90B8e04625b8a11C20e8b356f5996d2
- `validatorAddress`: evmosvaloper1c7dkjzafpw8qgcjm3gguyr5tx4h4n9kjuquq78
- `pubkey`: OD/HHcEPGg9z+sGO1OCFItC1oup2pHUVbyXZKxOtI/o=
- `value`: 100000000000000000000

Note that the input parameters in the `commissionRates` field should be decimal numbers with a precision of 18. So, the decimal values shown above are all 0.1. Replace `delegatorAddress`, `validatorAddress`, and `pubkey` with your actual values. Then send the transaction using Remix.
<img width="2303" alt="3" src="https://github.com/evmos/evmos/assets/9688029/adcb99cb-265a-4b36-a0c3-bdc26fb9d970">

### Step 3

Verify that node1 has become a validator.

The list of validators should now display an additional validator called node1.
<img width="2294" alt="4" src="https://github.com/evmos/evmos/assets/9688029/01b62a24-d2c5-4fa4-972a-4f8542f79093">

There are currently two validators and their signatures.
<img width="2303" alt="5" src="https://github.com/evmos/evmos/assets/9688029/d8fc7ae1-c909-4504-9adc-13a6b187c2c9">

Query evm type transactions.
<img width="2300" alt="6" src="https://github.com/evmos/evmos/assets/9688029/4ca30610-c73c-485b-adbf-7f86c8eaf3b8">

Query cosmos type transactions.
<img width="2296" alt="7" src="https://github.com/evmos/evmos/assets/9688029/6a170e54-932c-4531-8972-e690b9e3c7aa">

The tool website used in some of the above screenshots is http://cosmos.lucq.fun/

## TODO

- If you find this feature reasonable and merged, I will submit a separate PR to implement related uint tests.
- In the evmos code, I am not sure how to include a string type pubkey in the `CreateValidator` event.
- I have noticed that sending a transaction with gas price set to 0 to invoke a precompiled contract always fails. This might be a bug in all precompiled contracts.