### PR TITLE
fix(grpc): account address return in ValidatorAccount query response

### DIFF
--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -120,7 +120,7 @@ func (k Keeper) ValidatorAccount(c context.Context, req *types.QueryValidatorAcc
 	}
 
 	res := types.QueryValidatorAccountResponse{
-		AccountAddress: valAddr,
+		AccountAddress: sdk.AccAddress(addrBz).String(),
 	}
 
 	account := k.accountKeeper.GetAccount(ctx, addrBz)

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -515,8 +515,11 @@ func (suite *EvmKeeperTestSuite) TestQueryValidatorAccount() {
 					ConsAddress: sdk.ConsAddress(consAddr).String(),
 				}
 
+				addrBz, err := unitNetwork.App.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.OperatorAddress)
+				suite.Require().NoError(err)
+
 				resp := &types.QueryValidatorAccountResponse{
-					AccountAddress: val.OperatorAddress,
+					AccountAddress: sdk.AccAddress(addrBz).String(),
 					Sequence:       0,
 					AccountNumber:  1,
 				}
@@ -536,17 +539,19 @@ func (suite *EvmKeeperTestSuite) TestQueryValidatorAccount() {
 				accNumber := uint64(100)
 				accSeq := uint64(10)
 
-				addrBz, err := s.network.App.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.OperatorAddress)
+				addrBz, err := unitNetwork.App.StakingKeeper.ValidatorAddressCodec().StringToBytes(val.OperatorAddress)
 				suite.Require().NoError(err)
 
-				baseAcc := &authtypes.BaseAccount{Address: sdk.AccAddress(addrBz).String()}
+				accAddrStr := sdk.AccAddress(addrBz).String()
+
+				baseAcc := &authtypes.BaseAccount{Address: accAddrStr}
 				acc := unitNetwork.App.AccountKeeper.NewAccount(unitNetwork.GetContext(), baseAcc)
 				suite.Require().NoError(acc.SetSequence(accSeq))
 				suite.Require().NoError(acc.SetAccountNumber(accNumber))
 				unitNetwork.App.AccountKeeper.SetAccount(unitNetwork.GetContext(), acc)
 
 				resp := &types.QueryValidatorAccountResponse{
-					AccountAddress: val.OperatorAddress,
+					AccountAddress: accAddrStr,
 					Sequence:       accSeq,
 					AccountNumber:  accNumber,
 				}


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Currently, the ValidatorAccount query responds with the validator account address (the one has the `evmos` prefix, NOT the `evmosvaloper` prefix). See here [this diff](https://github.com/evmos/evmos/pull/2338/files#diff-16342075507fdd6168b893a629ec4088f1c8ab545f54e7c5b22367d8581e679c) when merged the evm refactor

This PR fixes this issue to avoid changing the API. So the query returns the `AccAddress` as expected

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
