### PR TITLE
chore(tests): migrate vesting precompile tests

### DIFF
--- a/precompiles/distribution/integration_test.go
+++ b/precompiles/distribution/integration_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Calling distribution precompile from EOA", func() {
 
 	Describe("Validator Commission: Execute WithdrawValidatorCommission tx", func() {
 		// expCommAmt is the expected commission amount
-		var expCommAmt = math.NewInt(1)
+		expCommAmt := math.NewInt(1)
 
 		BeforeEach(func() {
 			// set the default call arguments

--- a/precompiles/distribution/setup_test.go
+++ b/precompiles/distribution/setup_test.go
@@ -15,11 +15,6 @@ import (
 	testkeyring "github.com/evmos/evmos/v16/testutil/integration/evmos/keyring"
 	"github.com/evmos/evmos/v16/testutil/integration/evmos/network"
 
-	//nolint:revive // dot imports are fine for Ginkgo
-	. "github.com/onsi/ginkgo/v2"
-	//nolint:revive // dot imports are fine for Ginkgo
-	. "github.com/onsi/gomega"
-
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,11 +36,6 @@ func TestPrecompileUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(PrecompileTestSuite))
 }
 
-func TestPrecompileIntegrationTestSuite(t *testing.T) {
-	// Run Ginkgo integration tests
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Distribution Precompile Suite")
-}
 
 func (s *PrecompileTestSuite) SetupTest() {
 	keyring := testkeyring.New(2)

--- a/precompiles/distribution/setup_test.go
+++ b/precompiles/distribution/setup_test.go
@@ -36,7 +36,6 @@ func TestPrecompileUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(PrecompileTestSuite))
 }
 
-
 func (s *PrecompileTestSuite) SetupTest() {
 	keyring := testkeyring.New(2)
 	s.validatorsKeys = generateKeys(3)

--- a/precompiles/vesting/events.go
+++ b/precompiles/vesting/events.go
@@ -90,10 +90,6 @@ func (p Precompile) EmitCreateClawbackVestingAccountEvent(
 		return err
 	}
 
-	if err != nil {
-		return err
-	}
-
 	// Create the event
 	stateDB.AddLog(&ethtypes.Log{
 		Address:     p.Address(),

--- a/precompiles/vesting/integration_test.go
+++ b/precompiles/vesting/integration_test.go
@@ -904,16 +904,13 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				if callType.directCall {
 					updateFunderCheck = failCheck.
 						WithErrContains(fmt.Sprintf(
-							"account at address %s does not exist",
+							"account at address '%s' does not exist",
 							sdk.AccAddress(nonExistentAddr.Bytes()).String(),
 						))
 				}
 
 				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
-				if callType.directCall {
-					Expect(err.Error()).To(ContainSubstring("does not exist"))
-				}
 			})
 
 			It(fmt.Sprintf("should return an error when the account is no vesting account (%s)", callType.name), func() {
@@ -1237,7 +1234,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				balancesCheck := execRevertedCheck
 				if callType.directCall {
 					balancesCheck = failCheck.WithErrContains(fmt.Sprintf(
-						"account at address '%s' is not a vesting account",
+						"account at address '%s' either does not exist or is not a vesting account",
 						s.keyring.GetAccAddr(vestingAccIdx),
 					))
 				}

--- a/precompiles/vesting/integration_test.go
+++ b/precompiles/vesting/integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/evmos/evmos/v16/precompiles/vesting"
 	"github.com/evmos/evmos/v16/precompiles/vesting/testdata"
 	"github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
-	testutils "github.com/evmos/evmos/v16/testutil/integration/evmos/utils"
+	testkeyring "github.com/evmos/evmos/v16/testutil/integration/evmos/keyring"
 	testutiltx "github.com/evmos/evmos/v16/testutil/tx"
 	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
 	vestingtypes "github.com/evmos/evmos/v16/x/vesting/types"
@@ -28,8 +28,6 @@ import (
 	//nolint:revive // dot imports are fine for Ginkgo
 	. "github.com/onsi/gomega"
 )
-
-const vestingAccIdx = 1
 
 var (
 	// contractAddr is the address of the smart contract that calls the vesting extension
@@ -57,8 +55,6 @@ var (
 		{name: "directly", directCall: true},
 		{name: "through a smart contract", directCall: false},
 	}
-	// differentAddr is a new address used in testing
-	differentAddr = testutiltx.GenerateAddress()
 )
 
 func TestPrecompileIntegrationTestSuite(t *testing.T) {
@@ -73,7 +69,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 	BeforeEach(func() {
 		// Setup the test suite
 		s = new(PrecompileTestSuite)
-		s.SetupTest()
+		s.SetupTest(3)
 
 		// Set the default value for the vesting or lockup periods
 		defaultPeriod := vesting.Period{
@@ -115,56 +111,57 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			callType := callType
 
 			It(fmt.Sprintf("should create a clawback vesting account (%s)", callType.name), func() {
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					toAddr.Bytes(), math.NewInt(10000),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					funderAddr,
-					s.keyring.GetAddr(0),
+					funder.Addr,
+					vestingKey.Addr,
 					false,
 				}
 
 				createClawbackCheck := passCheck.WithExpEvents(vesting.EventTypeCreateClawbackVestingAccount)
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(vestingKey.Priv, txArgs, callArgs, createClawbackCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				s.ExpectSimpleVestingAccount(s.keyring.GetAddr(0), funderAddr)
+				s.ExpectSimpleVestingAccount(vestingKey.Addr, funder.Addr)
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account if the account is not initialized (%s)", callType.name), func() {
+				funder := s.keyring.GetKey(0)
+				nonExistentAddr, nonExistentPriv := testutiltx.NewAddrKey()
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					toAddr,
+					funder.Addr,
+					nonExistentAddr,
 					false,
 				}
 
 				createClawbackCheck := failCheck.WithErrContains("account is not initialized")
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(nonExistentPriv, txArgs, callArgs, createClawbackCheck)
 				Expect(err).To(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), toAddr.Bytes())
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), nonExistentAddr.Bytes())
 				Expect(acc).To(BeNil(), "account should not be created")
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account if the vesting account is the zero address (%s)", callType.name), func() {
+				funder := s.keyring.GetKey(0)
+				sender := s.keyring.GetKey(1)
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					common.Address{},
 					false,
 				}
@@ -175,16 +172,19 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					createClawbackCheck = failCheck.WithErrContains("execution reverted")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(sender.Priv, txArgs, callArgs, createClawbackCheck)
 				Expect(err).To(BeNil(), "error while calling the contract: %v", err)
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account if the funder account is the zero address (%s)", callType.name), func() {
+				funderAddr := common.Address{}
+				vestingKey := s.keyring.GetKey(1)
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					common.Address{},
-					s.keyring.GetAddr(0),
+					funderAddr,
+					vestingKey.Addr,
 					false,
 				}
 
@@ -194,31 +194,26 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					createClawbackCheck = failCheck.WithErrContains("execution reverted")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(vestingKey.Priv, txArgs, callArgs, createClawbackCheck)
 				Expect(err).To(BeNil(), "error while calling the contract: %v", err)
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account if the origin is different than the vesting address (%s)", callType.name), func() {
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					differentAddr.Bytes(),
-					math.NewInt(10000),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+				differentSender := s.keyring.GetKey(2)
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
+					funder.Addr,
+					vestingKey.Addr,
 					false,
 				}
 
 				createClawbackCheck := failCheck.WithErrContains("origin is different than the vesting address")
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(differentSender.Priv, txArgs, callArgs, createClawbackCheck)
 				Expect(err).To(HaveOccurred(), "error while calling the contract: %v", err)
 				if callType.directCall {
 					Expect(err.Error()).To(ContainSubstring("does not match the from address"))
@@ -226,6 +221,8 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account for a smart contract (%s)", callType.name), func() {
+				sender := s.keyring.GetKey(0)
+
 				if callType.directCall {
 					Skip("this should only be run for smart contract calls")
 				}
@@ -233,7 +230,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = "createClawbackVestingAccountForContract"
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, failCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(sender.Priv, txArgs, callArgs, failCheck)
 				Expect(err).To(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(err.Error()).To(ContainSubstring("execution reverted"))
 				Expect(s.network.NextBlock()).To(BeNil())
@@ -246,35 +243,28 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not create a clawback vesting account if the account already is subject to vesting (%s)", callType.name), func() {
-				addr, priv := testutiltx.NewAddrKey()
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					addr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
 
-				err = s.factory.CreateClawbackVestingAccount(priv, s.keyring.GetAccAddr(0), false)
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.CreateClawbackVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					addr,
+					funder.Addr,
+					vestingKey.Addr,
 					false,
 				}
 
 				createClawbackCheck := failCheck.WithErrContains("account is already subject to vesting")
 
-				_, _, err = s.factory.CallContractAndCheckLogs(priv, txArgs, callArgs, createClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(vestingKey.Priv, txArgs, callArgs, createClawbackCheck)
 				Expect(s.network.NextBlock()).To(BeNil())
 				Expect(err).To(HaveOccurred(), "error while calling the contract: %v", err)
 				if callType.directCall {
-					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%s is already a clawback vesting account", sdk.AccAddress(addr.Bytes()))))
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%s is already a clawback vesting account", vestingKey.AccAddr)))
 				}
 			})
 		}
@@ -285,6 +275,8 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			callType := callType
 
 			BeforeEach(func() {
+				funder := s.keyring.GetKey(0)
+
 				if callType.directCall == false {
 					approvalCallArgs := factory.CallArgs{
 						ContractABI: s.precompile.ABI,
@@ -298,25 +290,28 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					precompileAddr := s.precompile.Address()
 					logCheck := passCheck.WithExpEvents(authorization.EventTypeApproval)
 
-					_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
+					_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
 					Expect(err).To(BeNil())
 					Expect(s.network.NextBlock()).To(BeNil())
 
-					auths, err := s.grpcHandler.GetAuthorizations(sdk.AccAddress(contractAddr.Bytes()).String(), s.keyring.GetAccAddr(0).String())
+					auths, err := s.grpcHandler.GetAuthorizations(sdk.AccAddress(contractAddr.Bytes()).String(), funder.AccAddr.String())
 					Expect(err).To(BeNil())
 					Expect(auths).To(HaveLen(1))
 				}
 			})
 
 			It(fmt.Sprintf("should fund the vesting when defining only lockup (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
 					emptyPeriods,
@@ -325,7 +320,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				fundClawbackVestingCheck := passCheck.
 					WithExpEvents(vesting.EventTypeFundVestingAccount)
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
@@ -333,18 +328,21 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				//
 				// NOTE: The vesting account is created with the lockup periods only, since the vesting periods are empty.
 				// The vesting periods are defaulted to instant vesting, i.e. period length = 0.
-				s.ExpectVestingAccount(s.keyring.GetAddr(vestingAccIdx), defaultPeriods, instantPeriods)
+				s.ExpectVestingAccount(vestingKey.Addr, defaultPeriods, instantPeriods)
 			})
 
 			It(fmt.Sprintf("should fund the vesting when defining only vesting (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					emptyPeriods,
 					defaultPeriods,
@@ -353,7 +351,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				fundClawbackVestingCheck := passCheck.
 					WithExpEvents(vesting.EventTypeFundVestingAccount)
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
@@ -361,18 +359,21 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				//
 				// NOTE: The vesting account is created with the vesting periods only, since the lockup periods are empty.
 				// The lockup periods are defaulted to instant unlocking, i.e. period length = 0.
-				s.ExpectVestingAccount(s.keyring.GetAddr(vestingAccIdx), instantPeriods, defaultPeriods)
+				s.ExpectVestingAccount(vestingKey.Addr, instantPeriods, defaultPeriods)
 			})
 
 			It(fmt.Sprintf("should fund the vesting when defining both lockup and vesting (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
 					defaultPeriods,
@@ -381,23 +382,26 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				fundClawbackVestingCheck := passCheck.
 					WithExpEvents(vesting.EventTypeFundVestingAccount)
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				s.ExpectVestingAccount(s.keyring.GetAddr(vestingAccIdx), defaultPeriods, defaultPeriods)
+				s.ExpectVestingAccount(vestingKey.Addr, defaultPeriods, defaultPeriods)
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when defining different total coins for lockup and vesting (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
 					doublePeriods,
@@ -408,12 +412,12 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("vesting and lockup schedules must have same total coins")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), s.keyring.GetAccAddr(vestingAccIdx))
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), vestingKey.AccAddr)
 				Expect(acc).ToNot(BeNil(), "account should exist")
 				vestAcc, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeTrue())
@@ -422,15 +426,18 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when defining neither lockup nor vesting (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					emptyPeriods,
 					emptyPeriods,
@@ -441,12 +448,12 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("vesting and/or lockup schedules must be present")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), s.keyring.GetAccAddr(vestingAccIdx))
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), vestingKey.AccAddr)
 				Expect(acc).ToNot(BeNil(), "account should exist")
 				vestAcc, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeTrue())
@@ -455,11 +462,14 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when exceeding the funder balance (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
-				res, err := s.grpcHandler.GetBalance(s.keyring.GetAccAddr(0), s.bondDenom)
+				res, err := s.grpcHandler.GetBalance(funder.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balance := res.Balance
 				exceededBalance := new(big.Int).Add(big.NewInt(1), balance.Amount.BigInt())
@@ -472,8 +482,8 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					exceedingVesting,
 					emptyPeriods,
@@ -484,12 +494,12 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("insufficient funds")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), s.keyring.GetAccAddr(vestingAccIdx))
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), vestingKey.AccAddr)
 				va, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeTrue())
 				Expect(va.LockupPeriods).To(BeNil(), "vesting account should not be funded")
@@ -497,17 +507,19 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when not sending as the funder (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+				differentSender := s.keyring.GetKey(2)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
-
-				differentFunder := testutiltx.GenerateAddress()
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					differentFunder,
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					vestingKey.Addr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
 					defaultPeriods,
@@ -518,18 +530,18 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.
 						WithErrContains(
 							fmt.Sprintf("tx origin address %s does not match the from address %s",
-								s.keyring.GetAddr(0),
-								differentFunder,
+								differentSender.Addr,
+								funder.Addr,
 							),
 						)
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(differentSender.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check the vesting account
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), s.keyring.GetAccAddr(vestingAccIdx))
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), vestingKey.AccAddr)
 				Expect(acc).ToNot(BeNil(), "account should exist")
 				va, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeTrue())
@@ -538,12 +550,13 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when the address is blocked (%s)", callType.name), func() {
+				funder := s.keyring.GetKey(0)
 				moduleAddr := common.BytesToAddress(authtypes.NewModuleAddress("distribution").Bytes())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					moduleAddr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
@@ -555,7 +568,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("is not allowed to receive funds")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while creating a clawback vesting account for a module address", err)
 
 				// check that the module address is not a vesting account
@@ -566,10 +579,12 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when the address is blocked - a precompile address (%s)", callType.name), func() {
+				funder := s.keyring.GetKey(0)
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					s.precompile.Address(),
 					uint64(time.Now().Unix()),
 					defaultPeriods,
@@ -581,16 +596,19 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("is not allowed to receive funds")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while creating a clawback vesting account for a module address", err)
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when the address is uninitialized (%s)", callType.name), func() {
+				newAddr := testutiltx.GenerateAddress()
+				funder := s.keyring.GetKey(0)
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
+					funder.Addr,
+					newAddr,
 					uint64(time.Now().Unix()),
 					defaultPeriods,
 					defaultPeriods,
@@ -601,15 +619,17 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("does not exist")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while creating a clawback vesting account for a module address", err)
 			})
 
 			It(fmt.Sprintf("should not fund the vesting when the address is the zero address (%s)", callType.name), func() {
+				funder := s.keyring.GetKey(0)
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.FundVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					common.Address{},
 					uint64(time.Now().Unix()),
 					defaultPeriods,
@@ -621,19 +641,28 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					fundClawbackVestingCheck = failCheck.WithErrContains("invalid address")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, fundClawbackVestingCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, fundClawbackVestingCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while creating a clawback vesting account for the zero address", err)
 			})
 		}
 	})
 
 	Context("to claw back from a vesting account", func() {
+		var (
+			clawbackReceiver   common.Address
+			funder, vestingKey testkeyring.Key
+		)
+
 		BeforeEach(func() {
-			err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+			funder = s.keyring.GetKey(0)
+			vestingKey = s.keyring.GetKey(1)
+			clawbackReceiver = testutiltx.GenerateAddress()
+
+			err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 			Expect(err).To(BeNil())
 			Expect(s.network.NextBlock()).To(BeNil())
 
-			err = s.factory.FundVestingAccount(s.keyring.GetPrivKey(0), s.keyring.GetAccAddr(vestingAccIdx), time.Now(), sdkLockupPeriods, sdkVestingPeriods)
+			err = s.factory.FundVestingAccount(funder.Priv, vestingKey.AccAddr, time.Now(), sdkLockupPeriods, sdkVestingPeriods)
 			Expect(s.network.NextBlock()).To(BeNil())
 		})
 
@@ -654,29 +683,29 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					precompileAddr := s.precompile.Address()
 					logCheck := passCheck.WithExpEvents(authorization.EventTypeApproval)
 
-					_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
+					_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
 					Expect(err).To(BeNil())
 					Expect(s.network.NextBlock()).To(BeNil())
 				}
 			})
 
 			It(fmt.Sprintf("should claw back from the vesting when sending as the funder (%s)", callType.name), func() {
-				res, err := s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err := s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePre := res.Balance
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ClawbackMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
-					differentAddr,
+					funder.Addr,
+					vestingKey.Addr,
+					clawbackReceiver,
 				}
 
 				clawbackCheck := passCheck.
 					WithExpEvents(vesting.EventTypeClawback)
 
-				_, ethRes, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, clawbackCheck)
+				_, ethRes, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, clawbackCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
@@ -689,38 +718,29 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				Expect(err).ToNot(HaveOccurred(), "error while unpacking the clawback output: %v", err)
 				Expect(co.Coins).To(Equal(balances), "expected different clawback amount")
 
-				res, err = s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err = s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePost := res.Balance
 				Expect(balancePost.Amount).To(Equal(balancePre.Amount.Sub(expClawbackAmt)), "expected only initial balance after clawback")
-				res, err = s.grpcHandler.GetBalance(differentAddr.Bytes(), s.bondDenom)
+				res, err = s.grpcHandler.GetBalance(clawbackReceiver.Bytes(), s.bondDenom)
 				Expect(err).To(BeNil())
 				balanceReceiver := res.Balance
 				Expect(balanceReceiver.Amount).To(Equal(expClawbackAmt), "expected receiver to show different balance after clawback")
 			})
 
 			It(fmt.Sprintf("should return an error when not sending as the funder (%s)", callType.name), func() {
-				// create and fund new account
-				differentAddr, differentPriv := testutiltx.NewAddrKey()
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					differentAddr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				differentSender := s.keyring.GetKey(2)
 
-				res, err := s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err := s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePre := res.Balance
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ClawbackMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
-					differentAddr,
+					funder.Addr,
+					vestingKey.Addr,
+					differentSender.Addr,
 				}
 
 				clawbackCheck := execRevertedCheck
@@ -728,36 +748,28 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					clawbackCheck = failCheck.
 						WithErrContains(fmt.Sprintf(
 							"tx origin address %s does not match the funder address %s",
-							differentAddr, s.keyring.GetAddr(0),
+							differentSender.Addr, funder.Addr,
 						))
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(differentPriv, txArgs, callArgs, clawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(differentSender.Priv, txArgs, callArgs, clawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 
-				res, err = s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err = s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePost := res.Balance
 				Expect(balancePost).To(Equal(balancePre), "expected balance not to have changed")
 			})
 
 			It(fmt.Sprintf("should return an error when the vesting does not exist (%s)", callType.name), func() {
-				// fund the new account
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					differentAddr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				nonVestingKey := s.keyring.GetKey(2)
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ClawbackMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
-					s.keyring.GetAddr(0),
+					funder.Addr,
+					nonVestingKey.Addr,
+					funder.Addr,
 				}
 
 				clawbackCheck := execRevertedCheck
@@ -767,7 +779,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 						WithErrContains(vestingtypes.ErrNotSubjectToClawback.Error())
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, clawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, clawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
@@ -776,19 +788,19 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				err := s.network.NextBlockAfter(time.Hour * 24)
 				Expect(err).ToNot(HaveOccurred(), "error while committing block: %v", err)
 
-				res, err := s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err := s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePre := res.Balance
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ClawbackMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
-					s.keyring.GetAddr(0),
+					funder.Addr,
+					vestingKey.Addr,
+					funder.Addr,
 				}
 
-				_, ethRes, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, passCheck)
+				_, ethRes, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, passCheck)
 				Expect(err).To(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
@@ -797,7 +809,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				Expect(err).ToNot(HaveOccurred(), "error while unpacking the clawback output: %v", err)
 				Expect(co.Coins).To(BeEmpty(), "expected empty clawback amount")
 
-				res, err = s.grpcHandler.GetBalance(s.keyring.GetAccAddr(vestingAccIdx), s.bondDenom)
+				res, err = s.grpcHandler.GetBalance(vestingKey.AccAddr, s.bondDenom)
 				Expect(err).To(BeNil())
 				balancePost := res.Balance
 				Expect(balancePost).To(Equal(balancePre), "expected balance not to have changed")
@@ -806,8 +818,16 @@ var _ = Describe("Interacting with the vesting extension", func() {
 	})
 
 	Context("to update the vesting funder", func() {
+		var (
+			funder, newFunder, vestingKey testkeyring.Key
+		)
+
 		BeforeEach(func() {
-			err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+			funder = s.keyring.GetKey(0)
+			vestingKey = s.keyring.GetKey(1)
+			newFunder = s.keyring.GetKey(2)
+
+			err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 			Expect(err).To(BeNil())
 			Expect(s.network.NextBlock()).To(BeNil())
 		})
@@ -829,7 +849,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					precompileAddr := s.precompile.Address()
 					logCheck := passCheck.WithExpEvents(authorization.EventTypeApproval)
 
-					_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
+					_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, evmtypes.EvmTxArgs{To: &precompileAddr}, approvalCallArgs, logCheck)
 					Expect(err).To(BeNil())
 					Expect(s.network.NextBlock()).To(BeNil())
 				}
@@ -839,39 +859,31 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					newFunder.Addr,
+					vestingKey.Addr,
 				}
 
 				updateFunderCheck := passCheck.
 					WithExpEvents(vesting.EventTypeUpdateVestingFunder)
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check that the vesting account has the new funder
-				s.ExpectVestingFunder(s.keyring.GetAddr(vestingAccIdx), differentAddr)
+				s.ExpectVestingFunder(vestingKey.Addr, newFunder.Addr)
 			})
 
 			It(fmt.Sprintf("should return an error when not sending as the funder (%s)", callType.name), func() {
-				differentAddr, differentPriv := testutiltx.NewAddrKey()
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					differentAddr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				differentSender := s.keyring.GetKey(2)
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					differentSender.Addr,
+					vestingKey.Addr,
 				}
 
 				updateFunderCheck := execRevertedCheck
@@ -879,16 +891,16 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					updateFunderCheck = failCheck.
 						WithErrContains(fmt.Sprintf(
 							"tx origin address %s does not match the funder address %s",
-							differentAddr.String(), s.keyring.GetAddr(0).String(),
+							differentSender.Addr, funder.Addr.String(),
 						))
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(differentPriv, txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(differentSender.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				// Check that the vesting account still has the same funder
-				s.ExpectVestingFunder(s.keyring.GetAddr(vestingAccIdx), s.keyring.GetAddr(0))
+				s.ExpectVestingFunder(vestingKey.Addr, funder.Addr)
 			})
 
 			It(fmt.Sprintf("should return an error when the account does not exist (%s)", callType.name), func() {
@@ -900,8 +912,8 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
+					funder.Addr,
+					newFunder.Addr,
 					nonExistentAddr, // the address of the vesting account
 				}
 
@@ -914,23 +926,14 @@ var _ = Describe("Interacting with the vesting extension", func() {
 						))
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
 			It(fmt.Sprintf("should return an error when the account is no vesting account (%s)", callType.name), func() {
-				// Check that there's no vesting account
-				nonVestingAddr := testutiltx.GenerateAddress()
-				err := testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					nonVestingAddr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding the account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				KeyWithNoVesting := s.keyring.GetKey(2)
 
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), nonVestingAddr.Bytes())
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), KeyWithNoVesting.AccAddr)
 				Expect(acc).ToNot(BeNil(), "expected account to be found")
 				_, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeFalse(), "expected account not to be a vesting account")
@@ -938,9 +941,9 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					differentAddr,
-					nonVestingAddr, // the address of the vesting account
+					funder.Addr,
+					newFunder.Addr,
+					KeyWithNoVesting.Addr, // the address of the vesting account
 				}
 
 				updateFunderCheck := execRevertedCheck
@@ -948,12 +951,12 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					updateFunderCheck = failCheck.
 						WithErrContains(fmt.Sprintf(
 							"%s: %s",
-							sdk.AccAddress(nonVestingAddr.Bytes()),
+							KeyWithNoVesting.AccAddr,
 							vestingtypes.ErrNotSubjectToClawback.Error(),
 						))
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
@@ -961,9 +964,9 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					common.Address{},
-					s.keyring.GetAddr(vestingAccIdx),
+					vestingKey.Addr,
 				}
 
 				updateFunderCheck := execRevertedCheck
@@ -972,7 +975,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 						WithErrContains("new funder address cannot be the zero address")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
@@ -980,9 +983,9 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(0),
-					s.keyring.GetAddr(vestingAccIdx),
+					funder.Addr,
+					funder.Addr,
+					vestingKey.Addr,
 				}
 
 				updateFunderCheck := execRevertedCheck
@@ -991,11 +994,11 @@ var _ = Describe("Interacting with the vesting extension", func() {
 						WithErrContains("new funder address is equal to current funder address")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 
 				// Check that the vesting account still has the same funder
-				s.ExpectVestingFunder(s.keyring.GetAddr(vestingAccIdx), s.keyring.GetAddr(0))
+				s.ExpectVestingFunder(vestingKey.Addr, funder.Addr)
 			})
 
 			It(fmt.Sprintf("should return an error when the new funder is a blocked address (%s)", callType.name), func() {
@@ -1004,9 +1007,9 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.UpdateVestingFunderMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(0),
+					funder.Addr,
 					moduleAddr,
-					s.keyring.GetAddr(vestingAccIdx),
+					vestingKey.Addr,
 				}
 
 				updateFunderCheck := execRevertedCheck
@@ -1015,21 +1018,29 @@ var _ = Describe("Interacting with the vesting extension", func() {
 						WithErrContains("not allowed to fund vesting accounts")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, updateFunderCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, updateFunderCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while updating the funder to a module address: %v", err)
 			})
 		}
 	})
 
 	Context("to convert a vesting account", func() {
+		var (
+			funder, vestingKey, KeyWithNoVesting testkeyring.Key
+		)
+
 		BeforeEach(func() {
+			funder = s.keyring.GetKey(0)
+			vestingKey = s.keyring.GetKey(1)
+			KeyWithNoVesting = s.keyring.GetKey(2)
+
 			// Create a vesting account
-			err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+			err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 			Expect(err).To(BeNil())
 			Expect(s.network.NextBlock()).To(BeNil())
 
 			// Fund vesting account
-			err = s.factory.FundVestingAccount(s.keyring.GetPrivKey(0), s.keyring.GetAccAddr(vestingAccIdx), time.Now(), sdkLockupPeriods, sdkVestingPeriods)
+			err = s.factory.FundVestingAccount(funder.Priv, vestingKey.AccAddr, time.Now(), sdkLockupPeriods, sdkVestingPeriods)
 			Expect(err).To(BeNil())
 			Expect(s.network.NextBlock()).To(BeNil())
 		})
@@ -1045,18 +1056,18 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ConvertVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(vestingAccIdx),
+					vestingKey.Addr,
 				}
 
 				convertClawbackCheck := passCheck.
 					WithExpEvents(vesting.EventTypeConvertVestingAccount)
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, convertClawbackCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, convertClawbackCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 				Expect(s.network.NextBlock()).To(BeNil(), "failed to commit block")
 
 				// Check that the vesting account has been converted
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), s.keyring.GetAccAddr(vestingAccIdx))
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), vestingKey.AccAddr)
 				Expect(acc).ToNot(BeNil(), "expected account to be found")
 				_, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeFalse(), "expected account not to be a vesting account")
@@ -1066,7 +1077,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ConvertVestingAccountMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(vestingAccIdx),
+					vestingKey.Addr,
 				}
 
 				convertClawbackCheck := execRevertedCheck
@@ -1074,24 +1085,15 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					convertClawbackCheck = failCheck.WithErrContains("vesting coins still left in account")
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, convertClawbackCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, convertClawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
 			It(fmt.Sprintf("should return an error when the vesting does not exist (%s)", callType.name), func() {
-				err = testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					differentAddr.Bytes(),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
-
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.ConvertVestingAccountMethod
 				callArgs.Args = []interface{}{
-					differentAddr, // this currently has no vesting
+					KeyWithNoVesting.Addr, // this currently has no vesting
 				}
 
 				convertClawbackCheck := execRevertedCheck
@@ -1099,11 +1101,11 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					convertClawbackCheck = failCheck.WithErrContains("account is not subject to clawback vesting")
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, convertClawbackCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, convertClawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 
 				// Check that the account is no vesting account
-				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), differentAddr.Bytes())
+				acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), KeyWithNoVesting.AccAddr)
 				Expect(acc).ToNot(BeNil(), "expected account to be found")
 				_, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 				Expect(ok).To(BeFalse(), "expected account not to be a vesting account")
@@ -1119,21 +1121,24 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			callType := callType
 
 			It(fmt.Sprintf("should return the vesting when it exists (%s)", callType.name), func() {
-				err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
+				funder := s.keyring.GetKey(0)
+				vestingKey := s.keyring.GetKey(1)
+
+				err = s.factory.CreateClawbackVestingAccount(vestingKey.Priv, funder.AccAddr, false)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
-				err = s.factory.FundVestingAccount(s.keyring.GetPrivKey(0), s.keyring.GetAccAddr(vestingAccIdx), time.Now(), sdkLockupPeriods, sdkVestingPeriods)
+				err = s.factory.FundVestingAccount(funder.Priv, vestingKey.AccAddr, time.Now(), sdkLockupPeriods, sdkVestingPeriods)
 				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.BalancesMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(vestingAccIdx),
+					vestingKey.Addr,
 				}
 
-				_, ethRes, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, passCheck)
+				_, ethRes, err := s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, passCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 
 				var res vesting.BalancesOutput
@@ -1150,7 +1155,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				Expect(err).To(BeNil(), "failed to commit block")
 
 				// Recheck balances
-				_, ethRes, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, passCheck)
+				_, ethRes, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, passCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 
 				err = s.precompile.UnpackIntoInterface(&res, vesting.BalancesMethod, ethRes.Ret)
@@ -1166,7 +1171,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				Expect(err).To(BeNil(), "failed to commit block")
 
 				// Recheck balances
-				_, ethRes, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, passCheck)
+				_, ethRes, err = s.factory.CallContractAndCheckLogs(funder.Priv, txArgs, callArgs, passCheck)
 				Expect(err).ToNot(HaveOccurred(), "error while calling the contract: %v", err)
 
 				err = s.precompile.UnpackIntoInterface(&res, vesting.BalancesMethod, ethRes.Ret)
@@ -1178,47 +1183,43 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			})
 
 			It(fmt.Sprintf("should return an error when the account does not exist (%s)", callType.name), func() {
+				sender := s.keyring.GetKey(0)
+				nonExistentAddr := testutiltx.GenerateAddress()
+
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.BalancesMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(vestingAccIdx),
+					nonExistentAddr,
 				}
 
 				balancesCheck := execRevertedCheck
 				if callType.directCall {
 					balancesCheck = failCheck.WithErrContains(fmt.Sprintf(
-						"account at address '%s' either does not exist or is not a vesting account", s.keyring.GetAccAddr(vestingAccIdx)))
+						"account at address '%s' either does not exist or is not a vesting account", sdk.AccAddress(nonExistentAddr.Bytes())))
 				}
 
-				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, balancesCheck)
+				_, _, err := s.factory.CallContractAndCheckLogs(sender.Priv, txArgs, callArgs, balancesCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 
 			It(fmt.Sprintf("should return an error when the account is not a vesting account (%s)", callType.name), func() {
-				err = testutils.FundAccountWithBaseDenom(
-					s.factory, s.network,
-					s.keyring.GetKey(0),
-					s.keyring.GetAccAddr(vestingAccIdx),
-					math.NewInt(1e18),
-				)
-				Expect(err).ToNot(HaveOccurred(), "error while funding account: %v", err)
-				Expect(s.network.NextBlock()).To(BeNil())
+				KeyWithNoVesting := s.keyring.GetKey(0)
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)
 				callArgs.MethodName = vesting.BalancesMethod
 				callArgs.Args = []interface{}{
-					s.keyring.GetAddr(vestingAccIdx),
+					KeyWithNoVesting.Addr,
 				}
 
 				balancesCheck := execRevertedCheck
 				if callType.directCall {
 					balancesCheck = failCheck.WithErrContains(fmt.Sprintf(
 						"account at address '%s' either does not exist or is not a vesting account",
-						s.keyring.GetAccAddr(vestingAccIdx),
+						KeyWithNoVesting.AccAddr,
 					))
 				}
 
-				_, _, err = s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, balancesCheck)
+				_, _, err = s.factory.CallContractAndCheckLogs(KeyWithNoVesting.Priv, txArgs, callArgs, balancesCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
 		}

--- a/precompiles/vesting/integration_test.go
+++ b/precompiles/vesting/integration_test.go
@@ -257,6 +257,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				err = s.factory.CreateClawbackVestingAccount(priv, s.keyring.GetAccAddr(0), false)
+				Expect(err).To(BeNil())
 				Expect(s.network.NextBlock()).To(BeNil())
 
 				callArgs, txArgs := s.BuildCallArgs(callType, contractAddr)

--- a/precompiles/vesting/integration_test.go
+++ b/precompiles/vesting/integration_test.go
@@ -1022,6 +1022,11 @@ var _ = Describe("Interacting with the vesting extension", func() {
 			err = s.factory.CreateClawbackVestingAccount(s.keyring.GetPrivKey(vestingAccIdx), s.keyring.GetAccAddr(0), false)
 			Expect(err).To(BeNil())
 			Expect(s.network.NextBlock()).To(BeNil())
+
+			// Fund vesting account
+			err = s.factory.FundVestingAccount(s.keyring.GetPrivKey(0), s.keyring.GetAccAddr(vestingAccIdx), time.Now(), sdkLockupPeriods, sdkVestingPeriods)
+			Expect(err).To(BeNil())
+			Expect(s.network.NextBlock()).To(BeNil())
 		})
 
 		for _, callType := range callTypes {
@@ -1063,7 +1068,6 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					convertClawbackCheck = failCheck.WithErrContains("vesting coins still left in account")
 				}
 
-				txArgs.GasLimit = 300_000
 				_, _, err := s.factory.CallContractAndCheckLogs(s.keyring.GetPrivKey(0), txArgs, callArgs, convertClawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})
@@ -1094,7 +1098,6 @@ var _ = Describe("Interacting with the vesting extension", func() {
 					convertClawbackCheck = failCheck.WithErrContains("sender is not the funder")
 				}
 
-				txArgs.GasLimit = 300_000
 				_, _, err = s.factory.CallContractAndCheckLogs(differentPriv, txArgs, callArgs, convertClawbackCheck)
 				Expect(err).NotTo(HaveOccurred(), "error while calling the contract: %v", err)
 			})

--- a/precompiles/vesting/integration_test.go
+++ b/precompiles/vesting/integration_test.go
@@ -818,9 +818,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 	})
 
 	Context("to update the vesting funder", func() {
-		var (
-			funder, newFunder, vestingKey testkeyring.Key
-		)
+		var funder, newFunder, vestingKey testkeyring.Key
 
 		BeforeEach(func() {
 			funder = s.keyring.GetKey(0)
@@ -1025,9 +1023,7 @@ var _ = Describe("Interacting with the vesting extension", func() {
 	})
 
 	Context("to convert a vesting account", func() {
-		var (
-			funder, vestingKey, KeyWithNoVesting testkeyring.Key
-		)
+		var funder, vestingKey, KeyWithNoVesting testkeyring.Key
 
 		BeforeEach(func() {
 			funder = s.keyring.GetKey(0)

--- a/precompiles/vesting/query_test.go
+++ b/precompiles/vesting/query_test.go
@@ -5,11 +5,13 @@ package vesting_test
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	cmn "github.com/evmos/evmos/v16/precompiles/common"
 	"github.com/evmos/evmos/v16/precompiles/vesting"
 )
 
 func (s *PrecompileTestSuite) TestBalances() {
+	var ctx sdk.Context
 	method := s.precompile.Methods[vesting.BalancesMethod]
 
 	testCases := []struct {
@@ -57,7 +59,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 		{
 			"success - should return vesting account balances",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
+				s.CreateTestClawbackVestingAccount(ctx, s.keyring.GetAddr(0), toAddr)
 				s.FundTestClawbackVestingAccount()
 				return []interface{}{
 					toAddr,
@@ -79,8 +81,9 @@ func (s *PrecompileTestSuite) TestBalances() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			s.SetupTest() // reset
+			ctx = s.network.GetContext()
 
-			bz, err := s.precompile.Balances(s.network.GetContext(), &method, tc.malleate())
+			bz, err := s.precompile.Balances(ctx, &method, tc.malleate())
 
 			if tc.expError {
 				s.Require().Error(err)

--- a/precompiles/vesting/query_test.go
+++ b/precompiles/vesting/query_test.go
@@ -12,7 +12,6 @@ import (
 
 func (s *PrecompileTestSuite) TestBalances() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.BalancesMethod]
 
 	testCases := []struct {
 		name        string
@@ -82,6 +81,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2) // reset
 			ctx = s.network.GetContext()
+			method := s.precompile.Methods[vesting.BalancesMethod]
 
 			bz, err := s.precompile.Balances(ctx, &method, tc.malleate())
 

--- a/precompiles/vesting/query_test.go
+++ b/precompiles/vesting/query_test.go
@@ -46,7 +46,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 			"fail - account is not a vesting account",
 			func() []interface{} {
 				return []interface{}{
-					s.address,
+					s.keyring.GetAddr(0),
 				}
 			},
 			200000,
@@ -57,7 +57,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 		{
 			"success - should return vesting account balances",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.address, toAddr)
+				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
 				s.FundTestClawbackVestingAccount()
 				return []interface{}{
 					toAddr,
@@ -80,7 +80,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 		s.Run(tc.name, func() {
 			s.SetupTest() // reset
 
-			bz, err := s.precompile.Balances(s.ctx, &method, tc.malleate())
+			bz, err := s.precompile.Balances(s.network.GetContext(), &method, tc.malleate())
 
 			if tc.expError {
 				s.Require().Error(err)

--- a/precompiles/vesting/query_test.go
+++ b/precompiles/vesting/query_test.go
@@ -80,7 +80,7 @@ func (s *PrecompileTestSuite) TestBalances() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest() // reset
+			s.SetupTest(2) // reset
 			ctx = s.network.GetContext()
 
 			bz, err := s.precompile.Balances(ctx, &method, tc.malleate())

--- a/precompiles/vesting/setup_test.go
+++ b/precompiles/vesting/setup_test.go
@@ -29,8 +29,8 @@ func TestPrecompileUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(PrecompileTestSuite))
 }
 
-func (s *PrecompileTestSuite) SetupTest() {
-	keyring := testkeyring.New(2)
+func (s *PrecompileTestSuite) SetupTest(nKeys int) {
+	keyring := testkeyring.New(nKeys)
 	nw := network.NewUnitTestNetwork(
 		network.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
 	)

--- a/precompiles/vesting/setup_test.go
+++ b/precompiles/vesting/setup_test.go
@@ -5,53 +5,55 @@ package vesting_test
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	evmosapp "github.com/evmos/evmos/v16/app"
 	"github.com/evmos/evmos/v16/precompiles/vesting"
-	"github.com/evmos/evmos/v16/x/evm/statedb"
-	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
+	"github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
+	"github.com/evmos/evmos/v16/testutil/integration/evmos/grpc"
+	testkeyring "github.com/evmos/evmos/v16/testutil/integration/evmos/keyring"
+	"github.com/evmos/evmos/v16/testutil/integration/evmos/network"
 	"github.com/stretchr/testify/suite"
-
-	//nolint:revive // dot imports are fine for Ginkgo
-	. "github.com/onsi/ginkgo/v2"
-	//nolint:revive // dot imports are fine for Ginkgo
-	. "github.com/onsi/gomega"
 )
-
-var s *PrecompileTestSuite
 
 type PrecompileTestSuite struct {
 	suite.Suite
 
-	ctx        sdk.Context
-	app        *evmosapp.Evmos
-	address    common.Address
-	validators []stakingtypes.Validator
-	ethSigner  ethtypes.Signer
-	privKey    cryptotypes.PrivKey
-	signer     keyring.Signer
+	network     *network.UnitTestNetwork
+	factory     factory.TxFactory
+	grpcHandler grpc.Handler
+	keyring     testkeyring.Keyring
+
 	bondDenom  string
-
 	precompile *vesting.Precompile
-	stateDB    *statedb.StateDB
-
-	queryClientEVM evmtypes.QueryClient
 }
 
-func TestPrecompileTestSuite(t *testing.T) {
-	s = new(PrecompileTestSuite)
-	suite.Run(t, s)
-
-	// Run Ginkgo integration tests
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Precompile Test Suite")
+func TestPrecompileUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(PrecompileTestSuite))
 }
 
 func (s *PrecompileTestSuite) SetupTest() {
-	s.DoSetupTest()
+	keyring := testkeyring.New(2)
+	nw := network.NewUnitTestNetwork(
+		network.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
+	)
+	grpcHandler := grpc.NewIntegrationHandler(nw)
+	txFactory := factory.New(nw, grpcHandler)
+
+	ctx := nw.GetContext()
+	sk := nw.App.StakingKeeper
+	bondDenom, err := sk.BondDenom(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	s.bondDenom = bondDenom
+	s.factory = txFactory
+	s.grpcHandler = grpcHandler
+	s.keyring = keyring
+	s.network = nw
+
+	if s.precompile, err = vesting.NewPrecompile(
+		s.network.App.VestingKeeper,
+		s.network.App.AuthzKeeper,
+	); err != nil {
+		panic(err)
+	}
 }

--- a/precompiles/vesting/tx_test.go
+++ b/precompiles/vesting/tx_test.go
@@ -101,7 +101,6 @@ func (s *PrecompileTestSuite) TestCreateClawbackVestingAccount() {
 		s.Run(tc.name, func() {
 			s.SetupTest()
 			ctx = s.network.GetContext()
-
 			bz, err := s.precompile.CreateClawbackVestingAccount(ctx, s.keyring.GetAddr(0), s.network.GetStateDB(), &method, tc.malleate())
 
 			if tc.expError {

--- a/precompiles/vesting/tx_test.go
+++ b/precompiles/vesting/tx_test.go
@@ -109,7 +109,7 @@ func (s *PrecompileTestSuite) TestCreateClawbackVestingAccount() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupTest(2)
 			ctx = s.network.GetContext()
 			bz, err := s.precompile.CreateClawbackVestingAccount(ctx, s.keyring.GetAddr(0), s.network.GetStateDB(), &method, tc.malleate())
 
@@ -194,7 +194,7 @@ func (s *PrecompileTestSuite) TestFundVestingAccount() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupTest(2)
 			ctx = s.network.GetContext()
 
 			var contract *vm.Contract
@@ -274,7 +274,7 @@ func (s *PrecompileTestSuite) TestClawback() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupTest(2)
 			ctx = s.network.GetContext()
 
 			var contract *vm.Contract
@@ -362,7 +362,7 @@ func (s *PrecompileTestSuite) TestUpdateVestingFunder() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupTest(2)
 			ctx = s.network.GetContext()
 
 			var contract *vm.Contract
@@ -441,7 +441,7 @@ func (s *PrecompileTestSuite) TestConvertVestingAccount() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			s.SetupTest()
+			s.SetupTest(2)
 			ctx = s.network.GetContext()
 
 			bz, err := s.precompile.ConvertVestingAccount(ctx, s.network.GetStateDB(), &method, tc.malleate())

--- a/precompiles/vesting/tx_test.go
+++ b/precompiles/vesting/tx_test.go
@@ -49,7 +49,6 @@ var (
 
 func (s *PrecompileTestSuite) TestCreateClawbackVestingAccount() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.CreateClawbackVestingAccountMethod]
 
 	testCases := []struct {
 		name        string
@@ -111,7 +110,17 @@ func (s *PrecompileTestSuite) TestCreateClawbackVestingAccount() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2)
 			ctx = s.network.GetContext()
-			bz, err := s.precompile.CreateClawbackVestingAccount(ctx, s.keyring.GetAddr(0), s.network.GetStateDB(), &method, tc.malleate())
+			method := s.precompile.Methods[vesting.CreateClawbackVestingAccountMethod]
+
+			createArgs := tc.malleate()
+
+			bz, err := s.precompile.CreateClawbackVestingAccount(
+				ctx,
+				s.keyring.GetAddr(0),
+				s.network.GetStateDB(),
+				&method,
+				createArgs,
+			)
 
 			if tc.expError {
 				s.Require().ErrorContains(err, tc.errContains)
@@ -126,7 +135,6 @@ func (s *PrecompileTestSuite) TestCreateClawbackVestingAccount() {
 
 func (s *PrecompileTestSuite) TestFundVestingAccount() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.FundVestingAccountMethod]
 
 	testCases := []struct {
 		name        string
@@ -196,6 +204,7 @@ func (s *PrecompileTestSuite) TestFundVestingAccount() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2)
 			ctx = s.network.GetContext()
+			method := s.precompile.Methods[vesting.FundVestingAccountMethod]
 
 			var contract *vm.Contract
 			contract, ctx = testutil.NewPrecompileContract(s.T(), ctx, s.keyring.GetAddr(0), s.precompile, tc.gas)
@@ -215,7 +224,6 @@ func (s *PrecompileTestSuite) TestFundVestingAccount() {
 
 func (s *PrecompileTestSuite) TestClawback() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.ClawbackMethod]
 
 	testCases := []struct {
 		name        string
@@ -276,6 +284,7 @@ func (s *PrecompileTestSuite) TestClawback() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2)
 			ctx = s.network.GetContext()
+			method := s.precompile.Methods[vesting.ClawbackMethod]
 
 			var contract *vm.Contract
 			contract, ctx = testutil.NewPrecompileContract(s.T(), ctx, s.keyring.GetAddr(0), s.precompile, tc.gas)
@@ -295,7 +304,6 @@ func (s *PrecompileTestSuite) TestClawback() {
 
 func (s *PrecompileTestSuite) TestUpdateVestingFunder() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.UpdateVestingFunderMethod]
 
 	testCases := []struct {
 		name        string
@@ -364,6 +372,7 @@ func (s *PrecompileTestSuite) TestUpdateVestingFunder() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2)
 			ctx = s.network.GetContext()
+			method := s.precompile.Methods[vesting.UpdateVestingFunderMethod]
 
 			var contract *vm.Contract
 			contract, ctx = testutil.NewPrecompileContract(s.T(), ctx, s.keyring.GetAddr(0), s.precompile, tc.gas)
@@ -383,7 +392,6 @@ func (s *PrecompileTestSuite) TestUpdateVestingFunder() {
 
 func (s *PrecompileTestSuite) TestConvertVestingAccount() {
 	var ctx sdk.Context
-	method := s.precompile.Methods[vesting.ConvertVestingAccountMethod]
 
 	testCases := []struct {
 		name        string
@@ -443,6 +451,7 @@ func (s *PrecompileTestSuite) TestConvertVestingAccount() {
 		s.Run(tc.name, func() {
 			s.SetupTest(2)
 			ctx = s.network.GetContext()
+			method := s.precompile.Methods[vesting.ConvertVestingAccountMethod]
 
 			bz, err := s.precompile.ConvertVestingAccount(ctx, s.network.GetStateDB(), &method, tc.malleate())
 

--- a/precompiles/vesting/tx_test.go
+++ b/precompiles/vesting/tx_test.go
@@ -9,10 +9,12 @@ import (
 
 	"cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/evmos/evmos/v16/precompiles/testutil"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
 	cmn "github.com/evmos/evmos/v16/precompiles/common"
+	"github.com/evmos/evmos/v16/precompiles/testutil"
 	"github.com/evmos/evmos/v16/precompiles/vesting"
 	evmosutil "github.com/evmos/evmos/v16/testutil"
 	evmosutiltx "github.com/evmos/evmos/v16/testutil/tx"
@@ -25,15 +27,23 @@ var (
 	balances         = []cmn.Coin{{Denom: utils.BaseDenom, Amount: big.NewInt(1000)}}
 	quarter          = []cmn.Coin{{Denom: utils.BaseDenom, Amount: big.NewInt(250)}}
 	balancesSdkCoins = sdk.NewCoins(sdk.NewInt64Coin(utils.BaseDenom, 1000))
+	quarterSdkCoins  = sdk.NewCoins(sdk.NewInt64Coin(utils.BaseDenom, 250))
 	toAddr           = evmosutiltx.GenerateAddress()
 	funderAddr       = evmosutiltx.GenerateAddress()
 	diffFunderAddr   = evmosutiltx.GenerateAddress()
 	lockupPeriods    = []vesting.Period{{Length: 5000, Amount: balances}}
+	sdkLockupPeriods = []sdkvesting.Period{{Length: 5000, Amount: balancesSdkCoins}}
 	vestingPeriods   = []vesting.Period{
 		{Length: 2000, Amount: quarter},
 		{Length: 2000, Amount: quarter},
 		{Length: 2000, Amount: quarter},
 		{Length: 2000, Amount: quarter},
+	}
+	sdkVestingPeriods = []sdkvesting.Period{
+		{Length: 2000, Amount: quarterSdkCoins},
+		{Length: 2000, Amount: quarterSdkCoins},
+		{Length: 2000, Amount: quarterSdkCoins},
+		{Length: 2000, Amount: quarterSdkCoins},
 	}
 )
 
@@ -155,7 +165,7 @@ func (s *PrecompileTestSuite) TestFundVestingAccount() {
 		{
 			"success",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
+				s.CreateTestClawbackVestingAccount(ctx, s.keyring.GetAddr(0), toAddr)
 				err = evmosutil.FundAccount(ctx, s.network.App.BankKeeper, toAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
 				return []interface{}{
 					s.keyring.GetAddr(0),
@@ -242,7 +252,7 @@ func (s *PrecompileTestSuite) TestClawback() {
 		{
 			"success",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
+				s.CreateTestClawbackVestingAccount(ctx, s.keyring.GetAddr(0), toAddr)
 				s.FundTestClawbackVestingAccount()
 				return []interface{}{
 					s.keyring.GetAddr(0),
@@ -322,7 +332,7 @@ func (s *PrecompileTestSuite) TestUpdateVestingFunder() {
 		{
 			"success",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
+				s.CreateTestClawbackVestingAccount(ctx, s.keyring.GetAddr(0), toAddr)
 				vestingAcc := s.network.App.AccountKeeper.GetAccount(ctx, toAddr.Bytes())
 				va, ok := vestingAcc.(*vestingtypes.ClawbackVestingAccount)
 				s.Require().True(ok)
@@ -408,7 +418,7 @@ func (s *PrecompileTestSuite) TestConvertVestingAccount() {
 		{
 			"success",
 			func() []interface{} {
-				s.CreateTestClawbackVestingAccount(s.keyring.GetAddr(0), toAddr)
+				s.CreateTestClawbackVestingAccount(ctx, s.keyring.GetAddr(0), toAddr)
 				return []interface{}{
 					toAddr,
 				}

--- a/precompiles/vesting/utils_test.go
+++ b/precompiles/vesting/utils_test.go
@@ -58,6 +58,7 @@ func (s *PrecompileTestSuite) FundTestClawbackVestingAccount() {
 	createArgs := []interface{}{s.keyring.GetAddr(0), toAddr, uint64(time.Now().Unix()), lockupPeriods, vestingPeriods}
 	//nolint
 	msg, _, _, _, _, err := vesting.NewMsgFundVestingAccount(createArgs, &method)
+	s.Require().NoError(err)
 	_, err = s.network.App.VestingKeeper.FundVestingAccount(s.network.GetContext(), msg)
 	s.Require().NoError(err)
 	vestingAcc, err := s.network.App.VestingKeeper.Balances(s.network.GetContext(), &vestingtypes.QueryBalancesRequest{Address: sdk.AccAddress(toAddr.Bytes()).String()})
@@ -66,14 +67,15 @@ func (s *PrecompileTestSuite) FundTestClawbackVestingAccount() {
 	s.Require().Equal(vestingAcc.Unvested, balancesSdkCoins)
 }
 
-// CreateTestClawbackVestingAccount creates a vesting account that can clawback
-func (s *PrecompileTestSuite) CreateTestClawbackVestingAccount(funder, vestingAddr common.Address) {
+// CreateTestClawbackVestingAccount creates a vesting account that can clawback.
+// Useful for unit tests only
+func (s *PrecompileTestSuite) CreateTestClawbackVestingAccount(ctx sdk.Context, funder, vestingAddr common.Address) {
 	msgArgs := []interface{}{funder, vestingAddr, false}
 	//nolint
 	msg, _, _, err := vesting.NewMsgCreateClawbackVestingAccount(msgArgs)
-	err = evmosutil.FundAccount(s.network.GetContext(), s.network.App.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
+	err = evmosutil.FundAccount(ctx, s.network.App.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
 	s.Require().NoError(err)
-	_, err = s.network.App.VestingKeeper.CreateClawbackVestingAccount(s.network.GetContext(), msg)
+	_, err = s.network.App.VestingKeeper.CreateClawbackVestingAccount(ctx, msg)
 	s.Require().NoError(err)
 }
 

--- a/precompiles/vesting/utils_test.go
+++ b/precompiles/vesting/utils_test.go
@@ -56,7 +56,6 @@ func (s *PrecompileTestSuite) BuildCallArgs(
 func (s *PrecompileTestSuite) FundTestClawbackVestingAccount() {
 	method := s.precompile.Methods[vesting.FundVestingAccountMethod]
 	createArgs := []interface{}{s.keyring.GetAddr(0), toAddr, uint64(time.Now().Unix()), lockupPeriods, vestingPeriods}
-	//nolint
 	msg, _, _, _, _, err := vesting.NewMsgFundVestingAccount(createArgs, &method)
 	s.Require().NoError(err)
 	_, err = s.network.App.VestingKeeper.FundVestingAccount(s.network.GetContext(), msg)
@@ -71,7 +70,6 @@ func (s *PrecompileTestSuite) FundTestClawbackVestingAccount() {
 // Useful for unit tests only
 func (s *PrecompileTestSuite) CreateTestClawbackVestingAccount(ctx sdk.Context, funder, vestingAddr common.Address) {
 	msgArgs := []interface{}{funder, vestingAddr, false}
-	//nolint
 	msg, _, _, err := vesting.NewMsgCreateClawbackVestingAccount(msgArgs)
 	s.Require().NoError(err)
 	err = evmosutil.FundAccount(ctx, s.network.App.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))

--- a/precompiles/vesting/utils_test.go
+++ b/precompiles/vesting/utils_test.go
@@ -73,6 +73,7 @@ func (s *PrecompileTestSuite) CreateTestClawbackVestingAccount(ctx sdk.Context, 
 	msgArgs := []interface{}{funder, vestingAddr, false}
 	//nolint
 	msg, _, _, err := vesting.NewMsgCreateClawbackVestingAccount(msgArgs)
+	s.Require().NoError(err)
 	err = evmosutil.FundAccount(ctx, s.network.App.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
 	s.Require().NoError(err)
 	_, err = s.network.App.VestingKeeper.CreateClawbackVestingAccount(ctx, msg)

--- a/precompiles/vesting/utils_test.go
+++ b/precompiles/vesting/utils_test.go
@@ -3,207 +3,22 @@
 package vesting_test
 
 import (
-	"encoding/json"
 	"time"
 
 	"cosmossdk.io/math"
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/crypto/tmhash"
-	cmttypes "github.com/cometbft/cometbft/types"
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	evmosapp "github.com/evmos/evmos/v16/app"
-	cmn "github.com/evmos/evmos/v16/precompiles/common"
-	"github.com/evmos/evmos/v16/precompiles/testutil/contracts"
 	"github.com/evmos/evmos/v16/precompiles/vesting"
 	"github.com/evmos/evmos/v16/precompiles/vesting/testdata"
 	evmosutil "github.com/evmos/evmos/v16/testutil"
-	testutiltx "github.com/evmos/evmos/v16/testutil/tx"
-	evmostypes "github.com/evmos/evmos/v16/types"
+	"github.com/evmos/evmos/v16/testutil/integration/evmos/factory"
 	"github.com/evmos/evmos/v16/utils"
-	"github.com/evmos/evmos/v16/x/evm/statedb"
 	evmtypes "github.com/evmos/evmos/v16/x/evm/types"
-	inflationtypes "github.com/evmos/evmos/v16/x/inflation/v1/types"
 	vestingtypes "github.com/evmos/evmos/v16/x/vesting/types"
 
 	//nolint:revive // dot imports are fine for Ginkgo
 	. "github.com/onsi/gomega"
 )
-
-// SetupWithGenesisValSet initializes a new EvmosApp with a validator set and genesis accounts
-// that also act as delegators. For simplicity, each validator is bonded with a delegation
-// of one consensus engine unit (10^6) in the default token of the simapp from first genesis
-// account. A Nop logger is set in SimApp.
-func (s *PrecompileTestSuite) SetupWithGenesisValSet(valSet *cmttypes.ValidatorSet, genAccs []authtypes.GenesisAccount, balances ...banktypes.Balance) {
-	appI, genesisState := evmosapp.SetupTestingApp(cmn.DefaultChainID)()
-	app, ok := appI.(*evmosapp.Evmos)
-	s.Require().True(ok)
-
-	// set genesis accounts
-	authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), genAccs)
-	genesisState[authtypes.ModuleName] = app.AppCodec().MustMarshalJSON(authGenesis)
-
-	validators := make([]stakingtypes.Validator, 0, len(valSet.Validators))
-	delegations := make([]stakingtypes.Delegation, 0, len(valSet.Validators))
-
-	bondAmt := sdk.TokensFromConsensusPower(1, evmostypes.PowerReduction)
-
-	for _, val := range valSet.Validators {
-		pk, err := cryptocodec.FromTmPubKeyInterface(val.PubKey)
-		s.Require().NoError(err)
-		pkAny, err := codectypes.NewAnyWithValue(pk)
-		s.Require().NoError(err)
-		validator := stakingtypes.Validator{
-			OperatorAddress:   sdk.ValAddress(val.Address).String(),
-			ConsensusPubkey:   pkAny,
-			Jailed:            false,
-			Status:            stakingtypes.Bonded,
-			Tokens:            bondAmt,
-			DelegatorShares:   math.LegacyOneDec(),
-			Description:       stakingtypes.Description{},
-			UnbondingHeight:   int64(0),
-			UnbondingTime:     time.Unix(0, 0).UTC(),
-			Commission:        stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()),
-			MinSelfDelegation: math.ZeroInt(),
-		}
-		validators = append(validators, validator)
-		delegations = append(delegations, stakingtypes.NewDelegation(genAccs[0].GetAddress().String(), sdk.ValAddress(val.Address).String(), math.LegacyOneDec()))
-	}
-	s.validators = validators
-
-	// set validators and delegations
-	stakingParams := stakingtypes.DefaultParams()
-	// set bond demon to be aevmos
-	stakingParams.BondDenom = utils.BaseDenom
-	stakingGenesis := stakingtypes.NewGenesisState(stakingParams, validators, delegations)
-	genesisState[stakingtypes.ModuleName] = app.AppCodec().MustMarshalJSON(stakingGenesis)
-
-	totalBondAmt := math.ZeroInt()
-	for range validators {
-		totalBondAmt = totalBondAmt.Add(bondAmt)
-	}
-	totalSupply := sdk.NewCoins()
-	for _, b := range balances {
-		// add genesis acc tokens and delegated tokens to total supply
-		totalSupply = totalSupply.Add(b.Coins.Add(sdk.NewCoin(utils.BaseDenom, totalBondAmt))...)
-	}
-
-	// add bonded amount to bonded pool module account
-	balances = append(balances, banktypes.Balance{
-		Address: authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String(),
-		Coins:   sdk.Coins{sdk.NewCoin(utils.BaseDenom, totalBondAmt)},
-	})
-
-	// update total supply
-	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.SendEnabled{})
-	genesisState[banktypes.ModuleName] = app.AppCodec().MustMarshalJSON(bankGenesis)
-
-	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
-	s.Require().NoError(err)
-
-	header := evmosutil.NewHeader(
-		2,
-		time.Now().UTC(),
-		cmn.DefaultChainID,
-		sdk.ConsAddress(validators[0].GetOperator()),
-		tmhash.Sum([]byte("app")),
-		tmhash.Sum([]byte("validators")),
-	)
-
-	// init chain will set the validator set and initialize the genesis accounts
-	app.InitChain(
-		&abci.RequestInitChain{
-			ChainId:         cmn.DefaultChainID,
-			Validators:      []abci.ValidatorUpdate{},
-			ConsensusParams: evmosapp.DefaultConsensusParams,
-			AppStateBytes:   stateBytes,
-		},
-	)
-
-	// create Context
-	s.ctx = app.BaseApp.NewContextLegacy(false, header)
-
-	// commit genesis changes
-	app.Commit()
-	app.BeginBlocker(s.ctx)
-
-	s.app = app
-}
-
-func (s *PrecompileTestSuite) DoSetupTest() {
-	nValidators := 3
-	signers := make(map[string]cmttypes.PrivValidator, nValidators)
-	validators := make([]*cmttypes.Validator, 0, nValidators)
-
-	for i := 0; i < nValidators; i++ {
-		privVal := mock.NewPV()
-		pubKey, err := privVal.GetPubKey()
-		s.Require().NoError(err)
-		signers[pubKey.Address().String()] = privVal
-		validator := cmttypes.NewValidator(pubKey, 1)
-		validators = append(validators, validator)
-	}
-
-	valSet := cmttypes.NewValidatorSet(validators)
-
-	// generate genesis account
-	addr, priv := testutiltx.NewAddrKey()
-	s.privKey = priv
-	s.address = addr
-	s.signer = testutiltx.NewSigner(priv)
-
-	baseAcc := authtypes.NewBaseAccount(priv.PubKey().Address().Bytes(), priv.PubKey(), 0, 0)
-
-	acc := &evmostypes.EthAccount{
-		BaseAccount: baseAcc,
-		CodeHash:    common.BytesToHash(evmtypes.EmptyCodeHash).Hex(),
-	}
-
-	amount := sdk.TokensFromConsensusPower(5, evmostypes.PowerReduction)
-
-	balance := banktypes.Balance{
-		Address: acc.GetAddress().String(),
-		Coins:   sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, amount)),
-	}
-
-	s.SetupWithGenesisValSet(valSet, []authtypes.GenesisAccount{acc}, balance)
-
-	// Create StateDB
-	s.stateDB = statedb.New(s.ctx, s.app.EvmKeeper, statedb.NewEmptyTxConfig(common.BytesToHash(s.ctx.HeaderHash())))
-
-	// bond denom
-	stakingParams, err := s.app.StakingKeeper.GetParams(s.ctx)
-	s.Require().NoError(err)
-	stakingParams.BondDenom = utils.BaseDenom
-	s.bondDenom = stakingParams.BondDenom
-	err = s.app.StakingKeeper.SetParams(s.ctx, stakingParams)
-	s.Require().NoError(err, "failed to set params")
-
-	s.ethSigner = ethtypes.LatestSignerForChainID(s.app.EvmKeeper.ChainID())
-
-	precompile, err := vesting.NewPrecompile(s.app.VestingKeeper, s.app.AuthzKeeper)
-	s.Require().NoError(err)
-	s.precompile = precompile
-
-	coins := sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(5000000000000000000)))
-	distrCoins := sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(2000000000000000000)))
-	err = s.app.BankKeeper.MintCoins(s.ctx, inflationtypes.ModuleName, coins)
-	s.Require().NoError(err)
-	err = s.app.BankKeeper.SendCoinsFromModuleToModule(s.ctx, inflationtypes.ModuleName, authtypes.FeeCollectorName, distrCoins)
-	s.Require().NoError(err)
-
-	queryHelperEvm := baseapp.NewQueryServerTestHelper(s.ctx, s.app.InterfaceRegistry())
-	evmtypes.RegisterQueryServer(queryHelperEvm, s.app.EvmKeeper)
-	s.queryClientEVM = evmtypes.NewQueryClient(queryHelperEvm)
-}
 
 // CallType is a struct that represents the type of call to be made to the
 // precompile - either direct or through a smart contract.
@@ -219,30 +34,33 @@ type CallType struct {
 func (s *PrecompileTestSuite) BuildCallArgs(
 	callType CallType,
 	contractAddr common.Address,
-) contracts.CallArgs {
-	callArgs := contracts.CallArgs{
-		PrivKey: s.privKey,
-	}
+) (factory.CallArgs, evmtypes.EvmTxArgs) {
+	var (
+		to       common.Address
+		callArgs = factory.CallArgs{}
+		txArgs   = evmtypes.EvmTxArgs{}
+	)
+
 	if callType.directCall {
 		callArgs.ContractABI = s.precompile.ABI
-		callArgs.ContractAddr = s.precompile.Address()
+		to = s.precompile.Address()
 	} else {
-		callArgs.ContractAddr = contractAddr
+		to = contractAddr
 		callArgs.ContractABI = testdata.VestingCallerContract.ABI
 	}
-
-	return callArgs
+	txArgs.To = &to
+	return callArgs, txArgs
 }
 
 // FundTestClawbackVestingAccount funds the clawback vesting account with some tokens
 func (s *PrecompileTestSuite) FundTestClawbackVestingAccount() {
 	method := s.precompile.Methods[vesting.FundVestingAccountMethod]
-	createArgs := []interface{}{s.address, toAddr, uint64(time.Now().Unix()), lockupPeriods, vestingPeriods}
+	createArgs := []interface{}{s.keyring.GetAddr(0), toAddr, uint64(time.Now().Unix()), lockupPeriods, vestingPeriods}
 	//nolint
 	msg, _, _, _, _, err := vesting.NewMsgFundVestingAccount(createArgs, &method)
-	_, err = s.app.VestingKeeper.FundVestingAccount(s.ctx, msg)
+	_, err = s.network.App.VestingKeeper.FundVestingAccount(s.network.GetContext(), msg)
 	s.Require().NoError(err)
-	vestingAcc, err := s.app.VestingKeeper.Balances(s.ctx, &vestingtypes.QueryBalancesRequest{Address: sdk.AccAddress(toAddr.Bytes()).String()})
+	vestingAcc, err := s.network.App.VestingKeeper.Balances(s.network.GetContext(), &vestingtypes.QueryBalancesRequest{Address: sdk.AccAddress(toAddr.Bytes()).String()})
 	s.Require().NoError(err)
 	s.Require().Equal(vestingAcc.Locked, balancesSdkCoins)
 	s.Require().Equal(vestingAcc.Unvested, balancesSdkCoins)
@@ -253,22 +71,10 @@ func (s *PrecompileTestSuite) CreateTestClawbackVestingAccount(funder, vestingAd
 	msgArgs := []interface{}{funder, vestingAddr, false}
 	//nolint
 	msg, _, _, err := vesting.NewMsgCreateClawbackVestingAccount(msgArgs)
-	err = evmosutil.FundAccount(s.ctx, s.app.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
+	err = evmosutil.FundAccount(s.network.GetContext(), s.network.App.BankKeeper, vestingAddr.Bytes(), sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, math.NewInt(100))))
 	s.Require().NoError(err)
-	_, err = s.app.VestingKeeper.CreateClawbackVestingAccount(s.ctx, msg)
+	_, err = s.network.App.VestingKeeper.CreateClawbackVestingAccount(s.network.GetContext(), msg)
 	s.Require().NoError(err)
-}
-
-// DeployContract deploys a contract that calls the staking precompile's methods for testing purposes.
-func (s *PrecompileTestSuite) DeployContract(contract evmtypes.CompiledContract) (addr common.Address, err error) {
-	addr, err = evmosutil.DeployContract(
-		s.ctx,
-		s.app,
-		s.privKey,
-		s.queryClientEVM,
-		contract,
-	)
-	return
 }
 
 // ExpectSimpleVestingAccount checks that the vesting account has the expected funder address
@@ -301,16 +107,9 @@ func (s *PrecompileTestSuite) ExpectVestingFunder(vestingAddr common.Address, fu
 
 // GetVestingAccount returns the vesting account for the given address.
 func (s *PrecompileTestSuite) GetVestingAccount(addr common.Address) *vestingtypes.ClawbackVestingAccount {
-	acc := s.app.AccountKeeper.GetAccount(s.ctx, addr.Bytes())
+	acc := s.network.App.AccountKeeper.GetAccount(s.network.GetContext(), addr.Bytes())
 	Expect(acc).ToNot(BeNil(), "vesting account should exist")
 	vestingAcc, ok := acc.(*vestingtypes.ClawbackVestingAccount)
 	Expect(ok).To(BeTrue(), "vesting account should be of type VestingAccount")
 	return vestingAcc
-}
-
-// NextBlock commits the current block and sets up the next block.
-func (s *PrecompileTestSuite) NextBlock() {
-	var err error
-	s.ctx, err = evmosutil.CommitAndCreateNewCtx(s.ctx, s.app, time.Second, nil)
-	Expect(err).To(BeNil(), "failed to commit block")
 }

--- a/testutil/integration/evmos/factory/factory.go
+++ b/testutil/integration/evmos/factory/factory.go
@@ -29,6 +29,7 @@ import (
 // Methods are organized by build sign and broadcast type methods.
 type TxFactory interface {
 	commonfactory.CoreTxFactory
+	VestingTxFactory
 
 	// GenerateDefaultTxTypeArgs generates a default ETH tx args for the desired tx type
 	GenerateDefaultTxTypeArgs(sender common.Address, txType int) (evmtypes.EvmTxArgs, error)
@@ -72,6 +73,8 @@ var _ TxFactory = (*IntegrationTxFactory)(nil)
 // to the network on integration tests. This is to simulate the behavior of a real user.
 type IntegrationTxFactory struct {
 	commonfactory.CoreTxFactory
+	VestingTxFactory
+
 	grpcHandler grpc.Handler
 	network     network.Network
 	ec          *testutiltypes.TestEncodingConfig
@@ -83,11 +86,13 @@ func New(
 	grpcHandler grpc.Handler,
 ) TxFactory {
 	ec := makeConfig(app.ModuleBasics)
+	cf := commonfactory.New(network, grpcHandler, &ec)
 	return &IntegrationTxFactory{
-		CoreTxFactory: commonfactory.New(network, grpcHandler, &ec),
-		grpcHandler:   grpcHandler,
-		network:       network,
-		ec:            &ec,
+		CoreTxFactory:    cf,
+		VestingTxFactory: newVestingTxFactory(cf),
+		grpcHandler:      grpcHandler,
+		network:          network,
+		ec:               &ec,
 	}
 }
 

--- a/testutil/integration/evmos/factory/vesting.go
+++ b/testutil/integration/evmos/factory/vesting.go
@@ -52,8 +52,7 @@ func (tf *vestingTxFactory) CreateClawbackVestingAccount(vestingPriv cryptotypes
 	return err
 }
 
-// CreateClawbackVestingAccount in the provided address, with the provided
-// funder address
+// FundVestingAccount at the provided address with the given vesting schedules.
 func (tf *vestingTxFactory) FundVestingAccount(funderPriv cryptotypes.PrivKey, vestingAddr sdk.AccAddress, startTime time.Time, lockupPeriods, vestingPeriods sdkvesting.Periods) error {
 	funderAccAddr := sdk.AccAddress(funderPriv.PubKey().Address())
 

--- a/testutil/integration/evmos/factory/vesting.go
+++ b/testutil/integration/evmos/factory/vesting.go
@@ -1,0 +1,77 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package factory
+
+import (
+	"fmt"
+	"time"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
+	commonfactory "github.com/evmos/evmos/v16/testutil/integration/common/factory"
+	vestingtypes "github.com/evmos/evmos/v16/x/vesting/types"
+)
+
+type VestingTxFactory interface {
+	// CreateClawbackVestingAccount is a method to create and broadcast a MsgCreateClawbackVestingAccount
+	CreateClawbackVestingAccount(vestingPriv cryptotypes.PrivKey, funderAddr sdk.AccAddress, enableGovClawback bool) error
+	// FundVestingAccount is a method to create and broadcast a MsgFundVestingAccount
+	FundVestingAccount(funderPriv cryptotypes.PrivKey, vestingAddr sdk.AccAddress, startTime time.Time, lockupPeriods, vestingPeriods sdkvesting.Periods) error
+}
+
+type vestingTxFactory struct {
+	commonfactory.BaseTxFactory
+}
+
+func newVestingTxFactory(bf commonfactory.BaseTxFactory) VestingTxFactory {
+	return &vestingTxFactory{bf}
+}
+
+// CreateClawbackVestingAccount in the provided address, with the provided
+// funder address
+func (tf *vestingTxFactory) CreateClawbackVestingAccount(vestingPriv cryptotypes.PrivKey, funderAddr sdk.AccAddress, enableGovClawback bool) error {
+	vestingAccAddr := sdk.AccAddress(vestingPriv.PubKey().Address())
+
+	msg := vestingtypes.NewMsgCreateClawbackVestingAccount(
+		funderAddr,
+		vestingAccAddr,
+		enableGovClawback,
+	)
+
+	resp, err := tf.ExecuteCosmosTx(vestingPriv, commonfactory.CosmosTxArgs{
+		Msgs: []sdk.Msg{msg},
+	})
+
+	if resp.Code != 0 {
+		err = fmt.Errorf("received error code %d on CreateClawbackVestingAccount transaction. Logs: %s", resp.Code, resp.Log)
+	}
+
+	return err
+}
+
+// CreateClawbackVestingAccount in the provided address, with the provided
+// funder address
+func (tf *vestingTxFactory) FundVestingAccount(funderPriv cryptotypes.PrivKey, vestingAddr sdk.AccAddress, startTime time.Time, lockupPeriods, vestingPeriods sdkvesting.Periods) error {
+	funderAccAddr := sdk.AccAddress(funderPriv.PubKey().Address())
+
+	msg := vestingtypes.NewMsgFundVestingAccount(
+		funderAccAddr,
+		vestingAddr,
+		startTime,
+		lockupPeriods,
+		vestingPeriods,
+	)
+
+	resp, err := tf.ExecuteCosmosTx(funderPriv, commonfactory.CosmosTxArgs{
+		Msgs: []sdk.Msg{msg},
+	})
+
+	if resp.Code != 0 {
+		err = fmt.Errorf("received error code %d on FundVestingAccount transaction. Logs: %s", resp.Code, resp.Log)
+	}
+
+	return err
+}

--- a/testutil/integration/evmos/network/abci.go
+++ b/testutil/integration/evmos/network/abci.go
@@ -26,7 +26,7 @@ func (n *IntegrationNetwork) NextBlockAfter(duration time.Duration) error {
 	header.Height++
 	header.AppHash = n.app.LastCommitID().Hash
 	// Calculate new block time after duration
-	newBlockTime := time.Time{}.Add(duration)
+	newBlockTime := header.Time.Add(duration)
 	header.Time = newBlockTime
 
 	// add validator's commit info to allocate corresponding tokens to validators

--- a/testutil/integration/evmos/network/network.go
+++ b/testutil/integration/evmos/network/network.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"time"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -178,8 +179,10 @@ func (n *IntegrationNetwork) configureAndInitChain() error {
 		}
 	}
 
+	now := time.Now()
 	if _, err := evmosApp.InitChain(
 		&abcitypes.RequestInitChain{
+			Time:            now,
 			ChainId:         n.cfg.chainID,
 			Validators:      []abcitypes.ValidatorUpdate{},
 			ConsensusParams: consensusParams,
@@ -194,6 +197,7 @@ func (n *IntegrationNetwork) configureAndInitChain() error {
 		Hash:               evmosApp.LastCommitID().Hash,
 		NextValidatorsHash: valSet.Hash(),
 		ProposerAddress:    valSet.Proposer.Address,
+		Time:               now,
 	}
 
 	if _, err := evmosApp.FinalizeBlock(req); err != nil {
@@ -204,6 +208,7 @@ func (n *IntegrationNetwork) configureAndInitChain() error {
 		ChainID:            n.cfg.chainID,
 		Height:             req.Height,
 		AppHash:            req.Hash,
+		Time:               now,
 		ValidatorsHash:     req.NextValidatorsHash,
 		NextValidatorsHash: req.NextValidatorsHash,
 		ProposerAddress:    req.ProposerAddress,
@@ -282,6 +287,7 @@ func (n *IntegrationNetwork) GetValidators() []stakingtypes.Validator {
 // TODO - this should be change to gRPC
 func (n *IntegrationNetwork) BroadcastTxSync(txBytes []byte) (abcitypes.ExecTxResult, error) {
 	req := abcitypes.RequestFinalizeBlock{
+		Time:               n.ctx.BlockTime(),
 		Height:             n.app.LastBlockHeight() + 1,
 		Hash:               n.app.LastCommitID().Hash,
 		NextValidatorsHash: n.valSet.Hash(),

--- a/testutil/integration/evmos/network/network.go
+++ b/testutil/integration/evmos/network/network.go
@@ -179,7 +179,7 @@ func (n *IntegrationNetwork) configureAndInitChain() error {
 		}
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	if _, err := evmosApp.InitChain(
 		&abcitypes.RequestInitChain{
 			Time:            now,

--- a/testutil/integration/evmos/network/setup.go
+++ b/testutil/integration/evmos/network/setup.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/evmos/evmos/v16/app"
 	"github.com/evmos/evmos/v16/encoding"
 
@@ -33,6 +34,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/evmos/evmos/v16/types"
+	evmostypes "github.com/evmos/evmos/v16/types"
 	evmosutil "github.com/evmos/evmos/v16/utils"
 	epochstypes "github.com/evmos/evmos/v16/x/epochs/types"
 	erc20types "github.com/evmos/evmos/v16/x/erc20/types"
@@ -110,9 +112,14 @@ func createValidatorSetAndSigners(numberOfValidators int) (*cmttypes.ValidatorSe
 func createGenesisAccounts(accounts []sdktypes.AccAddress) []authtypes.GenesisAccount {
 	numberOfAccounts := len(accounts)
 	genAccounts := make([]authtypes.GenesisAccount, 0, numberOfAccounts)
+	codeHash := crypto.Keccak256Hash(nil).String()
 	for _, acc := range accounts {
 		baseAcc := authtypes.NewBaseAccount(acc, nil, 0, 0)
-		genAccounts = append(genAccounts, baseAcc)
+		ethAcc := &evmostypes.EthAccount{
+			BaseAccount: baseAcc,
+			CodeHash:    codeHash,
+		}
+		genAccounts = append(genAccounts, ethAcc)
 	}
 	return genAccounts
 }

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -15,6 +15,7 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 		suite     *KeeperTestSuite
 		epochInfo types.EpochInfo
 		found     bool
+		now       = time.Now().UTC()
 	)
 
 	testCases := []struct {
@@ -30,9 +31,9 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			name:                       "pass - initial epoch not started",
 			expCountingStarted:         false,
 			expCurrentEpochStartHeight: 0,
-			expCurrentEpochStartTime:   time.Time{},
+			expCurrentEpochStartTime:   now,
 			expCurrentEpoch:            0,
-			expInitialEpochStartTime:   time.Time{}.Add(time.Second),
+			expInitialEpochStartTime:   now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
@@ -45,12 +46,12 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			name:                       "pass - initial epoch started",
 			expCountingStarted:         true,
 			expCurrentEpochStartHeight: 2,
-			expCurrentEpochStartTime:   time.Time{}.Add(time.Second),
+			expCurrentEpochStartTime:   now.Add(time.Second),
 			expCurrentEpoch:            1,
-			expInitialEpochStartTime:   time.Time{}.Add(time.Second),
+			expInitialEpochStartTime:   now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(time.Time{}.Add(time.Second))
+				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
 				require.True(t, found)
@@ -60,17 +61,17 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			name:                       "pass - second epoch started",
 			expCountingStarted:         true,
 			expCurrentEpochStartHeight: 3,
-			expCurrentEpochStartTime:   time.Time{}.Add(time.Second).Add(month),
+			expCurrentEpochStartTime:   now.Add(time.Second).Add(month),
 			expCurrentEpoch:            2,
-			expInitialEpochStartTime:   time.Time{}.Add(time.Second),
+			expInitialEpochStartTime:   now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
 				// Epoch start
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(time.Time{}.Add(time.Second))
+				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				// Here we use seconds * 2 because we have to be 1 second more the end of previous
 				// epoch.
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(month))
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(2 * time.Second).Add(month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
 				require.True(t, found)
@@ -80,16 +81,16 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			name:                       "pass - still second epoch adding 1 month to epoch start",
 			expCountingStarted:         true,
 			expCurrentEpochStartHeight: 3,
-			expCurrentEpochStartTime:   time.Time{}.Add(time.Second).Add(month),
+			expCurrentEpochStartTime:   now.Add(time.Second).Add(month),
 			expCurrentEpoch:            2,
-			expInitialEpochStartTime:   time.Time{}.Add(time.Second),
+			expInitialEpochStartTime:   now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(time.Time{}.Add(time.Second))
+				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(month))
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(2 * time.Second).Add(month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(4).WithBlockTime(time.Time{}.Add(time.Second).Add(2 * month))
+				ctx = ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Second).Add(2 * month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
 				require.True(t, found)
@@ -101,16 +102,16 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			expCurrentEpochStartHeight: 4,
 			// NOTE: Even though previous epoch to complete needs 1 second more than its end,
 			// the start of next one is stored as equal to previous epoch end.
-			expCurrentEpochStartTime: time.Time{}.Add(time.Second).Add(2 * month),
+			expCurrentEpochStartTime: now.Add(time.Second).Add(2 * month),
 			expCurrentEpoch:          3,
-			expInitialEpochStartTime: time.Time{}.Add(time.Second),
+			expInitialEpochStartTime: now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(time.Time{}.Add(time.Second))
+				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(month))
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(2 * time.Second).Add(month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
-				ctx = ctx.WithBlockHeight(4).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(2 * month))
+				ctx = ctx.WithBlockHeight(4).WithBlockTime(now.Add(2 * time.Second).Add(2 * month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
 				require.True(t, found)
@@ -120,22 +121,22 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 			name:                       "pass - still third epoch adding 1 day from start",
 			expCountingStarted:         true,
 			expCurrentEpochStartHeight: 4,
-			expCurrentEpochStartTime:   time.Time{}.Add(time.Second).Add(2 * month),
+			expCurrentEpochStartTime:   now.Add(time.Second).Add(2 * month),
 			expCurrentEpoch:            3,
-			expInitialEpochStartTime:   time.Time{}.Add(time.Second),
+			expInitialEpochStartTime:   now.Add(time.Second),
 			malleate: func() {
 				ctx := suite.network.GetContext()
 				// First epoch
-				ctx = ctx.WithBlockHeight(2).WithBlockTime(time.Time{}.Add(time.Second))
+				ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				// Second epoch
-				ctx = ctx.WithBlockHeight(3).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(month))
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(2 * time.Second).Add(month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				// Third epoch
-				ctx = ctx.WithBlockHeight(4).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(2 * month))
+				ctx = ctx.WithBlockHeight(4).WithBlockTime(now.Add(2 * time.Second).Add(2 * month))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				// Still third epoch
-				ctx = ctx.WithBlockHeight(5).WithBlockTime(time.Time{}.Add(2 * time.Second).Add(2 * month).Add(day))
+				ctx = ctx.WithBlockHeight(5).WithBlockTime(now.Add(2 * time.Second).Add(2 * month).Add(day))
 				suite.network.App.EpochsKeeper.BeginBlocker(ctx)
 				epochInfo, found = suite.network.App.EpochsKeeper.GetEpochInfo(ctx, monthIdentifier)
 				require.True(t, found)
@@ -146,15 +147,15 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Case %s", tc.name), func(t *testing.T) {
 			// custom genesis defines an epoch that is not yet start but that should start at
-			// 1 second after the genesis time equal to time.Time{}. This happens in the BeginBlocker.
+			// 1 second after the genesis time equal to now. This happens in the BeginBlocker.
 			epochsInfo := []types.EpochInfo{
 				{
 					Identifier:              monthIdentifier,
-					StartTime:               time.Time{}.Add(time.Second),
+					StartTime:               now.Add(time.Second),
 					Duration:                month,
 					CurrentEpoch:            0,
 					CurrentEpochStartHeight: 0,
-					CurrentEpochStartTime:   time.Time{},
+					CurrentEpochStartTime:   now,
 					EpochCountingStarted:    false,
 				},
 			}
@@ -178,7 +179,7 @@ func TestEpochInfoChangesBeginBlockerAndInitGenesis(t *testing.T) {
 }
 
 func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
-	now := time.Now()
+	now := time.Now().UTC()
 	nowPlusMonth := now.Add(month)
 
 	epochsInfo := []types.EpochInfo{
@@ -188,7 +189,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 			Duration:                month,
 			CurrentEpoch:            0,
 			CurrentEpochStartHeight: 0,
-			CurrentEpochStartTime:   time.Time{},
+			CurrentEpochStartTime:   now,
 			EpochCountingStarted:    false,
 		},
 	}
@@ -200,7 +201,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, int64(0), epochInfo.CurrentEpoch, "expected first epoch not started")
 	require.Equal(t, int64(0), epochInfo.CurrentEpochStartHeight, "expected current epoch start height 0")
-	require.Equal(t, time.Time{}, epochInfo.CurrentEpochStartTime, "expected current epoch start time equal to genesis time.")
+	require.Equal(t, now, epochInfo.CurrentEpochStartTime, "expected current epoch start time equal to genesis time.")
 	require.Equal(t, false, epochInfo.EpochCountingStarted, "expected epoch counting not started")
 
 	// After 1 week.
@@ -211,7 +212,7 @@ func TestEpochStartingOneMonthAfterInitGenesis(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, int64(0), epochInfo.CurrentEpoch, "expected first epoch not started")
 	require.Equal(t, int64(0), epochInfo.CurrentEpochStartHeight, "expected current epoch start height 0")
-	require.Equal(t, time.Time{}, epochInfo.CurrentEpochStartTime, "expected current epoch start time equal to genesis time.")
+	require.Equal(t, now, epochInfo.CurrentEpochStartTime, "expected current epoch start time equal to genesis time.")
 	require.Equal(t, false, epochInfo.EpochCountingStarted, "expected epoch counting not started")
 
 	// After 1 month.

--- a/x/epochs/keeper/grpc_query_test.go
+++ b/x/epochs/keeper/grpc_query_test.go
@@ -37,26 +37,24 @@ func TestEpochInfo(t *testing.T) {
 
 				dayEpoch := types.EpochInfo{
 					Identifier:              types.DayEpochID,
-					StartTime:               time.Time{},
 					Duration:                day,
 					CurrentEpoch:            1,
 					CurrentEpochStartHeight: 1,
-					CurrentEpochStartTime:   time.Time{},
 					EpochCountingStarted:    true,
 				}
 				dayEpoch.StartTime = currentBlockTime
+				dayEpoch.CurrentEpochStartTime = currentBlockTime
 				dayEpoch.CurrentEpochStartHeight = currentBlockHeight
 
 				weekEpoch := types.EpochInfo{
 					Identifier:              types.WeekEpochID,
-					StartTime:               time.Time{},
 					Duration:                week,
 					CurrentEpoch:            1,
 					CurrentEpochStartHeight: 1,
-					CurrentEpochStartTime:   time.Time{},
 					EpochCountingStarted:    true,
 				}
 				weekEpoch.StartTime = currentBlockTime
+				weekEpoch.CurrentEpochStartTime = currentBlockTime
 				weekEpoch.CurrentEpochStartHeight = currentBlockHeight
 
 				expRes = &types.QueryEpochsInfoResponse{
@@ -80,39 +78,36 @@ func TestEpochInfo(t *testing.T) {
 
 				dayEpoch := types.EpochInfo{
 					Identifier:              types.DayEpochID,
-					StartTime:               time.Time{},
 					Duration:                time.Hour * 24,
 					CurrentEpoch:            1,
 					CurrentEpochStartHeight: 1,
-					CurrentEpochStartTime:   time.Time{},
 					EpochCountingStarted:    true,
 				}
 				dayEpoch.StartTime = currentBlockTime
+				dayEpoch.CurrentEpochStartTime = currentBlockTime
 				dayEpoch.CurrentEpochStartHeight = currentBlockHeight
 
 				weekEpoch := types.EpochInfo{
 					Identifier:              types.WeekEpochID,
-					StartTime:               time.Time{},
 					Duration:                time.Hour * 24 * 7,
 					CurrentEpoch:            1,
 					CurrentEpochStartHeight: 1,
-					CurrentEpochStartTime:   time.Time{},
 					EpochCountingStarted:    true,
 				}
 				weekEpoch.StartTime = currentBlockTime
+				weekEpoch.CurrentEpochStartTime = currentBlockTime
 				weekEpoch.CurrentEpochStartHeight = currentBlockHeight
 
 				quarterEpoch := types.EpochInfo{
 					Identifier:              "quarter",
-					StartTime:               time.Time{},
 					Duration:                time.Hour * 24 * 7 * 13,
 					CurrentEpoch:            0,
 					CurrentEpochStartHeight: 1,
-					CurrentEpochStartTime:   time.Time{},
 					EpochCountingStarted:    false,
 				}
 
 				quarterEpoch.StartTime = currentBlockTime
+				quarterEpoch.CurrentEpochStartTime = currentBlockTime
 				quarterEpoch.CurrentEpochStartHeight = currentBlockHeight
 				suite.network.App.EpochsKeeper.SetEpochInfo(ctx, quarterEpoch)
 
@@ -134,9 +129,7 @@ func TestEpochInfo(t *testing.T) {
 		t.Run(fmt.Sprintf("Case %s", tc.name), func(t *testing.T) {
 			// Default epoch infos at genesis with day and week.
 			suite = SetupTest([]types.EpochInfo{})
-			ctx := suite.network.GetContext()
-
-			ctx = tc.malleate()
+			ctx := tc.malleate()
 
 			res, err := suite.network.GetEpochsClient().EpochInfos(ctx, req)
 			if tc.expPass {

--- a/x/evm/keeper/benchmark_test.go
+++ b/x/evm/keeper/benchmark_test.go
@@ -27,7 +27,7 @@ func SetupContract(b *testing.B) (*KeeperTestSuite, common.Address) {
 	err = suite.network.App.BankKeeper.SendCoinsFromModuleToAccount(suite.network.GetContext(), types.ModuleName, suite.keyring.GetAddr(0).Bytes(), amt)
 	require.NoError(b, err)
 
-	contractAddr := suite.DeployTestContract(b, suite.keyring.GetAddr(0), sdkmath.NewIntWithDecimal(1000, 18).BigInt())
+	contractAddr := suite.DeployTestContract(b, suite.network.GetContext(), suite.keyring.GetAddr(0), sdkmath.NewIntWithDecimal(1000, 18).BigInt())
 	err = suite.network.NextBlock()
 	require.NoError(b, err)
 

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -106,7 +106,7 @@ func (suite *KeeperTestSuite) TestGetAccountStorage() {
 			func() {
 				i := 0
 				suite.network.App.AccountKeeper.IterateAccounts(ctx, func(account sdk.AccountI) bool {
-					defer func() {i++}()
+					defer func() { i++ }()
 					if i == 0 {
 						return false
 					}
@@ -123,7 +123,7 @@ func (suite *KeeperTestSuite) TestGetAccountStorage() {
 				suite.DeployTestContract(suite.T(), ctx, suite.keyring.GetAddr(0), supply)
 				i := 0
 				suite.network.App.AccountKeeper.IterateAccounts(ctx, func(account sdk.AccountI) bool {
-					defer func() {i++}()
+					defer func() { i++ }()
 					var storage evmtypes.Storage
 					ethAccount, ok := account.(evmostypes.EthAccountI)
 					if ok {

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -105,6 +105,7 @@ func (suite *KeeperTestSuite) TestGetAccountStorage() {
 			"Only one account that's not a contract (no storage)",
 			func() {
 				i := 0
+				// NOTE: here we're removing all accounts except for one
 				suite.network.App.AccountKeeper.IterateAccounts(ctx, func(account sdk.AccountI) bool {
 					defer func() { i++ }()
 					if i == 0 {

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -953,8 +953,11 @@ func (suite *KeeperTestSuite) TestSetBalance() {
 }
 
 func (suite *KeeperTestSuite) TestDeleteAccount() {
+	var (
+		ctx          sdk.Context
+		contractAddr common.Address
+	)
 	supply := big.NewInt(100)
-	contractAddr := suite.DeployTestContract(suite.T(), suite.keyring.GetAddr(0), supply)
 
 	testCases := []struct {
 		name   string
@@ -981,12 +984,15 @@ func (suite *KeeperTestSuite) TestDeleteAccount() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
-			err := suite.network.App.EvmKeeper.DeleteAccount(suite.network.GetContext(), tc.addr)
+			ctx = suite.network.GetContext()
+			contractAddr = suite.DeployTestContract(suite.T(), ctx, suite.keyring.GetAddr(0), supply)
+
+			err := suite.network.App.EvmKeeper.DeleteAccount(ctx, tc.addr)
 			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				balance := suite.network.App.EvmKeeper.GetBalance(suite.network.GetContext(), tc.addr)
+				balance := suite.network.App.EvmKeeper.GetBalance(ctx, tc.addr)
 				suite.Require().Equal(new(big.Int), balance)
 			}
 		})

--- a/x/evm/keeper/utils_test.go
+++ b/x/evm/keeper/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -26,8 +27,7 @@ func (suite *KeeperTestSuite) StateDB() *statedb.StateDB {
 }
 
 // DeployTestContract deploy a test erc20 contract and returns the contract address
-func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, owner common.Address, supply *big.Int) common.Address {
-	ctx := suite.network.GetContext()
+func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Context, owner common.Address, supply *big.Int) common.Address {
 	chainID := suite.network.App.EvmKeeper.ChainID()
 
 	ctorArgs, err := evmtypes.ERC20Contract.ABI.Pack("", owner, supply)


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

This PR includes the changes to migrate the vesting precompiled tests to the sdk v0.50.

```
❯ go clean --testcache &&  go test ./precompiles/vesting/...
ok      github.com/evmos/evmos/v16/precompiles/vesting  7.918s
```

To achieve this, some changes were necessary on the network setup of the integration tests suite.
For that reason, some of the already migrated tests needed small fixes.

Closes: ENG-2543

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
