### PR TITLE
imp(make): Add protolint to make proto-lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,10 @@ protoVer=0.11.6
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace --user 0 $(protoImageName)
 
+protoLintVer=0.44.0
+protoLinterImage=yoheimuta/protolint
+protoLinter=$(DOCKER) run --rm -v "$(CURDIR):/workspace" --workdir /workspace --user 0 $(protoLinterImage):$(protoLintVer)
+
 # ------
 # NOTE: If you are experiencing problems running these commands, try deleting
 #       the docker images and execute the desired command again.
@@ -444,6 +448,7 @@ proto-format:
 proto-lint:
 	@echo "Linting Protobuf files"
 	@$(protoImage) buf lint --error-format=json	
+	@$(protoLinter) lint ./proto
 
 proto-check-breaking:
 	@echo "Checking Protobuf files for breaking changes"


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

We are using [protolint](https://github.com/yoheimuta/protolint) as part of the super-linter running in CI. However, when running `make proto-lint` this is not the case and we're only using `buf lint` at the moment which is less restrictive.

Hence, this PR adds the `protolint` image to the `make proto-lint` target. 
