### PR TITLE
imp(tests): Move ERC-20 balance to utils

### DIFF
--- a/app/upgrades/v17/integration_test.go
+++ b/app/upgrades/v17/integration_test.go
@@ -124,7 +124,7 @@ var _ = Describe("STR v2 tests -", Ordered, func() {
 			)
 
 			// Test that the ERC-20 contract for the IBC native coin has the correct user balance after genesis.
-			balance, err := GetERC20BalanceForAddr(
+			balance, err := testutils.GetERC20BalanceForAddr(
 				ts.factory,
 				ts.keyring.GetPrivKey(erc20Deployer),
 				accountWithERC20s,
@@ -160,7 +160,7 @@ var _ = Describe("STR v2 tests -", Ordered, func() {
 		})
 
 		It("should have minted ERC-20 tokens for the contract deployer", func() {
-			balance, err := GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.erc20Contract)
+			balance, err := testutils.GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.erc20Contract)
 			Expect(err).ToNot(HaveOccurred(), "failed to query ERC-20 balance")
 			Expect(balance).To(Equal(mintAmount), "expected different balance after minting ERC-20")
 		})
@@ -237,7 +237,7 @@ var _ = Describe("STR v2 tests -", Ordered, func() {
 			// NOTE: We check that the ERC20 contract for the native token pair can still be called,
 			// even though the original contract code was deleted, and it is now re-deployed
 			// as a precompiled contract.
-			balance, err := GetERC20BalanceForAddr(
+			balance, err := testutils.GetERC20BalanceForAddr(
 				ts.factory,
 				ts.keyring.GetPrivKey(erc20Deployer),
 				accountWithERC20s,
@@ -258,13 +258,13 @@ var _ = Describe("STR v2 tests -", Ordered, func() {
 		})
 
 		It("should not have converted the native ERC-20s", func() {
-			balance, err := GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.nonNativeTokenPair.GetERC20Contract())
+			balance, err := testutils.GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.nonNativeTokenPair.GetERC20Contract())
 			Expect(err).ToNot(HaveOccurred(), "failed to query ERC20 balance")
 			Expect(balance).To(Equal(mintAmount), "expected different balance after converting ERC20")
 		})
 
 		It("should have withdrawn all WEVMOS tokens", func() {
-			balance, err := GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.wevmosContract)
+			balance, err := testutils.GetERC20Balance(ts.factory, ts.keyring.GetPrivKey(erc20Deployer), ts.wevmosContract)
 			Expect(err).ToNot(HaveOccurred(), "failed to query ERC20 balance")
 			Expect(balance.Int64()).To(Equal(int64(0)), "expected empty WEVMOS balance")
 		})

--- a/app/upgrades/v17/utils_test.go
+++ b/app/upgrades/v17/utils_test.go
@@ -1,15 +1,10 @@
 package v17_test
 
 import (
-	"fmt"
-	"math/big"
-
 	errorsmod "cosmossdk.io/errors"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/evmos/evmos/v16/contracts"
 	"github.com/evmos/evmos/v16/precompiles/werc20/testdata"
 	testfactory "github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
@@ -191,55 +186,4 @@ func PrepareNetwork(ts *ConvertERC20CoinsTestSuite) (*ConvertERC20CoinsTestSuite
 	ts.wevmosContract = wevmosAddr
 
 	return ts, nil
-}
-
-// GetERC20Balance is a helper method to return the balance of the given ERC-20 contract for the given address.
-func GetERC20Balance(txFactory testfactory.TxFactory, priv cryptotypes.PrivKey, erc20Addr common.Address) (*big.Int, error) {
-	addr := common.BytesToAddress(priv.PubKey().Address().Bytes())
-
-	return GetERC20BalanceForAddr(txFactory, priv, addr, erc20Addr)
-}
-
-// GetERC20BalanceForAddr is a helper method to return the balance of the given ERC-20 contract for the given address.
-//
-// NOTE: Under the hood this sends an actual EVM transaction instead of just querying the JSON-RPC.
-// TODO: Use query instead of transaction in future.
-func GetERC20BalanceForAddr(txFactory testfactory.TxFactory, priv cryptotypes.PrivKey, addr, erc20Addr common.Address) (*big.Int, error) {
-	erc20ABI := contracts.ERC20MinterBurnerDecimalsContract.ABI
-
-	txArgs := evmtypes.EvmTxArgs{
-		To: &erc20Addr,
-	}
-
-	callArgs := testfactory.CallArgs{
-		ContractABI: erc20ABI,
-		MethodName:  "balanceOf",
-		Args:        []interface{}{addr},
-	}
-
-	// TODO: should rather be done with EthCall
-	res, err := txFactory.ExecuteContractCall(priv, txArgs, callArgs)
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "failed to execute contract call")
-	}
-
-	ethRes, err := evmtypes.DecodeTxResponse(res.Data)
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "failed to decode tx response")
-	}
-	if len(ethRes.Ret) == 0 {
-		return nil, fmt.Errorf("got empty return value from contract call")
-	}
-
-	balanceI, err := erc20ABI.Unpack("balanceOf", ethRes.Ret)
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "failed to unpack balance")
-	}
-
-	balance, ok := balanceI[0].(*big.Int)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert balance to big.Int; got %T", balanceI[0])
-	}
-
-	return balance, nil
 }

--- a/testutil/integration/evmos/utils/erc20_balance.go
+++ b/testutil/integration/evmos/utils/erc20_balance.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"fmt"
+	"math/big"
+
+	errorsmod "cosmossdk.io/errors"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/evmos/evmos/v16/contracts"
+	testfactory "github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
+	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
+)
+
+// GetERC20Balance is a helper method to return the balance of the given ERC-20 contract for the given address.
+func GetERC20Balance(txFactory testfactory.TxFactory, priv cryptotypes.PrivKey, erc20Addr common.Address) (*big.Int, error) {
+	addr := common.BytesToAddress(priv.PubKey().Address().Bytes())
+
+	return GetERC20BalanceForAddr(txFactory, priv, addr, erc20Addr)
+}
+
+// GetERC20BalanceForAddr is a helper method to return the balance of the given ERC-20 contract for the given address.
+//
+// NOTE: Under the hood this sends an actual EVM transaction instead of just querying the JSON-RPC.
+// TODO: Use query instead of transaction in future.
+func GetERC20BalanceForAddr(txFactory testfactory.TxFactory, priv cryptotypes.PrivKey, addr, erc20Addr common.Address) (*big.Int, error) {
+	erc20ABI := contracts.ERC20MinterBurnerDecimalsContract.ABI
+
+	txArgs := evmtypes.EvmTxArgs{
+		To: &erc20Addr,
+	}
+
+	callArgs := testfactory.CallArgs{
+		ContractABI: erc20ABI,
+		MethodName:  "balanceOf",
+		Args:        []interface{}{addr},
+	}
+
+	// TODO: should rather be done with EthCall
+	res, err := txFactory.ExecuteContractCall(priv, txArgs, callArgs)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to execute contract call")
+	}
+
+	ethRes, err := evmtypes.DecodeTxResponse(res.Data)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to decode tx response")
+	}
+	if len(ethRes.Ret) == 0 {
+		return nil, fmt.Errorf("got empty return value from contract call")
+	}
+
+	balanceI, err := erc20ABI.Unpack("balanceOf", ethRes.Ret)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "failed to unpack balance")
+	}
+
+	balance, ok := balanceI[0].(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert balance to big.Int; got %T", balanceI[0])
+	}
+
+	return balance, nil
+}

--- a/testutil/integration/evmos/utils/erc20_balance_test.go
+++ b/testutil/integration/evmos/utils/erc20_balance_test.go
@@ -1,0 +1,123 @@
+package utils_test
+
+import (
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/evmos/evmos/v16/contracts"
+	"github.com/evmos/evmos/v16/crypto/ethsecp256k1"
+	testfactory "github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
+	"github.com/evmos/evmos/v16/testutil/integration/evmos/grpc"
+	testkeyring "github.com/evmos/evmos/v16/testutil/integration/evmos/keyring"
+	testnetwork "github.com/evmos/evmos/v16/testutil/integration/evmos/network"
+	testutils "github.com/evmos/evmos/v16/testutil/integration/evmos/utils"
+	utiltx "github.com/evmos/evmos/v16/testutil/tx"
+	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func TestGetERC20Balance(t *testing.T) {
+	keyring := testkeyring.New(2)
+	network := testnetwork.New(
+		testnetwork.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
+	)
+	handler := grpc.NewIntegrationHandler(network)
+	factory := testfactory.New(network, handler)
+
+	mintedBalance := big.NewInt(1000)
+	keyWithoutFunds, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err, "failed to generate dummy key")
+
+	// Deploy ERC20 contract
+	deployer := keyring.GetKey(0)
+	erc20Addr, err := factory.DeployContract(
+		deployer.Priv,
+		evmtypes.EvmTxArgs{}, // NOTE: using default values by passing empty struct
+		testfactory.ContractDeploymentData{
+			Contract: contracts.ERC20MinterBurnerDecimalsContract,
+			ConstructorArgs: []interface{}{
+				"TestToken", "TT", uint8(6),
+			},
+		},
+	)
+	require.NoError(t, err, "failed to deploy ERC20 contract")
+
+	testcases := []struct {
+		name         string
+		priv         cryptotypes.PrivKey
+		contractAddr common.Address
+		malleate     func() error
+		expBalance   *big.Int
+		expPass      bool
+		errContains  string
+	}{
+		{
+			name:         "pass - empty balance",
+			priv:         keyring.GetPrivKey(1),
+			contractAddr: erc20Addr,
+			expBalance:   big.NewInt(0),
+			expPass:      true,
+		},
+		{
+			name:         "pass - non-empty balance",
+			priv:         keyring.GetPrivKey(0),
+			contractAddr: erc20Addr,
+			malleate: func() error {
+				_, err := factory.ExecuteContractCall(
+					deployer.Priv,
+					evmtypes.EvmTxArgs{
+						To: &erc20Addr,
+					},
+					testfactory.CallArgs{
+						ContractABI: contracts.ERC20MinterBurnerDecimalsContract.ABI,
+						MethodName:  "mint",
+						Args: []interface{}{
+							keyring.GetAddr(0),
+							mintedBalance,
+						},
+					},
+				)
+				return err
+			},
+			expBalance: mintedBalance,
+			expPass:    true,
+		},
+		{
+			name:         "fail - wrong contract",
+			priv:         keyring.GetPrivKey(0),
+			contractAddr: utiltx.GenerateAddress(),
+			errContains:  "got empty return value from contract call",
+		},
+		{
+			name:         "fail - sender has no balance",
+			priv:         keyWithoutFunds,
+			contractAddr: erc20Addr,
+			errContains:  "failed to execute contract call",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.malleate != nil {
+				err = tc.malleate()
+				require.NoError(t, err, "failed to malleate")
+			}
+
+			balance, err := testutils.GetERC20Balance(
+				factory,
+				tc.priv,
+				tc.contractAddr,
+			)
+			if tc.expPass {
+				require.NoError(t, err, "failed to get ERC20 balance")
+				require.Equal(t, tc.expBalance.String(), balance.String(), "unexpected balance")
+			} else {
+				// NOTE: this is to be able to test errors potentially going forward.
+				// With the existing integration test setup, there are no errors to be forced.
+				require.Error(t, err, "expected error")
+				require.ErrorContains(t, err, tc.errContains, "unexpected error")
+			}
+		})
+	}
+}

--- a/testutil/integration/evmos/utils/erc20_balance_test.go
+++ b/testutil/integration/evmos/utils/erc20_balance_test.go
@@ -1,6 +1,9 @@
 package utils_test
 
 import (
+	"math/big"
+	"testing"
+
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/evmos/evmos/v16/contracts"
@@ -13,8 +16,6 @@ import (
 	utiltx "github.com/evmos/evmos/v16/testutil/tx"
 	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
 )
 
 func TestGetERC20Balance(t *testing.T) {


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

This PR moves some utilities to query the ERC-20 token balance with the integration testing setup to the dedicated utils subpackage.

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
