### PR TITLE
imp(erc20): Adjust ERC20 allowance behavior for same spender

### DIFF
--- a/precompiles/erc20/errors.go
+++ b/precompiles/erc20/errors.go
@@ -32,6 +32,7 @@ var (
 	ErrIncreaseNonPositiveValue = errors.New("cannot increase allowance with non-positive values")
 	ErrNegativeAmount           = errors.New("cannot approve negative values")
 	ErrNoIBCVoucherDenom        = errors.New("denom is not an IBC voucher")
+	ErrSpenderIsOwner           = errors.New("spender cannot be the owner")
 
 	// ERC20 errors
 	ErrDecreasedAllowanceBelowZero  = errors.New("ERC20: decreased allowance below zero")

--- a/precompiles/werc20/integration_test.go
+++ b/precompiles/werc20/integration_test.go
@@ -577,7 +577,7 @@ var _ = Describe("WEVMOS Extension -", func() {
 
 				transferCoins := sdk.Coins{sdk.NewInt64Coin(s.tokenDenom, amount.Int64())}
 
-				transferCheck := passCheck.WithExpEvents(erc20.EventTypeTransfer)
+				transferCheck := passCheck.WithExpEvents(erc20.EventTypeTransfer, auth.EventTypeApproval)
 				_, ethRes, err := s.factory.CallContractAndCheckLogs(sender.Priv, txArgs, transferArgs, transferCheck)
 				Expect(err).ToNot(HaveOccurred(), "unexpected result calling contract")
 


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR adjusts the behavior of the ERC20 EVM extension in the following way:

- Trying to approve when the owner is the spender will return an error
- Querying the allowance for the own account will always return `abi.MaxUint256` (infinite allowance)
- Executing `transferFrom` where the owner is the spender will work without need for an approval and always emit an `ApprovalEvent` with the new allowance being `abi.MaxUint256`.

This behavior differs from the standard ERC20 OpenZeppelin contracts, but is not otherwise possible without changes to the Cosmos SDK. Here, grants between the same granter and grantee are not supported. 
Since an allowance for oneself is completely useless, this will not inhibit any user stories and should be at most a minor inconvenience for users.

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->