### PR TITLE
fix(rpc/types): catch invalid values in CheckTxFee

### DIFF
--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -252,6 +253,12 @@ func CheckTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
 	// Short circuit if there is no cap for transaction fee at all.
 	if cap == 0 {
 		return nil
+	}
+	if gasPrice == nil {
+		return errors.New("gasPrice is nil")
+	}
+	if gasPrice.Sign() != 1 {
+		return errors.New("gasPrice must be positive!")
 	}
 	totalfee := new(big.Float).SetInt(new(big.Int).Mul(gasPrice, new(big.Int).SetUint64(gas)))
 	// 1 evmos in 10^18 aevmos

--- a/rpc/types/utils_test.go
+++ b/rpc/types/utils_test.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestCheckTxFeeInvalidArgs(t *testing.T) {
+	if err := CheckTxFee(nil, 10, 100); err == nil {
+		t.Fatal("expecting a non-nil error")
+	}
+
+	gp := big.NewInt(-1)
+	if err := CheckTxFee(gp, 10, 100); err == nil {
+		t.Fatal("expecting a non-nil error")
+	}
+}


### PR DESCRIPTION
This change catches invalid values in CheckTxFee
and returns an error for:
* nil gasPrice
* negative gasPrice

which improves the reliability of the system.

Fixes #2413
Fixes #2414