### PR TITLE
imp(evm): Check for dynamic extensions during EVM initialization

### DIFF
--- a/x/evm/types/params.go
+++ b/x/evm/types/params.go
@@ -163,7 +163,7 @@ func (p Params) EIPs() []int {
 
 // HasCustomPrecompiles returns true if the ActivePrecompiles slice is not empty.
 func (p Params) HasCustomPrecompiles() bool {
-	return len(p.ActivePrecompiles) > 0
+	return len(p.ActivePrecompiles) > 0 || len(p.ActiveDynamicPrecompiles) > 0
 }
 
 // IsEVMChannel returns true if the channel provided is in the list of


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

This PR extends the `HasCustomPrecompiles` method for the EVM params to also check for active dynamic precompiles. This is important, because when executing an EVM transaction, the EVM only is populated with Evmos' precompiles if this check returns true.

Closes: XAP-143
