### PR TITLE
fix(db): change versiondb directory permission from 777 (insecure) to 750 (general)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#1801](https://github.com/evmos/evmos/pull/1801) Fixed the problem gas_used is 0 when using evm type tx to transfer token to module account.
 - (evm) [#1943](https://github.com/evmos/evmos/pull/1943) Fix gas estimation (`eth_estimateGas`) to be consistent with gas used in EVM extensions transactions.
 - (test) [#1989](https://github.com/evmos/evmos/pull/1989) Fix the problem about deliverTxSimulate in test app/ante/cosmos/min_price_test.go
+- (db) [#2072](https://github.com/evmos/evmos/pull/2072) Change VersionDb directory permission from 777 (insecure) to 750 (general)
 
 ## [v15.0.0] - 2023-10-31
 

--- a/app/db.go
+++ b/app/db.go
@@ -34,7 +34,7 @@ func (app *Evmos) setupVersionDB(
 	memKeys map[string]*storetypes.MemoryStoreKey,
 ) (sdk.MultiStore, error) {
 	dataDir := filepath.Join(homePath, "data", versionDB)
-	if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return nil, err
 	}
 	store, err := tsrocksdb.NewStore(dataDir)

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -136,7 +136,7 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	return bz, nil
 }
 
-// IsTransaction checks if the given methodID corresponds to a transaction or query.
+// IsTransaction checks if the given method name corresponds to a transaction or query.
 //
 // Available distribution transactions are:
 //   - ClaimRewards

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -143,8 +143,8 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 //   - SetWithdrawAddress
 //   - WithdrawDelegatorRewards
 //   - WithdrawValidatorCommission
-func (Precompile) IsTransaction(methodID string) bool {
-	switch methodID {
+func (Precompile) IsTransaction(methodName string) bool {
+	switch methodName {
 	case ClaimRewardsMethod,
 		SetWithdrawAddressMethod,
 		WithdrawDelegatorRewardsMethod,

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -155,7 +155,7 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	return bz, nil
 }
 
-// IsTransaction checks if the given methodID corresponds to a transaction or query.
+// IsTransaction checks if the given method name corresponds to a transaction or query.
 func (Precompile) IsTransaction(methodName string) bool {
 	switch methodName {
 	case TransferMethod,

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -156,8 +156,8 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 }
 
 // IsTransaction checks if the given methodID corresponds to a transaction or query.
-func (Precompile) IsTransaction(methodID string) bool {
-	switch methodID {
+func (Precompile) IsTransaction(methodName string) bool {
+	switch methodName {
 	case TransferMethod,
 		TransferFromMethod,
 		auth.ApproveMethod,

--- a/precompiles/werc20/werc20.go
+++ b/precompiles/werc20/werc20.go
@@ -136,7 +136,7 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	return bz, nil
 }
 
-// IsTransaction checks if the given methodID corresponds to a transaction or query.
+// IsTransaction checks if the given method name corresponds to a transaction or query.
 func (p Precompile) IsTransaction(methodName string) bool {
 	switch methodName {
 	case DepositMethod, WithdrawMethod:


### PR DESCRIPTION
The `versiondb` directory was created with permission `os.ModePerm` (777) which is insecure so I changed it to generic permission 750.

In additional, I rename some wrong variable name which pointed out in #2058