### PR TITLE
only use os mail address for inquiries

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ of the Evmos repository. For more information see [LICENSE](./LICENSE).
 > [!WARNING]
 >
 > **NOTE: If you are interested in using this software**
-> email us at [os@evmos.org](mailto:os@evmos.org)
+> email us at [os@evmos.org](mailto:os@evmos.org).
 
 ### SPDX Identifier
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ of the Evmos repository. For more information see [LICENSE](./LICENSE).
 > [!WARNING]
 >
 > **NOTE: If you are interested in using this software**
-> email us at [evmos-sdk@evmos.org](mailto:evmos-sdk@evmos.org) with copy to [os@evmos.org](mailto:os@evmos.org)
+> email us at [os@evmos.org](mailto:os@evmos.org)
 
 ### SPDX Identifier
 


### PR DESCRIPTION
# Description

This minor PR removes the mention of the outdated SDK mail address in favor of the os@evmos.org address.