### PR TITLE
chore(tests): Remove configuration for deprecated modules from local node script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (werc20-precompile) [#2329](https://github.com/evmos/evmos/pull/2329) Make WEVMOS precompile `deposit` and `withdraw` functions no-ops.
 - (tests) [#2348](https://github.com/evmos/evmos/pull/2348) Extend integration transaction factory utils.
 - (all) [#2388](https://github.com/evmos/evmos/pull/2388) Remove legacy handler files from repository.
-- (tests) [#2421](https://github.com/evmos/evmos/pull/2421) Remove hardcoded supply in local node script.
+- (tests) [#2421](https://github.com/evmos/evmos/pull/2421) Remove configuration for deprecated modules from local node script.
 
 ## [v16.0.2](https://github.com/evmos/evmos/releases/tag/v16.0.2) - 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (werc20-precompile) [#2329](https://github.com/evmos/evmos/pull/2329) Make WEVMOS precompile `deposit` and `withdraw` functions no-ops.
 - (tests) [#2348](https://github.com/evmos/evmos/pull/2348) Extend integration transaction factory utils.
 - (all) [#2388](https://github.com/evmos/evmos/pull/2388) Remove legacy handler files from repository.
+- (tests) [#2421](https://github.com/evmos/evmos/pull/2421) Remove hardcoded supply in local node script.
 
 ## [v16.0.2](https://github.com/evmos/evmos/releases/tag/v16.0.2) - 2024-01-16
 

--- a/local_node.sh
+++ b/local_node.sh
@@ -109,10 +109,6 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 
 	# Import keys from mnemonics
 	echo "$VAL_MNEMONIC" | evmosd keys add "$VAL_KEY" --recover --keyring-backend "$KEYRING" --algo "$KEYALGO" --home "$HOMEDIR"
-
-	# Store the validator address in a variable to use it later
-	node_address=$(evmosd keys show -a "$VAL_KEY" --keyring-backend "$KEYRING" --home "$HOMEDIR")
-
 	echo "$USER1_MNEMONIC" | evmosd keys add "$USER1_KEY" --recover --keyring-backend "$KEYRING" --algo "$KEYALGO" --home "$HOMEDIR"
 	echo "$USER2_MNEMONIC" | evmosd keys add "$USER2_KEY" --recover --keyring-backend "$KEYRING" --algo "$KEYALGO" --home "$HOMEDIR"
 	echo "$USER3_MNEMONIC" | evmosd keys add "$USER3_KEY" --recover --keyring-backend "$KEYRING" --algo "$KEYALGO" --home "$HOMEDIR"

--- a/local_node.sh
+++ b/local_node.sh
@@ -207,10 +207,10 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	evmosd add-genesis-account "$(evmosd keys show "$USER3_KEY" -a --keyring-backend "$KEYRING" --home "$HOMEDIR")" 1000000000000000000000aevmos --keyring-backend "$KEYRING" --home "$HOMEDIR"
 	evmosd add-genesis-account "$(evmosd keys show "$USER4_KEY" -a --keyring-backend "$KEYRING" --home "$HOMEDIR")" 1000000000000000000000aevmos --keyring-backend "$KEYRING" --home "$HOMEDIR"
 
-	# bc is required to add these big numbers
-	# NOTE: we have the validator account (1e26) plus 4 (1e21) accounts
-	#       plus the claimed amount (1e4)
-	total_supply=100004000000000000000010000
+	# NOTE: we have to manually add the claimed amount to the genesis supply, the rest is taken care of by the add-genesis-account command
+	total_supply_pre=$(jq -r '.app_state["bank"]["supply"][0]["amount"]' "$GENESIS")
+	# we're adding the numbers by passing the corresponding expression into the bc calculator
+	total_supply=$(echo "$total_supply_pre + $amount_to_claim" | bc)
 	jq -r --arg total_supply "$total_supply" '.app_state["bank"]["supply"][0]["amount"]=$total_supply' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 	# Sign genesis transaction


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds a minor improvement to the local node script. Prior, the total supply was hardcoded and would have to be updated manually if either the genesis accounts or their corresponding balances were changed.