### PR TITLE
fix(min-price): block proposer 0 gas fee attack

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -37,6 +37,10 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 					)
 				}
 
+				if ctx.IsCheckTx() {
+					newCtx, _ := anteHandler(ctx, tx, sim)
+					return newCtx, nil
+				}
 				return anteHandler(ctx, tx, sim)
 			}
 		}
@@ -49,6 +53,13 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid transaction type: %T", tx)
 		}
 
+		// The validator do evil passed some illegal transactions when run CheckTx,
+		// and then packaged them into the block when he propose the block.
+		// forcing other validators to agree to these illegal transactions.
+		if ctx.IsCheckTx() {
+			newCtx, _ := anteHandler(ctx, tx, sim)
+			return newCtx, nil
+		}
 		return anteHandler(ctx, tx, sim)
 	}
 }

--- a/app/ante/cosmos/min_price.go
+++ b/app/ante/cosmos/min_price.go
@@ -86,6 +86,10 @@ func (mpd MinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	}
 
 	if !feeCoins.IsAnyGTE(requiredFees) {
+		// If the gasPrice set by the user is less than feemarket.params.min_gas_price at this time,
+		// it means that the validator is doing evil. Put the validator in jail
+		// slashingKeep.Jail(ctx, consAddr)
+
 		return ctx, errorsmod.Wrapf(errortypes.ErrInsufficientFee,
 			"provided fee < minimum global fee (%s < %s). Please increase the gas price.",
 			feeCoins,


### PR DESCRIPTION
## Description
Background: You can first read the discussion here: https://github.com/evmos/evmos/discussions/1747 , 
And I summarize the issues encountered in this discussion:

On the evmos mainnet, 
In block 15690857, the following information is relevant:
```
baseFeePerGas": 22187500000,
"gasLimit":40000000,
"gasUsed":34318622
```

In block 15690858, the following information is relevant:
```
"baseFeePerGas":28932117820,
"gasLimit":40000000,
"gasUsed":271310,
```

The user is supposed to have sent a transaction with gasPrice of **27715925175** in block 15690857. Since the gasPrice of this transaction is greater than the baseFee of **22187500000** in block 15690857, the transaction smoothly entered the validator's mempool.

Then, in block 15690858, it was the validator's turn to propose a block. At this time, due to the gasUsed in block 15690857 being greater than 50% of the block gasLimit, the baseFee increased to **28932117820**. This caused the transaction to fail when the validator executed it, as the transaction's gasPrice was less than the baseFee.

Based on the above situation，one potential problem that can arise is if validators can pack many transactions into a block without paying fees, effectively using the blockchain as a free database. Let's assume some chain parameters as follows:
```
consensus_params.block.max_bytes='22020096'
app_state.feemarket.params.no_base_fee=false
app_state.feemarket.params.min_gas_price='1000000000.000000000000000000'
app_state.feemarket.params.base_fee='1000000000'
```

The process of the attack is as follows:

Step 1: Modify the code in the CheckTx stage to allow some transactions that cannot pass the check to go into the validator's mempool. please see my modified code of `NewAnteHandler` function: I directly discard the errors detected by `anteHandler` so that the transaction can enter the mempool.

Step 2: The validator sends themselves some transactions with gasPrice of 0, storing them in their mempool.

Step 3: When proposing a block, the validator includes these transactions in their block.

I see that the mainnet block max bytes limit is **22020096**. Using this method, when a validator proposing a block, he can store 22M of block data on the chain for free.

The following are some screenshots of the validator's attack process:

I have tested on a chain with two validator nodes, each with a voting power of 50%. Node 0 is the attacker, and node 1 is an honest validator.

Validator node 0 publishes a transaction with gasPrice of 0, the sender currently has 10000000 evmos assets.
<img width="2270" alt="image" src="https://github.com/evmos/evmos/assets/9688029/e79e4d88-ec48-48e9-ae23-9a0dee313f78">

Validator node 0 packs the transactions with gasPrice of 0.
<img width="2030" alt="xxxx" src="https://github.com/evmos/evmos/assets/9688029/5b16ffb1-86aa-4bb6-8441-8b7a914d16a8">


Query the transactions to confirm they are on the chain.
<img width="1239" alt="image" src="https://github.com/evmos/evmos/assets/9688029/47fe3f0a-869d-4b2a-b66e-d7089e87ac11">

The transaction sender assets have not changed
<img width="1979" alt="image" src="https://github.com/evmos/evmos/assets/9688029/76f309a7-1041-4eeb-98e1-802a810dbc26">

Another form of attack: the user's native token evmos are 0, but the gasPrice of the transaction sent satisfies the feemarket module baseFee.

<img width="2026" alt="image" src="https://github.com/evmos/evmos/assets/9688029/3b4da522-e4f4-4a0f-803b-7bc8a89ff697">

<img width="2015" alt="image" src="https://github.com/evmos/evmos/assets/9688029/d2f5eb96-d717-4a0c-aaf2-1364763ae386">


##  Solution
To be honest, I just discovered this vulnerability and didn't think of a perfect way to solve this problem. The following is some of my relevant analysis

In the feemark module, there is a parameter called `app_state.feemarket.params.min_gas_price` . If a validator packs transactions with gasPrice lower than this parameter into a block, then the validator is certainly performing malicious behavior, and we can jail validator .

Of course, a validator can also, like the user above, send a transaction with a gasPrice greater than min_gas_price but less than the current block's baseFee, and still be able to pack this transaction into a block for free. However, currently, due to the relatively small number of transactions on evmos, there are few blocks with baseFee exceeding app_state.feemarket.params.min_gas_price, making it more difficult for validators to conduct attacks.

As I mentioned later, the situation where the user sends a transaction that satisfies baseFee but the native token evmos is 0 is even more complicated, because we cannot confirm whether the user or the validator did evil.

