### PR TITLE
fix(swagger): use correct version of proto dependencies to generate swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (test) [#1989](https://github.com/evmos/evmos/pull/1989) Fix the problem about deliverTxSimulate in test app/ante/cosmos/min_price_test.go
 - (db) [#2072](https://github.com/evmos/evmos/pull/2072) Change VersionDb directory permission from 777 (insecure) to 750 (general)
 - (api) [#2196](https://github.com/evmos/evmos/pull/2196) Remove governance proposals related to the deprecated `x/incentives` module to fix the governance proposals query.
+- (swagger) [#2218](https://github.com/evmos/evmos/pull/2218) Use correct version of proto dependencies to generate swagger
 
 ## [v15.0.0] - 2023-10-31
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ DOCKER_TAG := $(COMMIT_HASH)
 MOUNT_PATH := $(shell pwd)/build/:/root/
 E2E_SKIP_CLEANUP := false
 ROCKSDB_VERSION ?= "8.8.1"
+# Deps
+DEPS_COSMOS_SDK_VERSION := $(shell cat go.sum | grep 'github.com/evmos/cosmos-sdk' | grep -v -e 'go.mod' | tail -n 1 | awk '{ print $$2; }')
+DEPS_IBC_GO_VERSION := $(shell cat go.sum | grep 'github.com/cosmos/ibc-go' | grep -v -e 'go.mod' | tail -n 1 | awk '{ print $$2; }')
+DEPS_COSMOS_PROTO := $(shell cat go.sum | grep 'github.com/cosmos/cosmos-proto' | grep -v -e 'go.mod' | tail -n 1 | awk '{ print $$2; }')
+DEPS_COSMOS_GOGOPROTO := $(shell cat go.sum | grep 'github.com/cosmos/gogoproto' | grep -v -e 'go.mod' | tail -n 1 | awk '{ print $$2; }')
+DEPS_COSMOS_ICS23 := go/$(shell cat go.sum | grep 'github.com/cosmos/ics23/go' | grep -v -e 'go.mod' | tail -n 1 | awk '{ print $$2; }')
 
 export GO111MODULE = on
 
@@ -450,10 +456,10 @@ proto-download-deps:
 	mkdir -p "$(THIRD_PARTY_DIR)/cosmos_tmp" && \
 	cd "$(THIRD_PARTY_DIR)/cosmos_tmp" && \
 	git init && \
-	git remote add origin "https://github.com/cosmos/cosmos-sdk.git" && \
+	git remote add origin "https://github.com/evmos/cosmos-sdk.git" && \
 	git config core.sparseCheckout true && \
 	printf "proto\nthird_party\n" > .git/info/sparse-checkout && \
-	git pull origin main && \
+	git pull origin "$(DEPS_COSMOS_SDK_VERSION)" && \
 	rm -f ./proto/buf.* && \
 	mv ./proto/* ..
 	rm -rf "$(THIRD_PARTY_DIR)/cosmos_tmp"
@@ -464,7 +470,7 @@ proto-download-deps:
 	git remote add origin "https://github.com/cosmos/ibc-go.git" && \
 	git config core.sparseCheckout true && \
 	printf "proto\n" > .git/info/sparse-checkout && \
-	git pull origin main && \
+	git pull origin "$(DEPS_IBC_GO_VERSION)" && \
 	rm -f ./proto/buf.* && \
 	mv ./proto/* ..
 	rm -rf "$(THIRD_PARTY_DIR)/ibc_tmp"
@@ -475,20 +481,20 @@ proto-download-deps:
 	git remote add origin "https://github.com/cosmos/cosmos-proto.git" && \
 	git config core.sparseCheckout true && \
 	printf "proto\n" > .git/info/sparse-checkout && \
-	git pull origin main && \
+	git pull origin "$(DEPS_COSMOS_PROTO_VERSION)" && \
 	rm -f ./proto/buf.* && \
 	mv ./proto/* ..
 	rm -rf "$(THIRD_PARTY_DIR)/cosmos_proto_tmp"
 
 	mkdir -p "$(THIRD_PARTY_DIR)/gogoproto" && \
-	curl -SSL https://raw.githubusercontent.com/cosmos/gogoproto/main/gogoproto/gogo.proto > "$(THIRD_PARTY_DIR)/gogoproto/gogo.proto"
+	curl -SSL "https://raw.githubusercontent.com/cosmos/gogoproto/$(DEPS_COSMOS_GOGOPROTO)/gogoproto/gogo.proto" > "$(THIRD_PARTY_DIR)/gogoproto/gogo.proto"
 
 	mkdir -p "$(THIRD_PARTY_DIR)/google/api" && \
 	curl -sSL https://raw.githubusercontent.com/googleapis/googleapis/master/google/api/annotations.proto > "$(THIRD_PARTY_DIR)/google/api/annotations.proto"
 	curl -sSL https://raw.githubusercontent.com/googleapis/googleapis/master/google/api/http.proto > "$(THIRD_PARTY_DIR)/google/api/http.proto"
 
 	mkdir -p "$(THIRD_PARTY_DIR)/cosmos/ics23/v1" && \
-	curl -sSL https://raw.githubusercontent.com/cosmos/ics23/master/proto/cosmos/ics23/v1/proofs.proto > "$(THIRD_PARTY_DIR)/cosmos/ics23/v1/proofs.proto"
+	curl -sSL "https://raw.githubusercontent.com/cosmos/ics23/$(DEPS_COSMOS_ICS23)/proto/cosmos/ics23/v1/proofs.proto" > "$(THIRD_PARTY_DIR)/cosmos/ics23/v1/proofs.proto"
 
 
 .PHONY: proto-all proto-gen proto-format proto-lint proto-check-breaking proto-swagger-gen

--- a/client/docs/swagger-ui/swagger.json
+++ b/client/docs/swagger-ui/swagger.json
@@ -4618,7 +4618,7 @@
           },
           {
             "name": "latest_height",
-            "description": "latest_height overrides the height field and queries the latest stored\nConsensusState.",
+            "description": "latest_height overrrides the height field and queries the latest stored\nConsensusState.",
             "in": "query",
             "required": false,
             "type": "boolean"
@@ -4976,7 +4976,7 @@
                               "title": "list of features compatible with the specified identifier"
                             }
                           },
-                          "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+                          "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
                         },
                         "title": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection"
                       },
@@ -5181,7 +5181,7 @@
                             "title": "list of features compatible with the specified identifier"
                           }
                         },
-                        "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+                        "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
                       },
                       "description": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection."
                     },
@@ -5631,12 +5631,10 @@
                           "STATE_INIT",
                           "STATE_TRYOPEN",
                           "STATE_OPEN",
-                          "STATE_CLOSED",
-                          "STATE_FLUSHING",
-                          "STATE_FLUSHCOMPLETE"
+                          "STATE_CLOSED"
                         ],
                         "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-                        "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+                        "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
                       },
                       "ordering": {
                         "title": "whether the channel is ordered or unordered",
@@ -5681,11 +5679,6 @@
                       "channel_id": {
                         "type": "string",
                         "title": "channel identifier"
-                      },
-                      "upgrade_sequence": {
-                        "type": "string",
-                        "format": "uint64",
-                        "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
                       }
                     },
                     "description": "IdentifiedChannel defines a channel with additional port and channel\nidentifier fields."
@@ -5834,12 +5827,10 @@
                         "STATE_INIT",
                         "STATE_TRYOPEN",
                         "STATE_OPEN",
-                        "STATE_CLOSED",
-                        "STATE_FLUSHING",
-                        "STATE_FLUSHCOMPLETE"
+                        "STATE_CLOSED"
                       ],
                       "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-                      "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+                      "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
                     },
                     "ordering": {
                       "title": "whether the channel is ordered or unordered",
@@ -5876,11 +5867,6 @@
                     "version": {
                       "type": "string",
                       "title": "opaque channel version, which is agreed upon during the handshake"
-                    },
-                    "upgrade_sequence": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
                     }
                   },
                   "description": "Channel defines pipeline for exactly-once packet delivery between specific\nmodules on separate blockchains, which has at least one end capable of\nsending packets and one end capable of receiving packets."
@@ -6258,106 +6244,7 @@
                   "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
                 }
               },
-              "title": "QuerySequenceResponse is the response type for the\nQuery/QueryNextSequenceReceiveResponse RPC method"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string",
-                        "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Must be a valid serialized protocol buffer of the above specified type."
-                      }
-                    },
-                    "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "channel_id",
-            "description": "channel unique identifier",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "port_id",
-            "description": "port unique identifier",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Query"
-        ]
-      }
-    },
-    "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/next_sequence_send": {
-      "get": {
-        "summary": "NextSequenceSend returns the next send sequence for a given channel.",
-        "operationId": "NextSequenceSend",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "next_sequence_send": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "next sequence send number"
-                },
-                "proof": {
-                  "type": "string",
-                  "format": "byte",
-                  "title": "merkle proof of existence"
-                },
-                "proof_height": {
-                  "title": "height at which the proof was retrieved",
-                  "type": "object",
-                  "properties": {
-                    "revision_number": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the revision that the client is currently on"
-                    },
-                    "revision_height": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the height within the given revision"
-                    }
-                  },
-                  "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                }
-              },
-              "title": "QueryNextSequenceSendResponse is the request type for the\nQuery/QueryNextSequenceSend RPC method"
+              "title": "QuerySequenceResponse is the request type for the\nQuery/QueryNextSequenceReceiveResponse RPC method"
             }
           },
           "default": {
@@ -7312,269 +7199,6 @@
         ]
       }
     },
-    "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/upgrade": {
-      "get": {
-        "summary": "Upgrade returns the upgrade for a given port and channel id.",
-        "operationId": "Upgrade",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "upgrade": {
-                  "type": "object",
-                  "properties": {
-                    "fields": {
-                      "type": "object",
-                      "properties": {
-                        "ordering": {
-                          "type": "string",
-                          "enum": [
-                            "ORDER_NONE_UNSPECIFIED",
-                            "ORDER_UNORDERED",
-                            "ORDER_ORDERED"
-                          ],
-                          "default": "ORDER_NONE_UNSPECIFIED",
-                          "description": "- ORDER_NONE_UNSPECIFIED: zero-value for channel ordering\n - ORDER_UNORDERED: packets can be delivered in any order, which may differ from the order in\nwhich they were sent.\n - ORDER_ORDERED: packets are delivered exactly in the order which they were sent",
-                          "title": "Order defines if a channel is ORDERED or UNORDERED"
-                        },
-                        "connection_hops": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "version": {
-                          "type": "string"
-                        }
-                      },
-                      "description": "UpgradeFields are the fields in a channel end which may be changed\nduring a channel upgrade."
-                    },
-                    "timeout": {
-                      "type": "object",
-                      "properties": {
-                        "height": {
-                          "title": "block height after which the packet or upgrade times out",
-                          "type": "object",
-                          "properties": {
-                            "revision_number": {
-                              "type": "string",
-                              "format": "uint64",
-                              "title": "the revision that the client is currently on"
-                            },
-                            "revision_height": {
-                              "type": "string",
-                              "format": "uint64",
-                              "title": "the height within the given revision"
-                            }
-                          },
-                          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "uint64",
-                          "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-                        }
-                      },
-                      "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-                    },
-                    "next_sequence_send": {
-                      "type": "string",
-                      "format": "uint64"
-                    }
-                  },
-                  "description": "Upgrade is a verifiable type which contains the relevant information\nfor an attempted upgrade. It provides the proposed changes to the channel\nend, the timeout for this upgrade attempt and the next packet sequence\nwhich allows the counterparty to efficiently know the highest sequence it has received.\nThe next sequence send is used for pruning and upgrading from unordered to ordered channels."
-                },
-                "proof": {
-                  "type": "string",
-                  "format": "byte",
-                  "title": "merkle proof of existence"
-                },
-                "proof_height": {
-                  "title": "height at which the proof was retrieved",
-                  "type": "object",
-                  "properties": {
-                    "revision_number": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the revision that the client is currently on"
-                    },
-                    "revision_height": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the height within the given revision"
-                    }
-                  },
-                  "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                }
-              },
-              "title": "QueryUpgradeResponse is the response type for the QueryUpgradeResponse RPC method"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string",
-                        "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Must be a valid serialized protocol buffer of the above specified type."
-                      }
-                    },
-                    "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "channel_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "port_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Query"
-        ]
-      }
-    },
-    "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/upgrade_error": {
-      "get": {
-        "summary": "UpgradeError returns the error receipt if the upgrade handshake failed.",
-        "operationId": "UpgradeError",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error_receipt": {
-                  "type": "object",
-                  "properties": {
-                    "sequence": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the channel upgrade sequence"
-                    },
-                    "message": {
-                      "type": "string",
-                      "title": "the error message detailing the cause of failure"
-                    }
-                  },
-                  "description": "ErrorReceipt defines a type which encapsulates the upgrade sequence and error associated with the\nupgrade handshake failure. When a channel upgrade handshake is aborted both chains are expected to increment to the\nnext sequence."
-                },
-                "proof": {
-                  "type": "string",
-                  "format": "byte",
-                  "title": "merkle proof of existence"
-                },
-                "proof_height": {
-                  "title": "height at which the proof was retrieved",
-                  "type": "object",
-                  "properties": {
-                    "revision_number": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the revision that the client is currently on"
-                    },
-                    "revision_height": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the height within the given revision"
-                    }
-                  },
-                  "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                }
-              },
-              "title": "QueryUpgradeErrorResponse is the response type for the Query/QueryUpgradeError RPC method"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string",
-                        "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Must be a valid serialized protocol buffer of the above specified type."
-                      }
-                    },
-                    "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "channel_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "port_id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Query"
-        ]
-      }
-    },
     "/ibc/core/channel/v1/connections/{connection}/channels": {
       "get": {
         "summary": "ConnectionChannels queries all the channels associated with a connection\nend.",
@@ -7598,12 +7222,10 @@
                           "STATE_INIT",
                           "STATE_TRYOPEN",
                           "STATE_OPEN",
-                          "STATE_CLOSED",
-                          "STATE_FLUSHING",
-                          "STATE_FLUSHCOMPLETE"
+                          "STATE_CLOSED"
                         ],
                         "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-                        "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+                        "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
                       },
                       "ordering": {
                         "title": "whether the channel is ordered or unordered",
@@ -7648,11 +7270,6 @@
                       "channel_id": {
                         "type": "string",
                         "title": "channel identifier"
-                      },
-                      "upgrade_sequence": {
-                        "type": "string",
-                        "format": "uint64",
-                        "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
                       }
                     },
                     "description": "IdentifiedChannel defines a channel with additional port and channel\nidentifier fields."
@@ -7781,96 +7398,6 @@
             "type": "boolean"
           }
         ],
-        "tags": [
-          "Query"
-        ]
-      }
-    },
-    "/ibc/core/channel/v1/params": {
-      "get": {
-        "summary": "ChannelParams queries all parameters of the ibc channel submodule.",
-        "operationId": "ChannelParams",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "params": {
-                  "description": "params defines the parameters of the module.",
-                  "type": "object",
-                  "properties": {
-                    "upgrade_timeout": {
-                      "type": "object",
-                      "properties": {
-                        "height": {
-                          "title": "block height after which the packet or upgrade times out",
-                          "type": "object",
-                          "properties": {
-                            "revision_number": {
-                              "type": "string",
-                              "format": "uint64",
-                              "title": "the revision that the client is currently on"
-                            },
-                            "revision_height": {
-                              "type": "string",
-                              "format": "uint64",
-                              "title": "the height within the given revision"
-                            }
-                          },
-                          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "uint64",
-                          "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-                        }
-                      },
-                      "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-                    }
-                  }
-                }
-              },
-              "description": "QueryChannelParamsResponse is the response type for the Query/ChannelParams RPC method."
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string",
-                        "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Must be a valid serialized protocol buffer of the above specified type."
-                      }
-                    },
-                    "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-                  }
-                }
-              }
-            }
-          }
-        },
         "tags": [
           "Query"
         ]
@@ -9294,13 +8821,6 @@
             "in": "query",
             "required": false,
             "type": "boolean"
-          },
-          {
-            "name": "resolve_denom",
-            "description": "resolve_denom is the flag to resolve the denom into a human-readable form from the metadata.\n\nSince: cosmos-sdk 0.50",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
           }
         ],
         "tags": [
@@ -9826,128 +9346,6 @@
         ]
       }
     },
-    "/cosmos/bank/v1beta1/denoms_metadata_by_query_string": {
-      "get": {
-        "summary": "DenomsMetadata queries the client metadata of a given coin denomination.",
-        "operationId": "DenomMetadataByQueryString",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "metadata": {
-                  "type": "object",
-                  "properties": {
-                    "description": {
-                      "type": "string"
-                    },
-                    "denom_units": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "denom": {
-                            "type": "string",
-                            "description": "denom represents the string name of the given denom unit (e.g uatom)."
-                          },
-                          "exponent": {
-                            "type": "integer",
-                            "format": "int64",
-                            "description": "exponent represents power of 10 exponent that one must\nraise the base_denom to in order to equal the given DenomUnit's denom\n1 denom = 10^exponent base_denom\n(e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with\nexponent = 6, thus: 1 atom = 10^6 uatom)."
-                          },
-                          "aliases": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "title": "aliases is a list of string aliases for the given denom"
-                          }
-                        },
-                        "description": "DenomUnit represents a struct that describes a given\ndenomination unit of the basic token."
-                      },
-                      "title": "denom_units represents the list of DenomUnit's for a given coin"
-                    },
-                    "base": {
-                      "type": "string",
-                      "description": "base represents the base denom (should be the DenomUnit with exponent = 0)."
-                    },
-                    "display": {
-                      "type": "string",
-                      "description": "display indicates the suggested denom that should be\ndisplayed in clients."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Since: cosmos-sdk 0.43",
-                      "title": "name defines the name of the token (eg: Cosmos Atom)"
-                    },
-                    "symbol": {
-                      "type": "string",
-                      "description": "symbol is the token symbol usually shown on exchanges (eg: ATOM). This can\nbe the same as the display.\n\nSince: cosmos-sdk 0.43"
-                    },
-                    "uri": {
-                      "type": "string",
-                      "description": "URI to a document (on or off-chain) that contains additional information. Optional.\n\nSince: cosmos-sdk 0.46"
-                    },
-                    "uri_hash": {
-                      "type": "string",
-                      "description": "URIHash is a sha256 hash of a document pointed by URI. It's used to verify that\nthe document didn't change. Optional.\n\nSince: cosmos-sdk 0.46"
-                    }
-                  },
-                  "description": "Metadata represents a struct that describes\na basic token."
-                }
-              },
-              "description": "QueryDenomMetadataByQueryStringResponse is the response type for the Query/DenomMetadata RPC\nmethod. Identical with QueryDenomMetadataResponse but receives denom as query string in request."
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "denom",
-            "description": "denom is the coin denom to query the metadata for.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Query"
-        ]
-      }
-    },
     "/cosmos/bank/v1beta1/params": {
       "get": {
         "summary": "Params queries the parameters of x/bank module.",
@@ -9959,7 +9357,6 @@
               "type": "object",
               "properties": {
                 "params": {
-                  "description": "params provides the parameters of the bank module.",
                   "type": "object",
                   "properties": {
                     "send_enabled": {
@@ -9981,7 +9378,8 @@
                     "default_send_enabled": {
                       "type": "boolean"
                     }
-                  }
+                  },
+                  "description": "Params defines the parameters for the bank module."
                 }
               },
               "description": "QueryParamsResponse defines the response type for querying x/bank parameters."
@@ -10581,7 +9979,6 @@
     "/cosmos/distribution/v1beta1/community_pool": {
       "get": {
         "summary": "CommunityPool queries the community pool coins.",
-        "description": "Deprecated: Prefer to use x/protocolpool module's CommunityPool rpc method.\nSince: cosmos-sdk 0.50",
         "operationId": "CommunityPool",
         "responses": {
           "200": {
@@ -10606,7 +10003,7 @@
                   "description": "pool defines community pool's coins."
                 }
               },
-              "description": "QueryCommunityPoolResponse is the response type for the Query/CommunityPool\nRPC method.\n\nDeprecated\nSince: cosmos-sdk 0.50"
+              "description": "QueryCommunityPoolResponse is the response type for the Query/CommunityPool\nRPC method."
             }
           },
           "default": {
@@ -10650,7 +10047,7 @@
     },
     "/cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards": {
       "get": {
-        "summary": "DelegationTotalRewards queries the total rewards accrued by each\nvalidator.",
+        "summary": "DelegationTotalRewards queries the total rewards accrued by a each\nvalidator.",
         "operationId": "DelegationTotalRewards",
         "responses": {
           "200": {
@@ -11462,7 +10859,7 @@
     },
     "/cosmos/feegrant/v1beta1/allowance/{granter}/{grantee}": {
       "get": {
-        "summary": "Allowance returns granted allwance to the grantee by the granter.",
+        "summary": "Allowance returns fee granted to the grantee by the granter.",
         "operationId": "Allowance",
         "responses": {
           "200": {
@@ -11564,7 +10961,7 @@
     },
     "/cosmos/feegrant/v1beta1/allowances/{grantee}": {
       "get": {
-        "summary": "Allowances returns all the grants for the given grantee address.",
+        "summary": "Allowances returns all the grants for address.",
         "operationId": "Allowances",
         "responses": {
           "200": {
@@ -12769,7 +12166,7 @@
     },
     "/cosmos/gov/v1beta1/proposals/{proposal_id}/deposits/{depositor}": {
       "get": {
-        "summary": "Deposit queries single deposit information based on proposalID, depositor address.",
+        "summary": "Deposit queries single deposit information based proposalID, depositAddr.",
         "operationId": "Deposit",
         "responses": {
           "200": {
@@ -13138,7 +12535,7 @@
     },
     "/cosmos/gov/v1beta1/proposals/{proposal_id}/votes/{voter}": {
       "get": {
-        "summary": "Vote queries voted information based on proposalID, voterAddr.\nDue to how we handle state, this query would error for proposals that has already been finished.",
+        "summary": "Vote queries voted information based on proposalID, voterAddr.",
         "operationId": "Vote",
         "responses": {
           "200": {
@@ -13262,65 +12659,6 @@
         ]
       }
     },
-    "/cosmos/gov/v1/constitution": {
-      "get": {
-        "summary": "Constitution queries the chain's constitution.",
-        "operationId": "Constitution",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "constitution": {
-                  "type": "string"
-                }
-              },
-              "title": "QueryConstitutionResponse is the response type for the Query/Constitution RPC method"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                },
-                "details": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type_url": {
-                        "type": "string",
-                        "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
-                      },
-                      "value": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Must be a valid serialized protocol buffer of the above specified type."
-                      }
-                    },
-                    "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Query"
-        ]
-      }
-    },
     "/cosmos/gov/v1/params/{params_type}": {
       "get": {
         "summary": "Params queries all parameters of the gov module.",
@@ -13386,7 +12724,7 @@
                   }
                 },
                 "params": {
-                  "description": "params defines all the parameters of x/gov module.\n\nSince: cosmos-sdk 0.47",
+                  "description": "params defines all the paramaters of x/gov module.\n\nSince: cosmos-sdk 0.47",
                   "type": "object",
                   "properties": {
                     "min_deposit": {
@@ -13429,72 +12767,17 @@
                       "type": "string",
                       "description": "The ratio representing the proportion of the deposit value that must be paid at proposal submission."
                     },
-                    "proposal_cancel_ratio": {
-                      "type": "string",
-                      "description": "The cancel ratio which will not be returned back to the depositors when a proposal is cancelled.\n\nSince: cosmos-sdk 0.50"
-                    },
-                    "proposal_cancel_dest": {
-                      "type": "string",
-                      "description": "The address which will receive (proposal_cancel_ratio * deposit) proposal deposits.\nIf empty, the (proposal_cancel_ratio * deposit) proposal deposits will be burned.\n\nSince: cosmos-sdk 0.50"
-                    },
-                    "expedited_voting_period": {
-                      "type": "string",
-                      "description": "Duration of the voting period of an expedited proposal.\n\nSince: cosmos-sdk 0.50"
-                    },
-                    "expedited_threshold": {
-                      "type": "string",
-                      "description": "Minimum proportion of Yes votes for proposal to pass. Default value: 0.67.\n\nSince: cosmos-sdk 0.50"
-                    },
-                    "expedited_min_deposit": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "denom": {
-                            "type": "string"
-                          },
-                          "amount": {
-                            "type": "string"
-                          }
-                        },
-                        "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto."
-                      },
-                      "description": "Minimum expedited deposit for a proposal to enter voting period."
-                    },
                     "burn_vote_quorum": {
                       "type": "boolean",
-                      "description": "Since: cosmos-sdk 0.47",
                       "title": "burn deposits if a proposal does not meet quorum"
                     },
                     "burn_proposal_deposit_prevote": {
                       "type": "boolean",
-                      "description": "Since: cosmos-sdk 0.47",
                       "title": "burn deposits if the proposal does not enter voting period"
                     },
                     "burn_vote_veto": {
                       "type": "boolean",
-                      "description": "Since: cosmos-sdk 0.47",
                       "title": "burn deposits if quorum with vote type no_veto is met"
-                    },
-                    "min_deposit_ratio": {
-                      "type": "string",
-                      "description": "The ratio representing the proportion of the deposit value minimum that must be met when making a deposit.\nDefault value: 0.01. Meaning that for a chain with a min_deposit of 100stake, a deposit of 1stake would be\nrequired.\n\nSince: cosmos-sdk 0.50"
-                    },
-                    "proposal_cancel_max_period": {
-                      "type": "string",
-                      "description": "proposal_cancel_max_period defines how far in the voting period a proposer can cancel a proposal.\nIf the proposal is cancelled before the max cancel period, the deposit will be returned/burn to the\ndepositors, according to the proposal_cancel_ratio and proposal_cancel_dest parameters.\nAfter the max cancel period, the proposal cannot be cancelled anymore."
-                    },
-                    "optimistic_authorized_addresses": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Since: x/gov v1.0.0",
-                      "title": "optimistic_authorized_addresses is an optional governance parameter that limits the authorized accounts than can\nsubmit optimistic proposals"
-                    },
-                    "optimistic_rejected_threshold": {
-                      "type": "string",
-                      "description": "optimistic rejected threshold defines at which percentage of NO votes, the optimistic proposal should fail and be\nconverted to a standard proposal. The threshold is expressed as a percentage of the total bonded tokens.\n\nSince: x/gov v1.0.0"
                     }
                   }
                 }
@@ -13624,10 +12907,6 @@
                           "no_with_veto_count": {
                             "type": "string",
                             "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-                          },
-                          "spam_count": {
-                            "type": "string",
-                            "description": "spam_count is the number of spam votes on a proposal."
                           }
                         }
                       },
@@ -13669,7 +12948,7 @@
                       },
                       "metadata": {
                         "type": "string",
-                        "title": "metadata is any arbitrary metadata attached to the proposal.\nthe recommended format of the metadata is to be found here:\nhttps://docs.cosmos.network/v0.47/modules/gov#proposal-3"
+                        "description": "metadata is any arbitrary metadata attached to the proposal."
                       },
                       "title": {
                         "type": "string",
@@ -13684,30 +12963,7 @@
                       "proposer": {
                         "type": "string",
                         "description": "Since: cosmos-sdk 0.47",
-                        "title": "proposer is the address of the proposal sumbitter"
-                      },
-                      "expedited": {
-                        "type": "boolean",
-                        "description": "Since: cosmos-sdk 0.50\nDeprecated: Use ProposalType instead.",
-                        "title": "expedited defines if the proposal is expedited"
-                      },
-                      "failed_reason": {
-                        "type": "string",
-                        "description": "Since: cosmos-sdk 0.50",
-                        "title": "failed_reason defines the reason why the proposal failed"
-                      },
-                      "proposal_type": {
-                        "description": "Since: cosmos-sdk 0.51",
-                        "title": "proposal_type defines the type of the proposal",
-                        "type": "string",
-                        "enum": [
-                          "PROPOSAL_TYPE_UNSPECIFIED",
-                          "PROPOSAL_TYPE_STANDARD",
-                          "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-                          "PROPOSAL_TYPE_OPTIMISTIC",
-                          "PROPOSAL_TYPE_EXPEDITED"
-                        ],
-                        "default": "PROPOSAL_TYPE_UNSPECIFIED"
+                        "title": "Proposer is the address of the proposal sumbitter"
                       }
                     },
                     "description": "Proposal defines the core field members of a governance proposal."
@@ -13915,10 +13171,6 @@
                         "no_with_veto_count": {
                           "type": "string",
                           "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-                        },
-                        "spam_count": {
-                          "type": "string",
-                          "description": "spam_count is the number of spam votes on a proposal."
                         }
                       }
                     },
@@ -13960,7 +13212,7 @@
                     },
                     "metadata": {
                       "type": "string",
-                      "title": "metadata is any arbitrary metadata attached to the proposal.\nthe recommended format of the metadata is to be found here:\nhttps://docs.cosmos.network/v0.47/modules/gov#proposal-3"
+                      "description": "metadata is any arbitrary metadata attached to the proposal."
                     },
                     "title": {
                       "type": "string",
@@ -13975,30 +13227,7 @@
                     "proposer": {
                       "type": "string",
                       "description": "Since: cosmos-sdk 0.47",
-                      "title": "proposer is the address of the proposal sumbitter"
-                    },
-                    "expedited": {
-                      "type": "boolean",
-                      "description": "Since: cosmos-sdk 0.50\nDeprecated: Use ProposalType instead.",
-                      "title": "expedited defines if the proposal is expedited"
-                    },
-                    "failed_reason": {
-                      "type": "string",
-                      "description": "Since: cosmos-sdk 0.50",
-                      "title": "failed_reason defines the reason why the proposal failed"
-                    },
-                    "proposal_type": {
-                      "description": "Since: cosmos-sdk 0.51",
-                      "title": "proposal_type defines the type of the proposal",
-                      "type": "string",
-                      "enum": [
-                        "PROPOSAL_TYPE_UNSPECIFIED",
-                        "PROPOSAL_TYPE_STANDARD",
-                        "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-                        "PROPOSAL_TYPE_OPTIMISTIC",
-                        "PROPOSAL_TYPE_EXPEDITED"
-                      ],
-                      "default": "PROPOSAL_TYPE_UNSPECIFIED"
+                      "title": "Proposer is the address of the proposal sumbitter"
                     }
                   },
                   "description": "Proposal defines the core field members of a governance proposal."
@@ -14216,7 +13445,7 @@
     },
     "/cosmos/gov/v1/proposals/{proposal_id}/deposits/{depositor}": {
       "get": {
-        "summary": "Deposit queries single deposit information based on proposalID, depositAddr.",
+        "summary": "Deposit queries single deposit information based proposalID, depositAddr.",
         "operationId": "GovV1Deposit",
         "responses": {
           "200": {
@@ -14347,10 +13576,6 @@
                     "no_with_veto_count": {
                       "type": "string",
                       "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-                    },
-                    "spam_count": {
-                      "type": "string",
-                      "description": "spam_count is the number of spam votes on a proposal."
                     }
                   }
                 }
@@ -14444,15 +13669,10 @@
                               "type": "string",
                               "enum": [
                                 "VOTE_OPTION_UNSPECIFIED",
-                                "VOTE_OPTION_ONE",
                                 "VOTE_OPTION_YES",
-                                "VOTE_OPTION_TWO",
                                 "VOTE_OPTION_ABSTAIN",
-                                "VOTE_OPTION_THREE",
                                 "VOTE_OPTION_NO",
-                                "VOTE_OPTION_FOUR",
-                                "VOTE_OPTION_NO_WITH_VETO",
-                                "VOTE_OPTION_SPAM"
+                                "VOTE_OPTION_NO_WITH_VETO"
                               ],
                               "default": "VOTE_OPTION_UNSPECIFIED"
                             },
@@ -14467,7 +13687,7 @@
                       },
                       "metadata": {
                         "type": "string",
-                        "title": "metadata is any arbitrary metadata attached to the vote.\nthe recommended format of the metadata is to be found here: https://docs.cosmos.network/v0.47/modules/gov#vote-5"
+                        "description": "metadata is any  arbitrary metadata to attached to the vote."
                       }
                     },
                     "description": "Vote defines a vote on a governance proposal.\nA Vote consists of a proposal ID, the voter, and the vote option."
@@ -14616,15 +13836,10 @@
                             "type": "string",
                             "enum": [
                               "VOTE_OPTION_UNSPECIFIED",
-                              "VOTE_OPTION_ONE",
                               "VOTE_OPTION_YES",
-                              "VOTE_OPTION_TWO",
                               "VOTE_OPTION_ABSTAIN",
-                              "VOTE_OPTION_THREE",
                               "VOTE_OPTION_NO",
-                              "VOTE_OPTION_FOUR",
-                              "VOTE_OPTION_NO_WITH_VETO",
-                              "VOTE_OPTION_SPAM"
+                              "VOTE_OPTION_NO_WITH_VETO"
                             ],
                             "default": "VOTE_OPTION_UNSPECIFIED"
                           },
@@ -14639,7 +13854,7 @@
                     },
                     "metadata": {
                       "type": "string",
-                      "title": "metadata is any arbitrary metadata attached to the vote.\nthe recommended format of the metadata is to be found here: https://docs.cosmos.network/v0.47/modules/gov#vote-5"
+                      "description": "metadata is any  arbitrary metadata to attached to the vote."
                     }
                   },
                   "description": "Vote defines a vote on a governance proposal.\nA Vote consists of a proposal ID, the voter, and the vote option."
@@ -14806,12 +14021,12 @@
                       "start_height": {
                         "type": "string",
                         "format": "int64",
-                        "title": "Height at which validator was first a candidate OR was un-jailed"
+                        "title": "Height at which validator was first a candidate OR was unjailed"
                       },
                       "index_offset": {
                         "type": "string",
                         "format": "int64",
-                        "description": "Index which is incremented every time a validator is bonded in a block and\n_may_ have signed a pre-commit or not. This in conjunction with the\nsigned_blocks_window param determines the index in the missed block bitmap."
+                        "description": "Index which is incremented each time the validator was a bonded\nin a block and may have signed a precommit or not. This in conjunction with the\n`SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`."
                       },
                       "jailed_until": {
                         "type": "string",
@@ -14820,12 +14035,12 @@
                       },
                       "tombstoned": {
                         "type": "boolean",
-                        "description": "Whether or not a validator has been tombstoned (killed out of validator\nset). It is set once the validator commits an equivocation or for any other\nconfigured misbehavior."
+                        "description": "Whether or not a validator has been tombstoned (killed out of validator set). It is set\nonce the validator commits an equivocation or for any other configured misbehiavor."
                       },
                       "missed_blocks_counter": {
                         "type": "string",
                         "format": "int64",
-                        "description": "A counter of missed (unsigned) blocks. It is used to avoid unnecessary\nreads in the missed block bitmap."
+                        "description": "A counter kept to avoid unnecessary array reads.\nNote that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`."
                       }
                     },
                     "description": "ValidatorSigningInfo defines a validator's signing info for monitoring their\nliveness activity."
@@ -14950,12 +14165,12 @@
                     "start_height": {
                       "type": "string",
                       "format": "int64",
-                      "title": "Height at which validator was first a candidate OR was un-jailed"
+                      "title": "Height at which validator was first a candidate OR was unjailed"
                     },
                     "index_offset": {
                       "type": "string",
                       "format": "int64",
-                      "description": "Index which is incremented every time a validator is bonded in a block and\n_may_ have signed a pre-commit or not. This in conjunction with the\nsigned_blocks_window param determines the index in the missed block bitmap."
+                      "description": "Index which is incremented each time the validator was a bonded\nin a block and may have signed a precommit or not. This in conjunction with the\n`SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`."
                     },
                     "jailed_until": {
                       "type": "string",
@@ -14964,12 +14179,12 @@
                     },
                     "tombstoned": {
                       "type": "boolean",
-                      "description": "Whether or not a validator has been tombstoned (killed out of validator\nset). It is set once the validator commits an equivocation or for any other\nconfigured misbehavior."
+                      "description": "Whether or not a validator has been tombstoned (killed out of validator set). It is set\nonce the validator commits an equivocation or for any other configured misbehiavor."
                     },
                     "missed_blocks_counter": {
                       "type": "string",
                       "format": "int64",
-                      "description": "A counter of missed (unsigned) blocks. It is used to avoid unnecessary\nreads in the missed block bitmap."
+                      "description": "A counter kept to avoid unnecessary array reads.\nNote that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`."
                     }
                   },
                   "description": "ValidatorSigningInfo defines a validator's signing info for monitoring their\nliveness activity.",
@@ -15048,11 +14263,11 @@
                         "properties": {
                           "delegator_address": {
                             "type": "string",
-                            "description": "delegator_address is the encoded address of the delegator."
+                            "description": "delegator_address is the bech32-encoded address of the delegator."
                           },
                           "validator_address": {
                             "type": "string",
-                            "description": "validator_address is the encoded address of the validator."
+                            "description": "validator_address is the bech32-encoded address of the validator."
                           },
                           "shares": {
                             "type": "string",
@@ -15450,11 +14665,11 @@
                     "properties": {
                       "delegator_address": {
                         "type": "string",
-                        "description": "delegator_address is the encoded address of the delegator."
+                        "description": "delegator_address is the bech32-encoded address of the delegator."
                       },
                       "validator_address": {
                         "type": "string",
-                        "description": "validator_address is the encoded address of the validator."
+                        "description": "validator_address is the bech32-encoded address of the validator."
                       },
                       "entries": {
                         "type": "array",
@@ -15745,7 +14960,7 @@
                           "type": "string",
                           "format": "uint64"
                         },
-                        "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                        "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                       }
                     },
                     "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -15996,7 +15211,7 @@
                         "type": "string",
                         "format": "uint64"
                       },
-                      "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                      "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                     }
                   },
                   "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -16299,31 +15514,13 @@
                               "type": "string",
                               "format": "uint64"
                             },
-                            "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                            "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                           }
                         },
                         "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
                       }
                     }
                   }
-                },
-                "historical_record": {
-                  "type": "object",
-                  "properties": {
-                    "apphash": {
-                      "type": "string",
-                      "format": "byte"
-                    },
-                    "time": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "validators_hash": {
-                      "type": "string",
-                      "format": "byte"
-                    }
-                  },
-                  "description": "Historical contains a set of minimum values needed for evaluating historical validator sets and blocks.\nIt is stored as part of staking module's state, which persists the `n` most\nrecent HistoricalInfo\n(`n` is set by the staking module's `historical_entries` parameter)."
                 }
               },
               "description": "QueryHistoricalInfoResponse is response type for the Query/HistoricalInfo RPC\nmethod."
@@ -16421,19 +15618,6 @@
                     "min_commission_rate": {
                       "type": "string",
                       "title": "min_commission_rate is the chain-wide minimum commission rate that a validator can charge their delegators"
-                    },
-                    "key_rotation_fee": {
-                      "type": "object",
-                      "properties": {
-                        "denom": {
-                          "type": "string"
-                        },
-                        "amount": {
-                          "type": "string"
-                        }
-                      },
-                      "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto.",
-                      "title": "key_rotation_fee is fee to be spent when rotating validator's key\n(either consensus pubkey or operator key)"
                     }
                   }
                 }
@@ -16689,7 +15873,7 @@
                           "type": "string",
                           "format": "uint64"
                         },
-                        "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                        "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                       }
                     },
                     "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -16940,7 +16124,7 @@
                         "type": "string",
                         "format": "uint64"
                       },
-                      "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                      "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                     }
                   },
                   "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -17021,11 +16205,11 @@
                         "properties": {
                           "delegator_address": {
                             "type": "string",
-                            "description": "delegator_address is the encoded address of the delegator."
+                            "description": "delegator_address is the bech32-encoded address of the delegator."
                           },
                           "validator_address": {
                             "type": "string",
-                            "description": "validator_address is the encoded address of the validator."
+                            "description": "validator_address is the bech32-encoded address of the validator."
                           },
                           "shares": {
                             "type": "string",
@@ -17177,11 +16361,11 @@
                       "properties": {
                         "delegator_address": {
                           "type": "string",
-                          "description": "delegator_address is the encoded address of the delegator."
+                          "description": "delegator_address is the bech32-encoded address of the delegator."
                         },
                         "validator_address": {
                           "type": "string",
-                          "description": "validator_address is the encoded address of the validator."
+                          "description": "validator_address is the bech32-encoded address of the validator."
                         },
                         "shares": {
                           "type": "string",
@@ -17282,11 +16466,11 @@
                   "properties": {
                     "delegator_address": {
                       "type": "string",
-                      "description": "delegator_address is the encoded address of the delegator."
+                      "description": "delegator_address is the bech32-encoded address of the delegator."
                     },
                     "validator_address": {
                       "type": "string",
-                      "description": "validator_address is the encoded address of the validator."
+                      "description": "validator_address is the bech32-encoded address of the validator."
                     },
                     "entries": {
                       "type": "array",
@@ -17409,11 +16593,11 @@
                     "properties": {
                       "delegator_address": {
                         "type": "string",
-                        "description": "delegator_address is the encoded address of the delegator."
+                        "description": "delegator_address is the bech32-encoded address of the delegator."
                       },
                       "validator_address": {
                         "type": "string",
-                        "description": "validator_address is the encoded address of the validator."
+                        "description": "validator_address is the bech32-encoded address of the validator."
                       },
                       "entries": {
                         "type": "array",
@@ -17930,7 +17114,7 @@
                             }
                           }
                         },
-                        "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                        "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
                       },
                       "description": "Events contains a slice of Event objects that were emitted during message\nor handler execution."
                     },
@@ -18062,7 +17246,7 @@
         "parameters": [
           {
             "name": "events",
-            "description": "events is the list of transaction event type.\nDeprecated: post v0.47.x use query instead, which should contain a valid\nevents query.",
+            "description": "events is the list of transaction event type.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -18111,7 +17295,7 @@
           },
           {
             "name": "order_by",
-            "description": " - ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults\nto ASC in this case.\n - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order\n - ORDER_BY_DESC: ORDER_BY_DESC defines descending order",
+            "description": " - ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to ASC in this case.\n - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order\n - ORDER_BY_DESC: ORDER_BY_DESC defines descending order",
             "in": "query",
             "required": false,
             "type": "string",
@@ -18124,7 +17308,7 @@
           },
           {
             "name": "page",
-            "description": "page is the page number to query, starts at 1. If not provided, will\ndefault to first page.",
+            "description": "page is the page number to query, starts at 1. If not provided, will default to first page.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -18137,13 +17321,6 @@
             "required": false,
             "type": "string",
             "format": "uint64"
-          },
-          {
-            "name": "query",
-            "description": "query defines the transaction event query that is proxied to Tendermint's\nTxSearch RPC method. The query must be valid.\n\nSince cosmos-sdk 0.50",
-            "in": "query",
-            "required": false,
-            "type": "string"
           }
         ],
         "tags": [
@@ -18293,7 +17470,7 @@
                             }
                           }
                         },
-                        "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                        "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
                       },
                       "description": "Events defines all the events emitted by processing a transaction. Note,\nthese events include those emitted by processing all the messages and those\nemitted from the ante. Whereas Logs contains the events, with\nadditional metadata, emitted only by processing the messages.\n\nSince: cosmos-sdk 0.42.11, 0.44.5, 0.45"
                     }
@@ -18363,7 +17540,7 @@
                     "BROADCAST_MODE_ASYNC"
                   ],
                   "default": "BROADCAST_MODE_UNSPECIFIED",
-                  "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC\nmethod.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: Deprecated: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits\nfor a CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client\nreturns immediately."
+                  "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for\na CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns\nimmediately."
                 }
               },
               "description": "BroadcastTxRequest is the request type for the Service.BroadcastTxRequest\nRPC method."
@@ -18897,21 +18074,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "vote_b": {
                                     "type": "object",
@@ -18973,21 +18139,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "total_voting_power": {
                                     "type": "string",
@@ -19157,7 +18312,7 @@
                                                         "BLOCK_ID_FLAG_NIL"
                                                       ],
                                                       "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                                      "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                                      "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                                     },
                                                     "validator_address": {
                                                       "type": "string",
@@ -19359,7 +18514,7 @@
                                   "BLOCK_ID_FLAG_NIL"
                                 ],
                                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                "title": "BlockIdFlag indicates which BlcokID the signature is for"
                               },
                               "validator_address": {
                                 "type": "string",
@@ -19566,21 +18721,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "vote_b": {
                                     "type": "object",
@@ -19642,21 +18786,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "total_voting_power": {
                                     "type": "string",
@@ -19826,7 +18959,7 @@
                                                         "BLOCK_ID_FLAG_NIL"
                                                       ],
                                                       "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                                      "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                                      "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                                     },
                                                     "validator_address": {
                                                       "type": "string",
@@ -20028,7 +19161,7 @@
                                   "BLOCK_ID_FLAG_NIL"
                                 ],
                                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                "title": "BlockIdFlag indicates which BlcokID the signature is for"
                               },
                               "validator_address": {
                                 "type": "string",
@@ -20316,21 +19449,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "vote_b": {
                                     "type": "object",
@@ -20392,21 +19514,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "total_voting_power": {
                                     "type": "string",
@@ -20576,7 +19687,7 @@
                                                         "BLOCK_ID_FLAG_NIL"
                                                       ],
                                                       "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                                      "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                                      "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                                     },
                                                     "validator_address": {
                                                       "type": "string",
@@ -20778,7 +19889,7 @@
                                   "BLOCK_ID_FLAG_NIL"
                                 ],
                                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                "title": "BlockIdFlag indicates which BlcokID the signature is for"
                               },
                               "validator_address": {
                                 "type": "string",
@@ -20985,21 +20096,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "vote_b": {
                                     "type": "object",
@@ -21061,21 +20161,10 @@
                                       },
                                       "signature": {
                                         "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                                      },
-                                      "extension": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                                      },
-                                      "extension_signature": {
-                                        "type": "string",
-                                        "format": "byte",
-                                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                        "format": "byte"
                                       }
                                     },
-                                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                                   },
                                   "total_voting_power": {
                                     "type": "string",
@@ -21245,7 +20334,7 @@
                                                         "BLOCK_ID_FLAG_NIL"
                                                       ],
                                                       "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                                      "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                                      "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                                     },
                                                     "validator_address": {
                                                       "type": "string",
@@ -21447,7 +20536,7 @@
                                   "BLOCK_ID_FLAG_NIL"
                                 ],
                                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                "title": "BlockIdFlag indicates which BlcokID the signature is for"
                               },
                               "validator_address": {
                                 "type": "string",
@@ -24393,7 +23482,7 @@
                 "title": "list of features compatible with the specified identifier"
               }
             },
-            "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+            "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
           },
           "description": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection."
         },
@@ -24494,7 +23583,7 @@
                 "title": "list of features compatible with the specified identifier"
               }
             },
-            "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+            "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
           },
           "title": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection"
         },
@@ -24736,7 +23825,7 @@
                     "title": "list of features compatible with the specified identifier"
                   }
                 },
-                "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+                "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
               },
               "description": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection."
             },
@@ -24842,7 +23931,7 @@
                       "title": "list of features compatible with the specified identifier"
                     }
                   },
-                  "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+                  "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
                 },
                 "title": "IBC version which can be utilised to determine encodings or protocols for\nchannels or packets utilising this connection"
               },
@@ -24955,7 +24044,7 @@
           "title": "list of features compatible with the specified identifier"
         }
       },
-      "description": "Version defines the versioning scheme used to negotiate the IBC version in\nthe connection handshake."
+      "description": "Version defines the versioning scheme used to negotiate the IBC verison in\nthe connection handshake."
     },
     "ibc.core.channel.v1.Channel": {
       "type": "object",
@@ -24968,12 +24057,10 @@
             "STATE_INIT",
             "STATE_TRYOPEN",
             "STATE_OPEN",
-            "STATE_CLOSED",
-            "STATE_FLUSHING",
-            "STATE_FLUSHCOMPLETE"
+            "STATE_CLOSED"
           ],
           "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-          "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+          "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
         },
         "ordering": {
           "title": "whether the channel is ordered or unordered",
@@ -25010,11 +24097,6 @@
         "version": {
           "type": "string",
           "title": "opaque channel version, which is agreed upon during the handshake"
-        },
-        "upgrade_sequence": {
-          "type": "string",
-          "format": "uint64",
-          "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
         }
       },
       "description": "Channel defines pipeline for exactly-once packet delivery between specific\nmodules on separate blockchains, which has at least one end capable of\nsending packets and one end capable of receiving packets."
@@ -25033,21 +24115,6 @@
       },
       "title": "Counterparty defines a channel end counterparty"
     },
-    "ibc.core.channel.v1.ErrorReceipt": {
-      "type": "object",
-      "properties": {
-        "sequence": {
-          "type": "string",
-          "format": "uint64",
-          "title": "the channel upgrade sequence"
-        },
-        "message": {
-          "type": "string",
-          "title": "the error message detailing the cause of failure"
-        }
-      },
-      "description": "ErrorReceipt defines a type which encapsulates the upgrade sequence and error associated with the\nupgrade handshake failure. When a channel upgrade handshake is aborted both chains are expected to increment to the\nnext sequence."
-    },
     "ibc.core.channel.v1.IdentifiedChannel": {
       "type": "object",
       "properties": {
@@ -25059,12 +24126,10 @@
             "STATE_INIT",
             "STATE_TRYOPEN",
             "STATE_OPEN",
-            "STATE_CLOSED",
-            "STATE_FLUSHING",
-            "STATE_FLUSHCOMPLETE"
+            "STATE_CLOSED"
           ],
           "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-          "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+          "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
         },
         "ordering": {
           "title": "whether the channel is ordered or unordered",
@@ -25109,11 +24174,6 @@
         "channel_id": {
           "type": "string",
           "title": "channel identifier"
-        },
-        "upgrade_sequence": {
-          "type": "string",
-          "format": "uint64",
-          "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
         }
       },
       "description": "IdentifiedChannel defines a channel with additional port and channel\nidentifier fields."
@@ -25152,40 +24212,6 @@
         }
       },
       "description": "PacketState defines the generic type necessary to retrieve and store\npacket commitments, acknowledgements, and receipts.\nCaller is responsible for knowing the context necessary to interpret this\nstate as a commitment, acknowledgement, or a receipt."
-    },
-    "ibc.core.channel.v1.Params": {
-      "type": "object",
-      "properties": {
-        "upgrade_timeout": {
-          "type": "object",
-          "properties": {
-            "height": {
-              "title": "block height after which the packet or upgrade times out",
-              "type": "object",
-              "properties": {
-                "revision_number": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "the revision that the client is currently on"
-                },
-                "revision_height": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "the height within the given revision"
-                }
-              },
-              "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-            },
-            "timestamp": {
-              "type": "string",
-              "format": "uint64",
-              "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-            }
-          },
-          "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-        }
-      },
-      "description": "Params defines the set of IBC channel parameters."
     },
     "ibc.core.channel.v1.QueryChannelClientStateResponse": {
       "type": "object",
@@ -25290,46 +24316,6 @@
       },
       "title": "QueryChannelClientStateResponse is the Response type for the\nQuery/QueryChannelClientState RPC method"
     },
-    "ibc.core.channel.v1.QueryChannelParamsResponse": {
-      "type": "object",
-      "properties": {
-        "params": {
-          "description": "params defines the parameters of the module.",
-          "type": "object",
-          "properties": {
-            "upgrade_timeout": {
-              "type": "object",
-              "properties": {
-                "height": {
-                  "title": "block height after which the packet or upgrade times out",
-                  "type": "object",
-                  "properties": {
-                    "revision_number": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the revision that the client is currently on"
-                    },
-                    "revision_height": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the height within the given revision"
-                    }
-                  },
-                  "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                },
-                "timestamp": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-                }
-              },
-              "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-            }
-          }
-        }
-      },
-      "description": "QueryChannelParamsResponse is the response type for the Query/ChannelParams RPC method."
-    },
     "ibc.core.channel.v1.QueryChannelResponse": {
       "type": "object",
       "properties": {
@@ -25345,12 +24331,10 @@
                 "STATE_INIT",
                 "STATE_TRYOPEN",
                 "STATE_OPEN",
-                "STATE_CLOSED",
-                "STATE_FLUSHING",
-                "STATE_FLUSHCOMPLETE"
+                "STATE_CLOSED"
               ],
               "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-              "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+              "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
             },
             "ordering": {
               "title": "whether the channel is ordered or unordered",
@@ -25387,11 +24371,6 @@
             "version": {
               "type": "string",
               "title": "opaque channel version, which is agreed upon during the handshake"
-            },
-            "upgrade_sequence": {
-              "type": "string",
-              "format": "uint64",
-              "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
             }
           },
           "description": "Channel defines pipeline for exactly-once packet delivery between specific\nmodules on separate blockchains, which has at least one end capable of\nsending packets and one end capable of receiving packets."
@@ -25437,12 +24416,10 @@
                   "STATE_INIT",
                   "STATE_TRYOPEN",
                   "STATE_OPEN",
-                  "STATE_CLOSED",
-                  "STATE_FLUSHING",
-                  "STATE_FLUSHCOMPLETE"
+                  "STATE_CLOSED"
                 ],
                 "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-                "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+                "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
               },
               "ordering": {
                 "title": "whether the channel is ordered or unordered",
@@ -25487,11 +24464,6 @@
               "channel_id": {
                 "type": "string",
                 "title": "channel identifier"
-              },
-              "upgrade_sequence": {
-                "type": "string",
-                "format": "uint64",
-                "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
               }
             },
             "description": "IdentifiedChannel defines a channel with additional port and channel\nidentifier fields."
@@ -25551,12 +24523,10 @@
                   "STATE_INIT",
                   "STATE_TRYOPEN",
                   "STATE_OPEN",
-                  "STATE_CLOSED",
-                  "STATE_FLUSHING",
-                  "STATE_FLUSHCOMPLETE"
+                  "STATE_CLOSED"
                 ],
                 "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-                "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
+                "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
               },
               "ordering": {
                 "title": "whether the channel is ordered or unordered",
@@ -25601,11 +24571,6 @@
               "channel_id": {
                 "type": "string",
                 "title": "channel identifier"
-              },
-              "upgrade_sequence": {
-                "type": "string",
-                "format": "uint64",
-                "title": "upgrade sequence indicates the latest upgrade attempt performed by this channel\nthe value of 0 indicates the channel has never been upgraded"
               }
             },
             "description": "IdentifiedChannel defines a channel with additional port and channel\nidentifier fields."
@@ -25680,40 +24645,7 @@
           "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
         }
       },
-      "title": "QuerySequenceResponse is the response type for the\nQuery/QueryNextSequenceReceiveResponse RPC method"
-    },
-    "ibc.core.channel.v1.QueryNextSequenceSendResponse": {
-      "type": "object",
-      "properties": {
-        "next_sequence_send": {
-          "type": "string",
-          "format": "uint64",
-          "title": "next sequence send number"
-        },
-        "proof": {
-          "type": "string",
-          "format": "byte",
-          "title": "merkle proof of existence"
-        },
-        "proof_height": {
-          "title": "height at which the proof was retrieved",
-          "type": "object",
-          "properties": {
-            "revision_number": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the revision that the client is currently on"
-            },
-            "revision_height": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the height within the given revision"
-            }
-          },
-          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-        }
-      },
-      "title": "QueryNextSequenceSendResponse is the request type for the\nQuery/QueryNextSequenceSend RPC method"
+      "title": "QuerySequenceResponse is the request type for the\nQuery/QueryNextSequenceReceiveResponse RPC method"
     },
     "ibc.core.channel.v1.QueryPacketAcknowledgementResponse": {
       "type": "object",
@@ -26009,141 +24941,6 @@
       },
       "title": "QueryUnreceivedPacketsResponse is the response type for the\nQuery/UnreceivedPacketCommitments RPC method"
     },
-    "ibc.core.channel.v1.QueryUpgradeErrorResponse": {
-      "type": "object",
-      "properties": {
-        "error_receipt": {
-          "type": "object",
-          "properties": {
-            "sequence": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the channel upgrade sequence"
-            },
-            "message": {
-              "type": "string",
-              "title": "the error message detailing the cause of failure"
-            }
-          },
-          "description": "ErrorReceipt defines a type which encapsulates the upgrade sequence and error associated with the\nupgrade handshake failure. When a channel upgrade handshake is aborted both chains are expected to increment to the\nnext sequence."
-        },
-        "proof": {
-          "type": "string",
-          "format": "byte",
-          "title": "merkle proof of existence"
-        },
-        "proof_height": {
-          "title": "height at which the proof was retrieved",
-          "type": "object",
-          "properties": {
-            "revision_number": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the revision that the client is currently on"
-            },
-            "revision_height": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the height within the given revision"
-            }
-          },
-          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-        }
-      },
-      "title": "QueryUpgradeErrorResponse is the response type for the Query/QueryUpgradeError RPC method"
-    },
-    "ibc.core.channel.v1.QueryUpgradeResponse": {
-      "type": "object",
-      "properties": {
-        "upgrade": {
-          "type": "object",
-          "properties": {
-            "fields": {
-              "type": "object",
-              "properties": {
-                "ordering": {
-                  "type": "string",
-                  "enum": [
-                    "ORDER_NONE_UNSPECIFIED",
-                    "ORDER_UNORDERED",
-                    "ORDER_ORDERED"
-                  ],
-                  "default": "ORDER_NONE_UNSPECIFIED",
-                  "description": "- ORDER_NONE_UNSPECIFIED: zero-value for channel ordering\n - ORDER_UNORDERED: packets can be delivered in any order, which may differ from the order in\nwhich they were sent.\n - ORDER_ORDERED: packets are delivered exactly in the order which they were sent",
-                  "title": "Order defines if a channel is ORDERED or UNORDERED"
-                },
-                "connection_hops": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "description": "UpgradeFields are the fields in a channel end which may be changed\nduring a channel upgrade."
-            },
-            "timeout": {
-              "type": "object",
-              "properties": {
-                "height": {
-                  "title": "block height after which the packet or upgrade times out",
-                  "type": "object",
-                  "properties": {
-                    "revision_number": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the revision that the client is currently on"
-                    },
-                    "revision_height": {
-                      "type": "string",
-                      "format": "uint64",
-                      "title": "the height within the given revision"
-                    }
-                  },
-                  "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-                },
-                "timestamp": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-                }
-              },
-              "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-            },
-            "next_sequence_send": {
-              "type": "string",
-              "format": "uint64"
-            }
-          },
-          "description": "Upgrade is a verifiable type which contains the relevant information\nfor an attempted upgrade. It provides the proposed changes to the channel\nend, the timeout for this upgrade attempt and the next packet sequence\nwhich allows the counterparty to efficiently know the highest sequence it has received.\nThe next sequence send is used for pruning and upgrading from unordered to ordered channels."
-        },
-        "proof": {
-          "type": "string",
-          "format": "byte",
-          "title": "merkle proof of existence"
-        },
-        "proof_height": {
-          "title": "height at which the proof was retrieved",
-          "type": "object",
-          "properties": {
-            "revision_number": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the revision that the client is currently on"
-            },
-            "revision_height": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the height within the given revision"
-            }
-          },
-          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-        }
-      },
-      "title": "QueryUpgradeResponse is the response type for the QueryUpgradeResponse RPC method"
-    },
     "ibc.core.channel.v1.State": {
       "type": "string",
       "enum": [
@@ -26151,130 +24948,10 @@
         "STATE_INIT",
         "STATE_TRYOPEN",
         "STATE_OPEN",
-        "STATE_CLOSED",
-        "STATE_FLUSHING",
-        "STATE_FLUSHCOMPLETE"
+        "STATE_CLOSED"
       ],
       "default": "STATE_UNINITIALIZED_UNSPECIFIED",
-      "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN, FLUSHING, FLUSHCOMPLETE or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets.\n - STATE_FLUSHING: A channel has just accepted the upgrade handshake attempt and is flushing in-flight packets.\n - STATE_FLUSHCOMPLETE: A channel has just completed flushing any in-flight packets."
-    },
-    "ibc.core.channel.v1.Timeout": {
-      "type": "object",
-      "properties": {
-        "height": {
-          "title": "block height after which the packet or upgrade times out",
-          "type": "object",
-          "properties": {
-            "revision_number": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the revision that the client is currently on"
-            },
-            "revision_height": {
-              "type": "string",
-              "format": "uint64",
-              "title": "the height within the given revision"
-            }
-          },
-          "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "uint64",
-          "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-        }
-      },
-      "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-    },
-    "ibc.core.channel.v1.Upgrade": {
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "object",
-          "properties": {
-            "ordering": {
-              "type": "string",
-              "enum": [
-                "ORDER_NONE_UNSPECIFIED",
-                "ORDER_UNORDERED",
-                "ORDER_ORDERED"
-              ],
-              "default": "ORDER_NONE_UNSPECIFIED",
-              "description": "- ORDER_NONE_UNSPECIFIED: zero-value for channel ordering\n - ORDER_UNORDERED: packets can be delivered in any order, which may differ from the order in\nwhich they were sent.\n - ORDER_ORDERED: packets are delivered exactly in the order which they were sent",
-              "title": "Order defines if a channel is ORDERED or UNORDERED"
-            },
-            "connection_hops": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "description": "UpgradeFields are the fields in a channel end which may be changed\nduring a channel upgrade."
-        },
-        "timeout": {
-          "type": "object",
-          "properties": {
-            "height": {
-              "title": "block height after which the packet or upgrade times out",
-              "type": "object",
-              "properties": {
-                "revision_number": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "the revision that the client is currently on"
-                },
-                "revision_height": {
-                  "type": "string",
-                  "format": "uint64",
-                  "title": "the height within the given revision"
-                }
-              },
-              "description": "Normally the RevisionHeight is incremented at each height while keeping\nRevisionNumber the same. However some consensus algorithms may choose to\nreset the height in certain conditions e.g. hard forks, state-machine\nbreaking changes In these cases, the RevisionNumber is incremented so that\nheight continues to be monitonically increasing even as the RevisionHeight\ngets reset"
-            },
-            "timestamp": {
-              "type": "string",
-              "format": "uint64",
-              "title": "block timestamp (in nanoseconds) after which the packet or upgrade times out"
-            }
-          },
-          "description": "Timeout defines an execution deadline structure for 04-channel handlers.\nThis includes packet lifecycle handlers as well as the upgrade handshake handlers.\nA valid Timeout contains either one or both of a timestamp and block height (sequence)."
-        },
-        "next_sequence_send": {
-          "type": "string",
-          "format": "uint64"
-        }
-      },
-      "description": "Upgrade is a verifiable type which contains the relevant information\nfor an attempted upgrade. It provides the proposed changes to the channel\nend, the timeout for this upgrade attempt and the next packet sequence\nwhich allows the counterparty to efficiently know the highest sequence it has received.\nThe next sequence send is used for pruning and upgrading from unordered to ordered channels."
-    },
-    "ibc.core.channel.v1.UpgradeFields": {
-      "type": "object",
-      "properties": {
-        "ordering": {
-          "type": "string",
-          "enum": [
-            "ORDER_NONE_UNSPECIFIED",
-            "ORDER_UNORDERED",
-            "ORDER_ORDERED"
-          ],
-          "default": "ORDER_NONE_UNSPECIFIED",
-          "description": "- ORDER_NONE_UNSPECIFIED: zero-value for channel ordering\n - ORDER_UNORDERED: packets can be delivered in any order, which may differ from the order in\nwhich they were sent.\n - ORDER_ORDERED: packets are delivered exactly in the order which they were sent",
-          "title": "Order defines if a channel is ORDERED or UNORDERED"
-        },
-        "connection_hops": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "version": {
-          "type": "string"
-        }
-      },
-      "description": "UpgradeFields are the fields in a channel end which may be changed\nduring a channel upgrade."
+      "description": "State defines if a channel is in one of the following states:\nCLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.\n\n - STATE_UNINITIALIZED_UNSPECIFIED: Default State\n - STATE_INIT: A channel has just started the opening handshake.\n - STATE_TRYOPEN: A channel has acknowledged the handshake step on the counterparty chain.\n - STATE_OPEN: A channel has completed the handshake. Open channels are\nready to send and receive packets.\n - STATE_CLOSED: A channel has been closed and can no longer be used to send or receive\npackets."
     },
     "cosmos.auth.v1beta1.AddressBytesToStringResponse": {
       "type": "object",
@@ -26957,72 +25634,6 @@
       },
       "description": "QueryBalanceResponse is the response type for the Query/Balance RPC method."
     },
-    "cosmos.bank.v1beta1.QueryDenomMetadataByQueryStringResponse": {
-      "type": "object",
-      "properties": {
-        "metadata": {
-          "type": "object",
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "denom_units": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "denom": {
-                    "type": "string",
-                    "description": "denom represents the string name of the given denom unit (e.g uatom)."
-                  },
-                  "exponent": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "exponent represents power of 10 exponent that one must\nraise the base_denom to in order to equal the given DenomUnit's denom\n1 denom = 10^exponent base_denom\n(e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with\nexponent = 6, thus: 1 atom = 10^6 uatom)."
-                  },
-                  "aliases": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "title": "aliases is a list of string aliases for the given denom"
-                  }
-                },
-                "description": "DenomUnit represents a struct that describes a given\ndenomination unit of the basic token."
-              },
-              "title": "denom_units represents the list of DenomUnit's for a given coin"
-            },
-            "base": {
-              "type": "string",
-              "description": "base represents the base denom (should be the DenomUnit with exponent = 0)."
-            },
-            "display": {
-              "type": "string",
-              "description": "display indicates the suggested denom that should be\ndisplayed in clients."
-            },
-            "name": {
-              "type": "string",
-              "description": "Since: cosmos-sdk 0.43",
-              "title": "name defines the name of the token (eg: Cosmos Atom)"
-            },
-            "symbol": {
-              "type": "string",
-              "description": "symbol is the token symbol usually shown on exchanges (eg: ATOM). This can\nbe the same as the display.\n\nSince: cosmos-sdk 0.43"
-            },
-            "uri": {
-              "type": "string",
-              "description": "URI to a document (on or off-chain) that contains additional information. Optional.\n\nSince: cosmos-sdk 0.46"
-            },
-            "uri_hash": {
-              "type": "string",
-              "description": "URIHash is a sha256 hash of a document pointed by URI. It's used to verify that\nthe document didn't change. Optional.\n\nSince: cosmos-sdk 0.46"
-            }
-          },
-          "description": "Metadata represents a struct that describes\na basic token."
-        }
-      },
-      "description": "QueryDenomMetadataByQueryStringResponse is the response type for the Query/DenomMetadata RPC\nmethod. Identical with QueryDenomMetadataResponse but receives denom as query string in request."
-    },
     "cosmos.bank.v1beta1.QueryDenomMetadataResponse": {
       "type": "object",
       "properties": {
@@ -27226,7 +25837,6 @@
       "type": "object",
       "properties": {
         "params": {
-          "description": "params provides the parameters of the bank module.",
           "type": "object",
           "properties": {
             "send_enabled": {
@@ -27248,7 +25858,8 @@
             "default_send_enabled": {
               "type": "boolean"
             }
-          }
+          },
+          "description": "Params defines the parameters for the bank module."
         }
       },
       "description": "QueryParamsResponse defines the response type for querying x/bank parameters."
@@ -27478,7 +26089,7 @@
           "description": "pool defines community pool's coins."
         }
       },
-      "description": "QueryCommunityPoolResponse is the response type for the Query/CommunityPool\nRPC method.\n\nDeprecated\nSince: cosmos-sdk 0.50"
+      "description": "QueryCommunityPoolResponse is the response type for the Query/CommunityPool\nRPC method."
     },
     "cosmos.distribution.v1beta1.QueryDelegationRewardsResponse": {
       "type": "object",
@@ -28984,72 +27595,17 @@
           "type": "string",
           "description": "The ratio representing the proportion of the deposit value that must be paid at proposal submission."
         },
-        "proposal_cancel_ratio": {
-          "type": "string",
-          "description": "The cancel ratio which will not be returned back to the depositors when a proposal is cancelled.\n\nSince: cosmos-sdk 0.50"
-        },
-        "proposal_cancel_dest": {
-          "type": "string",
-          "description": "The address which will receive (proposal_cancel_ratio * deposit) proposal deposits.\nIf empty, the (proposal_cancel_ratio * deposit) proposal deposits will be burned.\n\nSince: cosmos-sdk 0.50"
-        },
-        "expedited_voting_period": {
-          "type": "string",
-          "description": "Duration of the voting period of an expedited proposal.\n\nSince: cosmos-sdk 0.50"
-        },
-        "expedited_threshold": {
-          "type": "string",
-          "description": "Minimum proportion of Yes votes for proposal to pass. Default value: 0.67.\n\nSince: cosmos-sdk 0.50"
-        },
-        "expedited_min_deposit": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "denom": {
-                "type": "string"
-              },
-              "amount": {
-                "type": "string"
-              }
-            },
-            "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto."
-          },
-          "description": "Minimum expedited deposit for a proposal to enter voting period."
-        },
         "burn_vote_quorum": {
           "type": "boolean",
-          "description": "Since: cosmos-sdk 0.47",
           "title": "burn deposits if a proposal does not meet quorum"
         },
         "burn_proposal_deposit_prevote": {
           "type": "boolean",
-          "description": "Since: cosmos-sdk 0.47",
           "title": "burn deposits if the proposal does not enter voting period"
         },
         "burn_vote_veto": {
           "type": "boolean",
-          "description": "Since: cosmos-sdk 0.47",
           "title": "burn deposits if quorum with vote type no_veto is met"
-        },
-        "min_deposit_ratio": {
-          "type": "string",
-          "description": "The ratio representing the proportion of the deposit value minimum that must be met when making a deposit.\nDefault value: 0.01. Meaning that for a chain with a min_deposit of 100stake, a deposit of 1stake would be\nrequired.\n\nSince: cosmos-sdk 0.50"
-        },
-        "proposal_cancel_max_period": {
-          "type": "string",
-          "description": "proposal_cancel_max_period defines how far in the voting period a proposer can cancel a proposal.\nIf the proposal is cancelled before the max cancel period, the deposit will be returned/burn to the\ndepositors, according to the proposal_cancel_ratio and proposal_cancel_dest parameters.\nAfter the max cancel period, the proposal cannot be cancelled anymore."
-        },
-        "optimistic_authorized_addresses": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Since: x/gov v1.0.0",
-          "title": "optimistic_authorized_addresses is an optional governance parameter that limits the authorized accounts than can\nsubmit optimistic proposals"
-        },
-        "optimistic_rejected_threshold": {
-          "type": "string",
-          "description": "optimistic rejected threshold defines at which percentage of NO votes, the optimistic proposal should fail and be\nconverted to a standard proposal. The threshold is expressed as a percentage of the total bonded tokens.\n\nSince: x/gov v1.0.0"
         }
       },
       "description": "Params defines the parameters for the x/gov module.\n\nSince: cosmos-sdk 0.47"
@@ -29113,10 +27669,6 @@
             "no_with_veto_count": {
               "type": "string",
               "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-            },
-            "spam_count": {
-              "type": "string",
-              "description": "spam_count is the number of spam votes on a proposal."
             }
           }
         },
@@ -29158,7 +27710,7 @@
         },
         "metadata": {
           "type": "string",
-          "title": "metadata is any arbitrary metadata attached to the proposal.\nthe recommended format of the metadata is to be found here:\nhttps://docs.cosmos.network/v0.47/modules/gov#proposal-3"
+          "description": "metadata is any arbitrary metadata attached to the proposal."
         },
         "title": {
           "type": "string",
@@ -29173,30 +27725,7 @@
         "proposer": {
           "type": "string",
           "description": "Since: cosmos-sdk 0.47",
-          "title": "proposer is the address of the proposal sumbitter"
-        },
-        "expedited": {
-          "type": "boolean",
-          "description": "Since: cosmos-sdk 0.50\nDeprecated: Use ProposalType instead.",
-          "title": "expedited defines if the proposal is expedited"
-        },
-        "failed_reason": {
-          "type": "string",
-          "description": "Since: cosmos-sdk 0.50",
-          "title": "failed_reason defines the reason why the proposal failed"
-        },
-        "proposal_type": {
-          "description": "Since: cosmos-sdk 0.51",
-          "title": "proposal_type defines the type of the proposal",
-          "type": "string",
-          "enum": [
-            "PROPOSAL_TYPE_UNSPECIFIED",
-            "PROPOSAL_TYPE_STANDARD",
-            "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-            "PROPOSAL_TYPE_OPTIMISTIC",
-            "PROPOSAL_TYPE_EXPEDITED"
-          ],
-          "default": "PROPOSAL_TYPE_UNSPECIFIED"
+          "title": "Proposer is the address of the proposal sumbitter"
         }
       },
       "description": "Proposal defines the core field members of a governance proposal."
@@ -29213,27 +27742,6 @@
       ],
       "default": "PROPOSAL_STATUS_UNSPECIFIED",
       "description": "ProposalStatus enumerates the valid statuses of a proposal.\n\n - PROPOSAL_STATUS_UNSPECIFIED: PROPOSAL_STATUS_UNSPECIFIED defines the default proposal status.\n - PROPOSAL_STATUS_DEPOSIT_PERIOD: PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit\nperiod.\n - PROPOSAL_STATUS_VOTING_PERIOD: PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting\nperiod.\n - PROPOSAL_STATUS_PASSED: PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has\npassed.\n - PROPOSAL_STATUS_REJECTED: PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has\nbeen rejected.\n - PROPOSAL_STATUS_FAILED: PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has\nfailed."
-    },
-    "cosmos.gov.v1.ProposalType": {
-      "type": "string",
-      "enum": [
-        "PROPOSAL_TYPE_UNSPECIFIED",
-        "PROPOSAL_TYPE_STANDARD",
-        "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-        "PROPOSAL_TYPE_OPTIMISTIC",
-        "PROPOSAL_TYPE_EXPEDITED"
-      ],
-      "default": "PROPOSAL_TYPE_UNSPECIFIED",
-      "description": "ProposalType enumerates the valid proposal types.\nAll proposal types are v1.Proposal which have different voting periods or tallying logic.\n\n - PROPOSAL_TYPE_UNSPECIFIED: PROPOSAL_TYPE_UNSPECIFIED defines no proposal type, which fallback to PROPOSAL_TYPE_STANDARD.\n - PROPOSAL_TYPE_STANDARD: PROPOSAL_TYPE_STANDARD defines the type for a standard proposal.\n - PROPOSAL_TYPE_MULTIPLE_CHOICE: PROPOSAL_TYPE_MULTIPLE_CHOICE defines the type for a multiple choice proposal.\n - PROPOSAL_TYPE_OPTIMISTIC: PROPOSAL_TYPE_OPTIMISTIC defines the type for an optimistic proposal.\n - PROPOSAL_TYPE_EXPEDITED: PROPOSAL_TYPE_EXPEDITED defines the type for an expedited proposal."
-    },
-    "cosmos.gov.v1.QueryConstitutionResponse": {
-      "type": "object",
-      "properties": {
-        "constitution": {
-          "type": "string"
-        }
-      },
-      "title": "QueryConstitutionResponse is the response type for the Query/Constitution RPC method"
     },
     "cosmos.gov.v1.QueryDepositResponse": {
       "type": "object",
@@ -29387,7 +27895,7 @@
           }
         },
         "params": {
-          "description": "params defines all the parameters of x/gov module.\n\nSince: cosmos-sdk 0.47",
+          "description": "params defines all the paramaters of x/gov module.\n\nSince: cosmos-sdk 0.47",
           "type": "object",
           "properties": {
             "min_deposit": {
@@ -29430,72 +27938,17 @@
               "type": "string",
               "description": "The ratio representing the proportion of the deposit value that must be paid at proposal submission."
             },
-            "proposal_cancel_ratio": {
-              "type": "string",
-              "description": "The cancel ratio which will not be returned back to the depositors when a proposal is cancelled.\n\nSince: cosmos-sdk 0.50"
-            },
-            "proposal_cancel_dest": {
-              "type": "string",
-              "description": "The address which will receive (proposal_cancel_ratio * deposit) proposal deposits.\nIf empty, the (proposal_cancel_ratio * deposit) proposal deposits will be burned.\n\nSince: cosmos-sdk 0.50"
-            },
-            "expedited_voting_period": {
-              "type": "string",
-              "description": "Duration of the voting period of an expedited proposal.\n\nSince: cosmos-sdk 0.50"
-            },
-            "expedited_threshold": {
-              "type": "string",
-              "description": "Minimum proportion of Yes votes for proposal to pass. Default value: 0.67.\n\nSince: cosmos-sdk 0.50"
-            },
-            "expedited_min_deposit": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "denom": {
-                    "type": "string"
-                  },
-                  "amount": {
-                    "type": "string"
-                  }
-                },
-                "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto."
-              },
-              "description": "Minimum expedited deposit for a proposal to enter voting period."
-            },
             "burn_vote_quorum": {
               "type": "boolean",
-              "description": "Since: cosmos-sdk 0.47",
               "title": "burn deposits if a proposal does not meet quorum"
             },
             "burn_proposal_deposit_prevote": {
               "type": "boolean",
-              "description": "Since: cosmos-sdk 0.47",
               "title": "burn deposits if the proposal does not enter voting period"
             },
             "burn_vote_veto": {
               "type": "boolean",
-              "description": "Since: cosmos-sdk 0.47",
               "title": "burn deposits if quorum with vote type no_veto is met"
-            },
-            "min_deposit_ratio": {
-              "type": "string",
-              "description": "The ratio representing the proportion of the deposit value minimum that must be met when making a deposit.\nDefault value: 0.01. Meaning that for a chain with a min_deposit of 100stake, a deposit of 1stake would be\nrequired.\n\nSince: cosmos-sdk 0.50"
-            },
-            "proposal_cancel_max_period": {
-              "type": "string",
-              "description": "proposal_cancel_max_period defines how far in the voting period a proposer can cancel a proposal.\nIf the proposal is cancelled before the max cancel period, the deposit will be returned/burn to the\ndepositors, according to the proposal_cancel_ratio and proposal_cancel_dest parameters.\nAfter the max cancel period, the proposal cannot be cancelled anymore."
-            },
-            "optimistic_authorized_addresses": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Since: x/gov v1.0.0",
-              "title": "optimistic_authorized_addresses is an optional governance parameter that limits the authorized accounts than can\nsubmit optimistic proposals"
-            },
-            "optimistic_rejected_threshold": {
-              "type": "string",
-              "description": "optimistic rejected threshold defines at which percentage of NO votes, the optimistic proposal should fail and be\nconverted to a standard proposal. The threshold is expressed as a percentage of the total bonded tokens.\n\nSince: x/gov v1.0.0"
             }
           }
         }
@@ -29564,10 +28017,6 @@
                 "no_with_veto_count": {
                   "type": "string",
                   "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-                },
-                "spam_count": {
-                  "type": "string",
-                  "description": "spam_count is the number of spam votes on a proposal."
                 }
               }
             },
@@ -29609,7 +28058,7 @@
             },
             "metadata": {
               "type": "string",
-              "title": "metadata is any arbitrary metadata attached to the proposal.\nthe recommended format of the metadata is to be found here:\nhttps://docs.cosmos.network/v0.47/modules/gov#proposal-3"
+              "description": "metadata is any arbitrary metadata attached to the proposal."
             },
             "title": {
               "type": "string",
@@ -29624,30 +28073,7 @@
             "proposer": {
               "type": "string",
               "description": "Since: cosmos-sdk 0.47",
-              "title": "proposer is the address of the proposal sumbitter"
-            },
-            "expedited": {
-              "type": "boolean",
-              "description": "Since: cosmos-sdk 0.50\nDeprecated: Use ProposalType instead.",
-              "title": "expedited defines if the proposal is expedited"
-            },
-            "failed_reason": {
-              "type": "string",
-              "description": "Since: cosmos-sdk 0.50",
-              "title": "failed_reason defines the reason why the proposal failed"
-            },
-            "proposal_type": {
-              "description": "Since: cosmos-sdk 0.51",
-              "title": "proposal_type defines the type of the proposal",
-              "type": "string",
-              "enum": [
-                "PROPOSAL_TYPE_UNSPECIFIED",
-                "PROPOSAL_TYPE_STANDARD",
-                "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-                "PROPOSAL_TYPE_OPTIMISTIC",
-                "PROPOSAL_TYPE_EXPEDITED"
-              ],
-              "default": "PROPOSAL_TYPE_UNSPECIFIED"
+              "title": "Proposer is the address of the proposal sumbitter"
             }
           },
           "description": "Proposal defines the core field members of a governance proposal."
@@ -29719,10 +28145,6 @@
                   "no_with_veto_count": {
                     "type": "string",
                     "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-                  },
-                  "spam_count": {
-                    "type": "string",
-                    "description": "spam_count is the number of spam votes on a proposal."
                   }
                 }
               },
@@ -29764,7 +28186,7 @@
               },
               "metadata": {
                 "type": "string",
-                "title": "metadata is any arbitrary metadata attached to the proposal.\nthe recommended format of the metadata is to be found here:\nhttps://docs.cosmos.network/v0.47/modules/gov#proposal-3"
+                "description": "metadata is any arbitrary metadata attached to the proposal."
               },
               "title": {
                 "type": "string",
@@ -29779,30 +28201,7 @@
               "proposer": {
                 "type": "string",
                 "description": "Since: cosmos-sdk 0.47",
-                "title": "proposer is the address of the proposal sumbitter"
-              },
-              "expedited": {
-                "type": "boolean",
-                "description": "Since: cosmos-sdk 0.50\nDeprecated: Use ProposalType instead.",
-                "title": "expedited defines if the proposal is expedited"
-              },
-              "failed_reason": {
-                "type": "string",
-                "description": "Since: cosmos-sdk 0.50",
-                "title": "failed_reason defines the reason why the proposal failed"
-              },
-              "proposal_type": {
-                "description": "Since: cosmos-sdk 0.51",
-                "title": "proposal_type defines the type of the proposal",
-                "type": "string",
-                "enum": [
-                  "PROPOSAL_TYPE_UNSPECIFIED",
-                  "PROPOSAL_TYPE_STANDARD",
-                  "PROPOSAL_TYPE_MULTIPLE_CHOICE",
-                  "PROPOSAL_TYPE_OPTIMISTIC",
-                  "PROPOSAL_TYPE_EXPEDITED"
-                ],
-                "default": "PROPOSAL_TYPE_UNSPECIFIED"
+                "title": "Proposer is the address of the proposal sumbitter"
               }
             },
             "description": "Proposal defines the core field members of a governance proposal."
@@ -29850,10 +28249,6 @@
             "no_with_veto_count": {
               "type": "string",
               "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-            },
-            "spam_count": {
-              "type": "string",
-              "description": "spam_count is the number of spam votes on a proposal."
             }
           }
         }
@@ -29885,15 +28280,10 @@
                     "type": "string",
                     "enum": [
                       "VOTE_OPTION_UNSPECIFIED",
-                      "VOTE_OPTION_ONE",
                       "VOTE_OPTION_YES",
-                      "VOTE_OPTION_TWO",
                       "VOTE_OPTION_ABSTAIN",
-                      "VOTE_OPTION_THREE",
                       "VOTE_OPTION_NO",
-                      "VOTE_OPTION_FOUR",
-                      "VOTE_OPTION_NO_WITH_VETO",
-                      "VOTE_OPTION_SPAM"
+                      "VOTE_OPTION_NO_WITH_VETO"
                     ],
                     "default": "VOTE_OPTION_UNSPECIFIED"
                   },
@@ -29908,7 +28298,7 @@
             },
             "metadata": {
               "type": "string",
-              "title": "metadata is any arbitrary metadata attached to the vote.\nthe recommended format of the metadata is to be found here: https://docs.cosmos.network/v0.47/modules/gov#vote-5"
+              "description": "metadata is any  arbitrary metadata to attached to the vote."
             }
           },
           "description": "Vote defines a vote on a governance proposal.\nA Vote consists of a proposal ID, the voter, and the vote option."
@@ -29943,15 +28333,10 @@
                       "type": "string",
                       "enum": [
                         "VOTE_OPTION_UNSPECIFIED",
-                        "VOTE_OPTION_ONE",
                         "VOTE_OPTION_YES",
-                        "VOTE_OPTION_TWO",
                         "VOTE_OPTION_ABSTAIN",
-                        "VOTE_OPTION_THREE",
                         "VOTE_OPTION_NO",
-                        "VOTE_OPTION_FOUR",
-                        "VOTE_OPTION_NO_WITH_VETO",
-                        "VOTE_OPTION_SPAM"
+                        "VOTE_OPTION_NO_WITH_VETO"
                       ],
                       "default": "VOTE_OPTION_UNSPECIFIED"
                     },
@@ -29966,7 +28351,7 @@
               },
               "metadata": {
                 "type": "string",
-                "title": "metadata is any arbitrary metadata attached to the vote.\nthe recommended format of the metadata is to be found here: https://docs.cosmos.network/v0.47/modules/gov#vote-5"
+                "description": "metadata is any  arbitrary metadata to attached to the vote."
               }
             },
             "description": "Vote defines a vote on a governance proposal.\nA Vote consists of a proposal ID, the voter, and the vote option."
@@ -30028,10 +28413,6 @@
         "no_with_veto_count": {
           "type": "string",
           "description": "no_with_veto_count is the number of no with veto votes on a proposal."
-        },
-        "spam_count": {
-          "type": "string",
-          "description": "spam_count is the number of spam votes on a proposal."
         }
       },
       "description": "TallyResult defines a standard tally for a governance proposal."
@@ -30058,15 +28439,10 @@
                 "type": "string",
                 "enum": [
                   "VOTE_OPTION_UNSPECIFIED",
-                  "VOTE_OPTION_ONE",
                   "VOTE_OPTION_YES",
-                  "VOTE_OPTION_TWO",
                   "VOTE_OPTION_ABSTAIN",
-                  "VOTE_OPTION_THREE",
                   "VOTE_OPTION_NO",
-                  "VOTE_OPTION_FOUR",
-                  "VOTE_OPTION_NO_WITH_VETO",
-                  "VOTE_OPTION_SPAM"
+                  "VOTE_OPTION_NO_WITH_VETO"
                 ],
                 "default": "VOTE_OPTION_UNSPECIFIED"
               },
@@ -30081,7 +28457,7 @@
         },
         "metadata": {
           "type": "string",
-          "title": "metadata is any arbitrary metadata attached to the vote.\nthe recommended format of the metadata is to be found here: https://docs.cosmos.network/v0.47/modules/gov#vote-5"
+          "description": "metadata is any  arbitrary metadata to attached to the vote."
         }
       },
       "description": "Vote defines a vote on a governance proposal.\nA Vote consists of a proposal ID, the voter, and the vote option."
@@ -30090,18 +28466,13 @@
       "type": "string",
       "enum": [
         "VOTE_OPTION_UNSPECIFIED",
-        "VOTE_OPTION_ONE",
         "VOTE_OPTION_YES",
-        "VOTE_OPTION_TWO",
         "VOTE_OPTION_ABSTAIN",
-        "VOTE_OPTION_THREE",
         "VOTE_OPTION_NO",
-        "VOTE_OPTION_FOUR",
-        "VOTE_OPTION_NO_WITH_VETO",
-        "VOTE_OPTION_SPAM"
+        "VOTE_OPTION_NO_WITH_VETO"
       ],
       "default": "VOTE_OPTION_UNSPECIFIED",
-      "description": "VoteOption enumerates the valid vote options for a given governance proposal.\n\n - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.\n - VOTE_OPTION_ONE: VOTE_OPTION_ONE defines the first proposal vote option.\n - VOTE_OPTION_YES: VOTE_OPTION_YES defines the yes proposal vote option.\n - VOTE_OPTION_TWO: VOTE_OPTION_TWO defines the second proposal vote option.\n - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines the abstain proposal vote option.\n - VOTE_OPTION_THREE: VOTE_OPTION_THREE defines the third proposal vote option.\n - VOTE_OPTION_NO: VOTE_OPTION_NO defines the no proposal vote option.\n - VOTE_OPTION_FOUR: VOTE_OPTION_FOUR defines the fourth proposal vote option.\n - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines the no with veto proposal vote option.\n - VOTE_OPTION_SPAM: VOTE_OPTION_SPAM defines the spam proposal vote option."
+      "description": "VoteOption enumerates the valid vote options for a given governance proposal.\n\n - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.\n - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.\n - VOTE_OPTION_ABSTAIN: VOTE_OPTION_ABSTAIN defines an abstain vote option.\n - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.\n - VOTE_OPTION_NO_WITH_VETO: VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option."
     },
     "cosmos.gov.v1.VotingParams": {
       "type": "object",
@@ -30121,15 +28492,10 @@
           "type": "string",
           "enum": [
             "VOTE_OPTION_UNSPECIFIED",
-            "VOTE_OPTION_ONE",
             "VOTE_OPTION_YES",
-            "VOTE_OPTION_TWO",
             "VOTE_OPTION_ABSTAIN",
-            "VOTE_OPTION_THREE",
             "VOTE_OPTION_NO",
-            "VOTE_OPTION_FOUR",
-            "VOTE_OPTION_NO_WITH_VETO",
-            "VOTE_OPTION_SPAM"
+            "VOTE_OPTION_NO_WITH_VETO"
           ],
           "default": "VOTE_OPTION_UNSPECIFIED"
         },
@@ -30208,12 +28574,12 @@
             "start_height": {
               "type": "string",
               "format": "int64",
-              "title": "Height at which validator was first a candidate OR was un-jailed"
+              "title": "Height at which validator was first a candidate OR was unjailed"
             },
             "index_offset": {
               "type": "string",
               "format": "int64",
-              "description": "Index which is incremented every time a validator is bonded in a block and\n_may_ have signed a pre-commit or not. This in conjunction with the\nsigned_blocks_window param determines the index in the missed block bitmap."
+              "description": "Index which is incremented each time the validator was a bonded\nin a block and may have signed a precommit or not. This in conjunction with the\n`SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`."
             },
             "jailed_until": {
               "type": "string",
@@ -30222,12 +28588,12 @@
             },
             "tombstoned": {
               "type": "boolean",
-              "description": "Whether or not a validator has been tombstoned (killed out of validator\nset). It is set once the validator commits an equivocation or for any other\nconfigured misbehavior."
+              "description": "Whether or not a validator has been tombstoned (killed out of validator set). It is set\nonce the validator commits an equivocation or for any other configured misbehiavor."
             },
             "missed_blocks_counter": {
               "type": "string",
               "format": "int64",
-              "description": "A counter of missed (unsigned) blocks. It is used to avoid unnecessary\nreads in the missed block bitmap."
+              "description": "A counter kept to avoid unnecessary array reads.\nNote that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`."
             }
           },
           "description": "ValidatorSigningInfo defines a validator's signing info for monitoring their\nliveness activity.",
@@ -30250,12 +28616,12 @@
               "start_height": {
                 "type": "string",
                 "format": "int64",
-                "title": "Height at which validator was first a candidate OR was un-jailed"
+                "title": "Height at which validator was first a candidate OR was unjailed"
               },
               "index_offset": {
                 "type": "string",
                 "format": "int64",
-                "description": "Index which is incremented every time a validator is bonded in a block and\n_may_ have signed a pre-commit or not. This in conjunction with the\nsigned_blocks_window param determines the index in the missed block bitmap."
+                "description": "Index which is incremented each time the validator was a bonded\nin a block and may have signed a precommit or not. This in conjunction with the\n`SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`."
               },
               "jailed_until": {
                 "type": "string",
@@ -30264,12 +28630,12 @@
               },
               "tombstoned": {
                 "type": "boolean",
-                "description": "Whether or not a validator has been tombstoned (killed out of validator\nset). It is set once the validator commits an equivocation or for any other\nconfigured misbehavior."
+                "description": "Whether or not a validator has been tombstoned (killed out of validator set). It is set\nonce the validator commits an equivocation or for any other configured misbehiavor."
               },
               "missed_blocks_counter": {
                 "type": "string",
                 "format": "int64",
-                "description": "A counter of missed (unsigned) blocks. It is used to avoid unnecessary\nreads in the missed block bitmap."
+                "description": "A counter kept to avoid unnecessary array reads.\nNote that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`."
               }
             },
             "description": "ValidatorSigningInfo defines a validator's signing info for monitoring their\nliveness activity."
@@ -30304,12 +28670,12 @@
         "start_height": {
           "type": "string",
           "format": "int64",
-          "title": "Height at which validator was first a candidate OR was un-jailed"
+          "title": "Height at which validator was first a candidate OR was unjailed"
         },
         "index_offset": {
           "type": "string",
           "format": "int64",
-          "description": "Index which is incremented every time a validator is bonded in a block and\n_may_ have signed a pre-commit or not. This in conjunction with the\nsigned_blocks_window param determines the index in the missed block bitmap."
+          "description": "Index which is incremented each time the validator was a bonded\nin a block and may have signed a precommit or not. This in conjunction with the\n`SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`."
         },
         "jailed_until": {
           "type": "string",
@@ -30318,12 +28684,12 @@
         },
         "tombstoned": {
           "type": "boolean",
-          "description": "Whether or not a validator has been tombstoned (killed out of validator\nset). It is set once the validator commits an equivocation or for any other\nconfigured misbehavior."
+          "description": "Whether or not a validator has been tombstoned (killed out of validator set). It is set\nonce the validator commits an equivocation or for any other configured misbehiavor."
         },
         "missed_blocks_counter": {
           "type": "string",
           "format": "int64",
-          "description": "A counter of missed (unsigned) blocks. It is used to avoid unnecessary\nreads in the missed block bitmap."
+          "description": "A counter kept to avoid unnecessary array reads.\nNote that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`."
         }
       },
       "description": "ValidatorSigningInfo defines a validator's signing info for monitoring their\nliveness activity."
@@ -30391,11 +28757,11 @@
       "properties": {
         "delegator_address": {
           "type": "string",
-          "description": "delegator_address is the encoded address of the delegator."
+          "description": "delegator_address is the bech32-encoded address of the delegator."
         },
         "validator_address": {
           "type": "string",
-          "description": "validator_address is the encoded address of the validator."
+          "description": "validator_address is the bech32-encoded address of the validator."
         },
         "shares": {
           "type": "string",
@@ -30412,11 +28778,11 @@
           "properties": {
             "delegator_address": {
               "type": "string",
-              "description": "delegator_address is the encoded address of the delegator."
+              "description": "delegator_address is the bech32-encoded address of the delegator."
             },
             "validator_address": {
               "type": "string",
-              "description": "validator_address is the encoded address of the validator."
+              "description": "validator_address is the bech32-encoded address of the validator."
             },
             "shares": {
               "type": "string",
@@ -30691,7 +29057,7 @@
                   "type": "string",
                   "format": "uint64"
                 },
-                "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
               }
             },
             "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -30699,24 +29065,6 @@
         }
       },
       "description": "HistoricalInfo contains header and validator information for a given block.\nIt is stored as part of staking module's state, which persists the `n` most\nrecent HistoricalInfo\n(`n` is set by the staking module's `historical_entries` parameter)."
-    },
-    "cosmos.staking.v1beta1.HistoricalRecord": {
-      "type": "object",
-      "properties": {
-        "apphash": {
-          "type": "string",
-          "format": "byte"
-        },
-        "time": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "validators_hash": {
-          "type": "string",
-          "format": "byte"
-        }
-      },
-      "description": "Historical contains a set of minimum values needed for evaluating historical validator sets and blocks.\nIt is stored as part of staking module's state, which persists the `n` most\nrecent HistoricalInfo\n(`n` is set by the staking module's `historical_entries` parameter)."
     },
     "cosmos.staking.v1beta1.Params": {
       "type": "object",
@@ -30747,19 +29095,6 @@
         "min_commission_rate": {
           "type": "string",
           "title": "min_commission_rate is the chain-wide minimum commission rate that a validator can charge their delegators"
-        },
-        "key_rotation_fee": {
-          "type": "object",
-          "properties": {
-            "denom": {
-              "type": "string"
-            },
-            "amount": {
-              "type": "string"
-            }
-          },
-          "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto.",
-          "title": "key_rotation_fee is fee to be spent when rotating validator's key\n(either consensus pubkey or operator key)"
         }
       },
       "description": "Params defines the parameters for the x/staking module."
@@ -30787,11 +29122,11 @@
               "properties": {
                 "delegator_address": {
                   "type": "string",
-                  "description": "delegator_address is the encoded address of the delegator."
+                  "description": "delegator_address is the bech32-encoded address of the delegator."
                 },
                 "validator_address": {
                   "type": "string",
-                  "description": "validator_address is the encoded address of the validator."
+                  "description": "validator_address is the bech32-encoded address of the validator."
                 },
                 "shares": {
                   "type": "string",
@@ -30831,11 +29166,11 @@
                 "properties": {
                   "delegator_address": {
                     "type": "string",
-                    "description": "delegator_address is the encoded address of the delegator."
+                    "description": "delegator_address is the bech32-encoded address of the delegator."
                   },
                   "validator_address": {
                     "type": "string",
-                    "description": "validator_address is the encoded address of the validator."
+                    "description": "validator_address is the bech32-encoded address of the validator."
                   },
                   "shares": {
                     "type": "string",
@@ -30890,11 +29225,11 @@
             "properties": {
               "delegator_address": {
                 "type": "string",
-                "description": "delegator_address is the encoded address of the delegator."
+                "description": "delegator_address is the bech32-encoded address of the delegator."
               },
               "validator_address": {
                 "type": "string",
-                "description": "validator_address is the encoded address of the validator."
+                "description": "validator_address is the bech32-encoded address of the validator."
               },
               "entries": {
                 "type": "array",
@@ -31085,7 +29420,7 @@
                 "type": "string",
                 "format": "uint64"
               },
-              "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+              "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
             }
           },
           "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -31223,7 +29558,7 @@
                   "type": "string",
                   "format": "uint64"
                 },
-                "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
               }
             },
             "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -31478,31 +29813,13 @@
                       "type": "string",
                       "format": "uint64"
                     },
-                    "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                    "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
                   }
                 },
                 "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
               }
             }
           }
-        },
-        "historical_record": {
-          "type": "object",
-          "properties": {
-            "apphash": {
-              "type": "string",
-              "format": "byte"
-            },
-            "time": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "validators_hash": {
-              "type": "string",
-              "format": "byte"
-            }
-          },
-          "description": "Historical contains a set of minimum values needed for evaluating historical validator sets and blocks.\nIt is stored as part of staking module's state, which persists the `n` most\nrecent HistoricalInfo\n(`n` is set by the staking module's `historical_entries` parameter)."
         }
       },
       "description": "QueryHistoricalInfoResponse is response type for the Query/HistoricalInfo RPC\nmethod."
@@ -31540,19 +29857,6 @@
             "min_commission_rate": {
               "type": "string",
               "title": "min_commission_rate is the chain-wide minimum commission rate that a validator can charge their delegators"
-            },
-            "key_rotation_fee": {
-              "type": "object",
-              "properties": {
-                "denom": {
-                  "type": "string"
-                },
-                "amount": {
-                  "type": "string"
-                }
-              },
-              "description": "Coin defines a token with a denomination and an amount.\n\nNOTE: The amount field is an Int which implements the custom method\nsignatures required by gogoproto.",
-              "title": "key_rotation_fee is fee to be spent when rotating validator's key\n(either consensus pubkey or operator key)"
             }
           }
         }
@@ -31718,11 +30022,11 @@
           "properties": {
             "delegator_address": {
               "type": "string",
-              "description": "delegator_address is the encoded address of the delegator."
+              "description": "delegator_address is the bech32-encoded address of the delegator."
             },
             "validator_address": {
               "type": "string",
-              "description": "validator_address is the encoded address of the validator."
+              "description": "validator_address is the bech32-encoded address of the validator."
             },
             "entries": {
               "type": "array",
@@ -31781,11 +30085,11 @@
                 "properties": {
                   "delegator_address": {
                     "type": "string",
-                    "description": "delegator_address is the encoded address of the delegator."
+                    "description": "delegator_address is the bech32-encoded address of the delegator."
                   },
                   "validator_address": {
                     "type": "string",
-                    "description": "validator_address is the encoded address of the validator."
+                    "description": "validator_address is the bech32-encoded address of the validator."
                   },
                   "shares": {
                     "type": "string",
@@ -31957,7 +30261,7 @@
                 "type": "string",
                 "format": "uint64"
               },
-              "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+              "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
             }
           },
           "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -31975,11 +30279,11 @@
             "properties": {
               "delegator_address": {
                 "type": "string",
-                "description": "delegator_address is the encoded address of the delegator."
+                "description": "delegator_address is the bech32-encoded address of the delegator."
               },
               "validator_address": {
                 "type": "string",
-                "description": "validator_address is the encoded address of the validator."
+                "description": "validator_address is the bech32-encoded address of the validator."
               },
               "entries": {
                 "type": "array",
@@ -32172,7 +30476,7 @@
                   "type": "string",
                   "format": "uint64"
                 },
-                "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+                "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
               }
             },
             "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -32444,11 +30748,11 @@
       "properties": {
         "delegator_address": {
           "type": "string",
-          "description": "delegator_address is the encoded address of the delegator."
+          "description": "delegator_address is the bech32-encoded address of the delegator."
         },
         "validator_address": {
           "type": "string",
-          "description": "validator_address is the encoded address of the validator."
+          "description": "validator_address is the bech32-encoded address of the validator."
         },
         "entries": {
           "type": "array",
@@ -32650,7 +30954,7 @@
             "type": "string",
             "format": "uint64"
           },
-          "title": "list of unbonding ids, each uniquely identifying an unbonding of this validator"
+          "title": "list of unbonding ids, each uniquely identifing an unbonding of this validator"
         }
       },
       "description": "Validator defines a validator, together with the total amount of the\nValidator's bond shares and their exchange rate to coins. Slashing results in\na decrease in the exchange rate, allowing correct calculation of future\nundelegations without iterating over delegators. When coins are delegated to\nthis validator, the validator is credited with a delegation whose number of\nbond shares is based on the amount of coins delegated divided by the current\nexchange rate. Voting power can be calculated as total bonded shares\nmultiplied by exchange rate."
@@ -32910,7 +31214,7 @@
                 }
               }
             },
-            "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+            "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
           },
           "description": "Events contains a slice of Event objects that were emitted during message\nor handler execution."
         },
@@ -33094,7 +31398,7 @@
                 }
               }
             },
-            "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+            "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
           },
           "description": "Events defines all the events emitted by processing a transaction. Note,\nthese events include those emitted by processing all the messages and those\nemitted from the ante. Whereas Logs contains the events, with\nadditional metadata, emitted only by processing the messages.\n\nSince: cosmos-sdk 0.42.11, 0.44.5, 0.45"
         }
@@ -33126,7 +31430,7 @@
         "SIGN_MODE_EIP_191"
       ],
       "default": "SIGN_MODE_UNSPECIFIED",
-      "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT.\n\nSince: cosmos-sdk 0.50\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2\nDeprecated: post 0.47.x Sign mode refers to a method of encoding string data for\nsigning, but in the SDK, it also refers to how to encode a transaction into a string.\nThis opens the possibility for additional EIP191 sign modes, like SIGN_MODE_EIP_191_TEXTUAL,\nSIGN_MODE_EIP_191_LEGACY_JSON, and more.\nEach new EIP191 sign mode should be accompanied by an associated ADR."
+      "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT. It is currently not supported.\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`. It also allows\nfor adding Tips in transactions.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2"
     },
     "cosmos.tx.v1beta1.AuthInfo": {
       "type": "object",
@@ -33211,7 +31515,7 @@
         "BROADCAST_MODE_ASYNC"
       ],
       "default": "BROADCAST_MODE_UNSPECIFIED",
-      "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC\nmethod.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: Deprecated: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits\nfor a CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client\nreturns immediately."
+      "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for\na CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns\nimmediately."
     },
     "cosmos.tx.v1beta1.BroadcastTxRequest": {
       "type": "object",
@@ -33230,7 +31534,7 @@
             "BROADCAST_MODE_ASYNC"
           ],
           "default": "BROADCAST_MODE_UNSPECIFIED",
-          "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC\nmethod.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: Deprecated: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits\nfor a CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client\nreturns immediately."
+          "description": "BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.\n\n - BROADCAST_MODE_UNSPECIFIED: zero-value for mode ordering\n - BROADCAST_MODE_BLOCK: DEPRECATED: use BROADCAST_MODE_SYNC instead,\nBROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.\n - BROADCAST_MODE_SYNC: BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for\na CheckTx execution response only.\n - BROADCAST_MODE_ASYNC: BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns\nimmediately."
         }
       },
       "description": "BroadcastTxRequest is the request type for the Service.BroadcastTxRequest\nRPC method."
@@ -33372,7 +31676,7 @@
                     }
                   }
                 },
-                "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
               },
               "description": "Events defines all the events emitted by processing a transaction. Note,\nthese events include those emitted by processing all the messages and those\nemitted from the ante. Whereas Logs contains the events, with\nadditional metadata, emitted only by processing the messages.\n\nSince: cosmos-sdk 0.42.11, 0.44.5, 0.45"
             }
@@ -33634,21 +31938,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "vote_b": {
                             "type": "object",
@@ -33710,21 +32003,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "total_voting_power": {
                             "type": "string",
@@ -33894,7 +32176,7 @@
                                                 "BLOCK_ID_FLAG_NIL"
                                               ],
                                               "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                              "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                              "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                             },
                                             "validator_address": {
                                               "type": "string",
@@ -34096,7 +32378,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",
@@ -34136,7 +32418,7 @@
           }
         }
       },
-      "description": "GetBlockWithTxsResponse is the response type for the Service.GetBlockWithTxs\nmethod.\n\nSince: cosmos-sdk 0.45.2"
+      "description": "GetBlockWithTxsResponse is the response type for the Service.GetBlockWithTxs method.\n\nSince: cosmos-sdk 0.45.2"
     },
     "cosmos.tx.v1beta1.GetTxResponse": {
       "type": "object",
@@ -34279,7 +32561,7 @@
                     }
                   }
                 },
-                "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
               },
               "description": "Events defines all the events emitted by processing a transaction. Note,\nthese events include those emitted by processing all the messages and those\nemitted from the ante. Whereas Logs contains the events, with\nadditional metadata, emitted only by processing the messages.\n\nSince: cosmos-sdk 0.42.11, 0.44.5, 0.45"
             }
@@ -34435,7 +32717,7 @@
                       }
                     }
                   },
-                  "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                  "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
                 },
                 "description": "Events defines all the events emitted by processing a transaction. Note,\nthese events include those emitted by processing all the messages and those\nemitted from the ante. Whereas Logs contains the events, with\nadditional metadata, emitted only by processing the messages.\n\nSince: cosmos-sdk 0.42.11, 0.44.5, 0.45"
               }
@@ -34445,7 +32727,7 @@
           "description": "tx_responses is the list of queried TxResponses."
         },
         "pagination": {
-          "description": "pagination defines a pagination for the response.\nDeprecated: post v0.46.x use total instead.",
+          "description": "pagination defines a pagination for the response.\nDeprecated post v0.46.x: use total instead.",
           "type": "object",
           "properties": {
             "next_key": {
@@ -34487,7 +32769,7 @@
                 "SIGN_MODE_EIP_191"
               ],
               "default": "SIGN_MODE_UNSPECIFIED",
-              "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT.\n\nSince: cosmos-sdk 0.50\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2\nDeprecated: post 0.47.x Sign mode refers to a method of encoding string data for\nsigning, but in the SDK, it also refers to how to encode a transaction into a string.\nThis opens the possibility for additional EIP191 sign modes, like SIGN_MODE_EIP_191_TEXTUAL,\nSIGN_MODE_EIP_191_LEGACY_JSON, and more.\nEach new EIP191 sign mode should be accompanied by an associated ADR."
+              "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT. It is currently not supported.\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`. It also allows\nfor adding Tips in transactions.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2"
             }
           }
         },
@@ -34541,7 +32823,7 @@
             "SIGN_MODE_EIP_191"
           ],
           "default": "SIGN_MODE_UNSPECIFIED",
-          "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT.\n\nSince: cosmos-sdk 0.50\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2\nDeprecated: post 0.47.x Sign mode refers to a method of encoding string data for\nsigning, but in the SDK, it also refers to how to encode a transaction into a string.\nThis opens the possibility for additional EIP191 sign modes, like SIGN_MODE_EIP_191_TEXTUAL,\nSIGN_MODE_EIP_191_LEGACY_JSON, and more.\nEach new EIP191 sign mode should be accompanied by an associated ADR."
+          "description": "SignMode represents a signing mode with its own security guarantees.\n\nThis enum should be considered a registry of all known sign modes\nin the Cosmos ecosystem. Apps are not expected to support all known\nsign modes. Apps that would like to support custom  sign modes are\nencouraged to open a small PR against this file to add a new case\nto this SignMode enum describing their sign mode so that different\napps have a consistent version of this enum.\n\n - SIGN_MODE_UNSPECIFIED: SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be\nrejected.\n - SIGN_MODE_DIRECT: SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is\nverified with raw bytes from Tx.\n - SIGN_MODE_TEXTUAL: SIGN_MODE_TEXTUAL is a future signing mode that will verify some\nhuman-readable textual representation on top of the binary representation\nfrom SIGN_MODE_DIRECT. It is currently not supported.\n - SIGN_MODE_DIRECT_AUX: SIGN_MODE_DIRECT_AUX specifies a signing mode which uses\nSignDocDirectAux. As opposed to SIGN_MODE_DIRECT, this sign mode does not\nrequire signers signing over other signers' `signer_info`. It also allows\nfor adding Tips in transactions.\n\nSince: cosmos-sdk 0.46\n - SIGN_MODE_LEGACY_AMINO_JSON: SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses\nAmino JSON and will be removed in the future.\n - SIGN_MODE_EIP_191: SIGN_MODE_EIP_191 specifies the sign mode for EIP 191 signing on the Cosmos\nSDK. Ref: https://eips.ethereum.org/EIPS/eip-191\n\nCurrently, SIGN_MODE_EIP_191 is registered as a SignMode enum variant,\nbut is not implemented on the SDK by default. To enable EIP-191, you need\nto pass a custom `TxConfig` that has an implementation of\n`SignModeHandler` for EIP-191. The SDK may decide to fully support\nEIP-191 in the future.\n\nSince: cosmos-sdk 0.45.2"
         }
       },
       "title": "Single is the mode info for a single signer. It is structured as a message\nto allow for additional fields such as locale for SIGN_MODE_TEXTUAL in the\nfuture"
@@ -34554,7 +32836,7 @@
         "ORDER_BY_DESC"
       ],
       "default": "ORDER_BY_UNSPECIFIED",
-      "description": "- ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults\nto ASC in this case.\n - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order\n - ORDER_BY_DESC: ORDER_BY_DESC defines descending order",
+      "description": "- ORDER_BY_UNSPECIFIED: ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to ASC in this case.\n - ORDER_BY_ASC: ORDER_BY_ASC defines ascending order\n - ORDER_BY_DESC: ORDER_BY_DESC defines descending order",
       "title": "OrderBy defines the sorting order"
     },
     "cosmos.tx.v1beta1.SignerInfo": {
@@ -34661,7 +32943,7 @@
                     }
                   }
                 },
-                "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+                "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
               },
               "description": "Events contains a slice of Event objects that were emitted during message\nor handler execution."
             },
@@ -34983,7 +33265,7 @@
           }
         }
       },
-      "description": "Event allows application developers to attach additional information to\nResponseFinalizeBlock and ResponseCheckTx.\nLater, transactions may be queried using these events."
+      "description": "Event allows application developers to attach additional information to\nResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.\nLater, transactions may be queried using these events."
     },
     "tendermint.abci.EventAttribute": {
       "type": "object",
@@ -35197,21 +33479,10 @@
                           },
                           "signature": {
                             "type": "string",
-                            "format": "byte",
-                            "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                          },
-                          "extension": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                          },
-                          "extension_signature": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                            "format": "byte"
                           }
                         },
-                        "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                        "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                       },
                       "vote_b": {
                         "type": "object",
@@ -35273,21 +33544,10 @@
                           },
                           "signature": {
                             "type": "string",
-                            "format": "byte",
-                            "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                          },
-                          "extension": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                          },
-                          "extension_signature": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                            "format": "byte"
                           }
                         },
-                        "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                        "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                       },
                       "total_voting_power": {
                         "type": "string",
@@ -35457,7 +33717,7 @@
                                             "BLOCK_ID_FLAG_NIL"
                                           ],
                                           "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                          "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                          "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                         },
                                         "validator_address": {
                                           "type": "string",
@@ -35659,7 +33919,7 @@
                       "BLOCK_ID_FLAG_NIL"
                     ],
                     "default": "BLOCK_ID_FLAG_UNKNOWN",
-                    "title": "BlockIdFlag indicates which BlockID the signature is for"
+                    "title": "BlockIdFlag indicates which BlcokID the signature is for"
                   },
                   "validator_address": {
                     "type": "string",
@@ -35691,7 +33951,7 @@
         "BLOCK_ID_FLAG_NIL"
       ],
       "default": "BLOCK_ID_FLAG_UNKNOWN",
-      "title": "BlockIdFlag indicates which BlockID the signature is for"
+      "title": "BlockIdFlag indicates which BlcokID the signature is for"
     },
     "tendermint.types.Commit": {
       "type": "object",
@@ -35742,7 +34002,7 @@
                   "BLOCK_ID_FLAG_NIL"
                 ],
                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                "title": "BlockIdFlag indicates which BlcokID the signature is for"
               },
               "validator_address": {
                 "type": "string",
@@ -35775,7 +34035,7 @@
             "BLOCK_ID_FLAG_NIL"
           ],
           "default": "BLOCK_ID_FLAG_UNKNOWN",
-          "title": "BlockIdFlag indicates which BlockID the signature is for"
+          "title": "BlockIdFlag indicates which BlcokID the signature is for"
         },
         "validator_address": {
           "type": "string",
@@ -35869,21 +34129,10 @@
             },
             "signature": {
               "type": "string",
-              "format": "byte",
-              "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-            },
-            "extension": {
-              "type": "string",
-              "format": "byte",
-              "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-            },
-            "extension_signature": {
-              "type": "string",
-              "format": "byte",
-              "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+              "format": "byte"
             }
           },
-          "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+          "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
         },
         "vote_b": {
           "type": "object",
@@ -35945,21 +34194,10 @@
             },
             "signature": {
               "type": "string",
-              "format": "byte",
-              "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-            },
-            "extension": {
-              "type": "string",
-              "format": "byte",
-              "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-            },
-            "extension_signature": {
-              "type": "string",
-              "format": "byte",
-              "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+              "format": "byte"
             }
           },
-          "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+          "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
         },
         "total_voting_power": {
           "type": "string",
@@ -36042,21 +34280,10 @@
                 },
                 "signature": {
                   "type": "string",
-                  "format": "byte",
-                  "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                },
-                "extension": {
-                  "type": "string",
-                  "format": "byte",
-                  "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                },
-                "extension_signature": {
-                  "type": "string",
-                  "format": "byte",
-                  "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                  "format": "byte"
                 }
               },
-              "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+              "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
             },
             "vote_b": {
               "type": "object",
@@ -36118,21 +34345,10 @@
                 },
                 "signature": {
                   "type": "string",
-                  "format": "byte",
-                  "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                },
-                "extension": {
-                  "type": "string",
-                  "format": "byte",
-                  "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                },
-                "extension_signature": {
-                  "type": "string",
-                  "format": "byte",
-                  "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                  "format": "byte"
                 }
               },
-              "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+              "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
             },
             "total_voting_power": {
               "type": "string",
@@ -36302,7 +34518,7 @@
                                   "BLOCK_ID_FLAG_NIL"
                                 ],
                                 "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                "title": "BlockIdFlag indicates which BlcokID the signature is for"
                               },
                               "validator_address": {
                                 "type": "string",
@@ -36523,21 +34739,10 @@
                       },
                       "signature": {
                         "type": "string",
-                        "format": "byte",
-                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                      },
-                      "extension": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                      },
-                      "extension_signature": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                        "format": "byte"
                       }
                     },
-                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                   },
                   "vote_b": {
                     "type": "object",
@@ -36599,21 +34804,10 @@
                       },
                       "signature": {
                         "type": "string",
-                        "format": "byte",
-                        "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                      },
-                      "extension": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                      },
-                      "extension_signature": {
-                        "type": "string",
-                        "format": "byte",
-                        "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                        "format": "byte"
                       }
                     },
-                    "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                    "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                   },
                   "total_voting_power": {
                     "type": "string",
@@ -36783,7 +34977,7 @@
                                         "BLOCK_ID_FLAG_NIL"
                                       ],
                                       "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                      "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                      "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                     },
                                     "validator_address": {
                                       "type": "string",
@@ -37086,7 +35280,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",
@@ -37338,7 +35532,7 @@
                               "BLOCK_ID_FLAG_NIL"
                             ],
                             "default": "BLOCK_ID_FLAG_UNKNOWN",
-                            "title": "BlockIdFlag indicates which BlockID the signature is for"
+                            "title": "BlockIdFlag indicates which BlcokID the signature is for"
                           },
                           "validator_address": {
                             "type": "string",
@@ -37633,7 +35827,7 @@
                       "BLOCK_ID_FLAG_NIL"
                     ],
                     "default": "BLOCK_ID_FLAG_UNKNOWN",
-                    "title": "BlockIdFlag indicates which BlockID the signature is for"
+                    "title": "BlockIdFlag indicates which BlcokID the signature is for"
                   },
                   "validator_address": {
                     "type": "string",
@@ -37832,21 +36026,10 @@
         },
         "signature": {
           "type": "string",
-          "format": "byte",
-          "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-        },
-        "extension": {
-          "type": "string",
-          "format": "byte",
-          "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-        },
-        "extension_signature": {
-          "type": "string",
-          "format": "byte",
-          "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+          "format": "byte"
         }
       },
-      "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+      "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
     },
     "cosmos.base.tendermint.v1beta1.ABCIQueryResponse": {
       "type": "object",
@@ -38092,21 +36275,10 @@
                           },
                           "signature": {
                             "type": "string",
-                            "format": "byte",
-                            "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                          },
-                          "extension": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                          },
-                          "extension_signature": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                            "format": "byte"
                           }
                         },
-                        "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                        "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                       },
                       "vote_b": {
                         "type": "object",
@@ -38168,21 +36340,10 @@
                           },
                           "signature": {
                             "type": "string",
-                            "format": "byte",
-                            "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                          },
-                          "extension": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                          },
-                          "extension_signature": {
-                            "type": "string",
-                            "format": "byte",
-                            "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                            "format": "byte"
                           }
                         },
-                        "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                        "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                       },
                       "total_voting_power": {
                         "type": "string",
@@ -38352,7 +36513,7 @@
                                             "BLOCK_ID_FLAG_NIL"
                                           ],
                                           "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                          "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                          "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                         },
                                         "validator_address": {
                                           "type": "string",
@@ -38554,7 +36715,7 @@
                       "BLOCK_ID_FLAG_NIL"
                     ],
                     "default": "BLOCK_ID_FLAG_UNKNOWN",
-                    "title": "BlockIdFlag indicates which BlockID the signature is for"
+                    "title": "BlockIdFlag indicates which BlcokID the signature is for"
                   },
                   "validator_address": {
                     "type": "string",
@@ -38789,21 +36950,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "vote_b": {
                             "type": "object",
@@ -38865,21 +37015,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "total_voting_power": {
                             "type": "string",
@@ -39049,7 +37188,7 @@
                                                 "BLOCK_ID_FLAG_NIL"
                                               ],
                                               "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                              "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                              "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                             },
                                             "validator_address": {
                                               "type": "string",
@@ -39251,7 +37390,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",
@@ -39458,21 +37597,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "vote_b": {
                             "type": "object",
@@ -39534,21 +37662,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "total_voting_power": {
                             "type": "string",
@@ -39718,7 +37835,7 @@
                                                 "BLOCK_ID_FLAG_NIL"
                                               ],
                                               "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                              "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                              "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                             },
                                             "validator_address": {
                                               "type": "string",
@@ -39920,7 +38037,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",
@@ -40158,21 +38275,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "vote_b": {
                             "type": "object",
@@ -40234,21 +38340,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "total_voting_power": {
                             "type": "string",
@@ -40418,7 +38513,7 @@
                                                 "BLOCK_ID_FLAG_NIL"
                                               ],
                                               "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                              "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                              "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                             },
                                             "validator_address": {
                                               "type": "string",
@@ -40620,7 +38715,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",
@@ -40827,21 +38922,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "vote_b": {
                             "type": "object",
@@ -40903,21 +38987,10 @@
                               },
                               "signature": {
                                 "type": "string",
-                                "format": "byte",
-                                "description": "Vote signature by the validator if they participated in consensus for the\nassociated block."
-                              },
-                              "extension": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension provided by the application. Only valid for precommit\nmessages."
-                              },
-                              "extension_signature": {
-                                "type": "string",
-                                "format": "byte",
-                                "description": "Vote extension signature by the validator if they participated in\nconsensus for the associated block.\nOnly valid for precommit messages."
+                                "format": "byte"
                               }
                             },
-                            "description": "Vote represents a prevote or precommit vote from validators for\nconsensus."
+                            "description": "Vote represents a prevote, precommit, or commit vote from validators for\nconsensus."
                           },
                           "total_voting_power": {
                             "type": "string",
@@ -41087,7 +39160,7 @@
                                                 "BLOCK_ID_FLAG_NIL"
                                               ],
                                               "default": "BLOCK_ID_FLAG_UNKNOWN",
-                                              "title": "BlockIdFlag indicates which BlockID the signature is for"
+                                              "title": "BlockIdFlag indicates which BlcokID the signature is for"
                                             },
                                             "validator_address": {
                                               "type": "string",
@@ -41289,7 +39362,7 @@
                           "BLOCK_ID_FLAG_NIL"
                         ],
                         "default": "BLOCK_ID_FLAG_UNKNOWN",
-                        "title": "BlockIdFlag indicates which BlockID the signature is for"
+                        "title": "BlockIdFlag indicates which BlcokID the signature is for"
                       },
                       "validator_address": {
                         "type": "string",


### PR DESCRIPTION
Problem: `Makefile` currently pull `main`/`master` branches of multiple repositories for swagger gen.

This would cause wrong docs generated, eg: your chain using ibc v7 but latest ibc is v8 thus generated swagger is wrong
___
## Not Tested:
I'm on metered connection so inconvenient to test, feel free to correct, update or even rework in another PR as you wish.