### PR TITLE
Problem: versiondb version checking on startup is too strict

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -815,8 +815,9 @@ func NewEvmos(
 		if queryMultiStore != nil {
 			v1 := queryMultiStore.LatestVersion()
 			v2 := app.LastBlockHeight()
-			if v1 > 0 && v1 != v2 {
-				tmos.Exit(fmt.Sprintf("versiondb lastest version %d don't match iavl latest version %d", v1, v2))
+			// prevent creating gaps in versiondb
+			if v1 > 0 && v1 < v2 {
+				tmos.Exit(fmt.Sprintf("versiondb lastest version %d lag behind iavl latest version %d", v1, v2))
 			}
 		}
 	}


### PR DESCRIPTION
there was the version equality checking on startup between versiondb and iavl, for two purposes:
- if versiondb lag behind iavl, when commit new blocks, it creates gap in versiondb. this can happen because cms is committed before versiondb.
- if versiondb is beyond iavl, and when commit new blocks, versiondb will write some duplicated data, this is actually not harmful, if the rewritten data is identical to the old ones. this can happen with memiavl async-commit.

the latter case is not harmful, so we can relax the checking to improve UX.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->