### PR TITLE
feat(gasprice): local gas price check for transaction fees during CheckTx stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (osmosis-outpost) [#1986](https://github.com/evmos/evmos/pull/1986) Add Osmosis outpost transaction.
 - (erc20) [#1997](https://github.com/evmos/evmos/pull/1997) Add logic for ERC-20 precompile registration.
 - (bech32) [#2038](https://github.com/evmos/evmos/pull/2038) Add `bech32` conversion precompile.
+- (local-gas-price) [#2071](https://github.com/evmos/evmos/pull/2071) Local gas price check for transaction fees during CheckTx stage.
 
 ### Improvements
 

--- a/cmd/evmosd/testnet.go
+++ b/cmd/evmosd/testnet.go
@@ -163,6 +163,16 @@ Example:
 			baseFee, _ := cmd.Flags().GetString(flagBaseFee)
 			minGasPrice, _ := cmd.Flags().GetString(flagMinGasPrice)
 
+			// only allow user use aevmos native token as transaction fees
+			minGasPrices, err := sdk.ParseDecCoin(args.minGasPrices)
+			if err != nil {
+				return err
+			}
+
+			if minGasPrices.Denom != cmdcfg.BaseDenom {
+				return fmt.Errorf("invalid value for --minimum-gas-prices. expected %s for gas price but got %s", cmdcfg.BaseDenom, minGasPrices.Denom)
+			}
+
 			var ok bool
 			args.baseFee, ok = sdk.NewIntFromString(baseFee)
 			if !ok || args.baseFee.LT(sdk.ZeroInt()) {


### PR DESCRIPTION
## Description
In the **app.toml** configuration file, there is a `minimum-gas-prices` field, which I call it **local gas price**. In the feemarket module, there is also a min_gas_price field, which I call it **global gas price**. Evmos does not have any functionality to manage the local gas price field. I believe this should be left for validators to configure. 

For example, when there are many transactions, validator would like to choose some transactions with higher gas prices to enter the mempool. Here's a simple example: assuming the current global gas price is 10 gwei, if a validator sets the local gas price to 20 gwei, then the validator will not put transactions with a gas price below 20 gwei in the mempool. If the validator sets the local gas price to 5 gwei, then transactions with a gas price below the global gas price of 10 gwei will not be put in the mempool. 

**Summarize: in the CheckTx phase, a transaction will only be put in the mempool if it meets both the global gas price and local gas price requirements.**