### PR TITLE
feat(str): Disable `ToggleConversion` for Native Coins pairs

### DIFF
--- a/x/erc20/keeper/proposals.go
+++ b/x/erc20/keeper/proposals.go
@@ -173,6 +173,12 @@ func (k Keeper) ToggleConversion(
 		)
 	}
 
+	if pair.ContractOwner == types.OWNER_MODULE {
+		return types.TokenPair{}, errorsmod.Wrapf(
+			types.ErrTokenPairNotFound, "not allowed to disable '%s' token", token,
+		)
+	}
+
 	pair.Enabled = !pair.Enabled
 
 	k.SetTokenPair(ctx, pair)

--- a/x/erc20/keeper/proposals_test.go
+++ b/x/erc20/keeper/proposals_test.go
@@ -7,6 +7,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/ethereum/go-ethereum/common"
+	teststypes "github.com/evmos/evmos/v16/types/tests"
 	"github.com/evmos/evmos/v16/x/erc20/keeper"
 	"github.com/evmos/evmos/v16/x/erc20/types"
 	erc20mocks "github.com/evmos/evmos/v16/x/erc20/types/mocks"
@@ -236,6 +237,17 @@ func (suite KeeperTestSuite) TestToggleConverision() { //nolint:govet // we can 
 				pair, _ = suite.app.Erc20Keeper.ToggleConversion(suite.ctx, contractAddr.String())
 			},
 			true,
+			true,
+		},
+		{
+			"not allowed to disable native coin pair",
+			func() {
+				suite.app.Erc20Keeper.RegisterERC20Extension(suite.ctx, teststypes.UosmoIbcdenom, contractAddr)
+				id = suite.app.Erc20Keeper.GetTokenPairID(suite.ctx, contractAddr.String())
+				pair, _ = suite.app.Erc20Keeper.GetTokenPair(suite.ctx, id)
+
+			},
+			false,
 			true,
 		},
 	}


### PR DESCRIPTION
# Description

With STRV2 we are trying to walk away from cosmos transactions. After this goes live, if we disable a token-pair we will be effectively preventing a coin from being used on the evmos ecosystem. To avoid this we need to deny the possibility to disable a token pair that is module owned. The easiest and most straight forward way to accomplish this is to update the proposal handler to return an error in case of Native coin token pair.

Closes: XAP-118

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
