### PR TITLE
chore(erc20): re-add deleted erc20 evm hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (revenue) [#2379](https://github.com/evmos/evmos/pull/2379) Remove `x/revenue` module.
 - (evm) [#2380](https://github.com/evmos/evmos/pull/2380) Remove EVM hooks from app and EVM module.
 - (evm) [#2501](https://github.com/evmos/evmos/pull/2501) Revert deletion from EVM hooks (#2380)
+- (erc20) [#2502](https://github.com/evmos/evmos/pull/2502) Revert deletion from EVM hooks (#2154) (#2442)
 
 ### Bug Fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -528,7 +528,9 @@ func NewEvmos(
 	)
 
 	app.EvmKeeper = app.EvmKeeper.SetHooks(
-		evmkeeper.NewMultiEvmHooks(),
+		evmkeeper.NewMultiEvmHooks(
+			app.Erc20Keeper.Hooks(),
+		),
 	)
 
 	// Override the ICS20 app module

--- a/x/erc20/keeper/evm_hooks.go
+++ b/x/erc20/keeper/evm_hooks.go
@@ -1,0 +1,166 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package keeper
+
+import (
+	"bytes"
+	"math/big"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+
+	"github.com/evmos/evmos/v18/contracts"
+	"github.com/evmos/evmos/v18/x/erc20/types"
+)
+
+var _ evmtypes.EvmHooks = Hooks{}
+
+// Hooks wrapper struct for erc20 keeper
+type Hooks struct {
+	k Keeper
+}
+
+// Return the wrapper struct
+func (k Keeper) Hooks() Hooks {
+	return Hooks{k}
+}
+
+// PostTxProcessing is a wrapper for calling the EVM PostTxProcessing hook on
+// the module keeper
+func (h Hooks) PostTxProcessing(ctx sdk.Context, msg core.Message, receipt *ethtypes.Receipt) error {
+	return h.k.PostTxProcessing(ctx, msg, receipt)
+}
+
+// PostTxProcessing implements EvmHooks.PostTxProcessing. The EVM hooks allows
+// users to convert ERC20s to Cosmos Coins by sending an Ethereum tx transfer to
+// the module account address. This hook applies to both token pairs that have
+// been registered through a native Cosmos coin or an ERC20 token. If token pair
+// has been registered with:
+//   - coin -> burn tokens and transfer escrowed coins on module to sender
+//   - token -> escrow tokens on module account and mint & transfer coins to sender
+//
+// Note that the PostTxProcessing hook is only called by sending an EVM
+// transaction that triggers `ApplyTransaction`. A cosmos tx with a
+// `ConvertERC20` msg does not trigger the hook as it only calls `ApplyMessage`.
+func (k Keeper) PostTxProcessing(
+	ctx sdk.Context,
+	_ core.Message,
+	receipt *ethtypes.Receipt,
+) error {
+	params := k.GetParams(ctx)
+	if !params.EnableErc20 || !params.EnableEVMHook {
+		// no error is returned to avoid reverting the tx and allow for other post
+		// processing txs to pass and
+		return nil
+	}
+
+	erc20 := contracts.ERC20MinterBurnerDecimalsContract.ABI
+
+	for i, log := range receipt.Logs {
+		// Note: the `Transfer` event contains 3 topics (id, from, to)
+		if len(log.Topics) != 3 {
+			continue
+		}
+
+		// Check if event is included in ERC20
+		eventID := log.Topics[0]
+		event, err := erc20.EventByID(eventID)
+		if err != nil {
+			continue
+		}
+
+		// Check if event is a `Transfer` event.
+		if event.Name != types.ERC20EventTransfer {
+			k.Logger(ctx).Info("emitted event", "name", event.Name, "signature", event.Sig)
+			continue
+		}
+
+		transferEvent, err := erc20.Unpack(event.Name, log.Data)
+		if err != nil {
+			k.Logger(ctx).Error("failed to unpack transfer event", "error", err.Error())
+			continue
+		}
+
+		if len(transferEvent) == 0 {
+			continue
+		}
+
+		tokens, ok := transferEvent[0].(*big.Int)
+		// safety check and ignore if amount not positive
+		if !ok || tokens == nil || tokens.Sign() != 1 {
+			continue
+		}
+
+		// Check that the contract is a registered token pair
+		contractAddr := log.Address
+		id := k.GetERC20Map(ctx, contractAddr)
+		if len(id) == 0 {
+			continue
+		}
+
+		pair, found := k.GetTokenPair(ctx, id)
+		if !found {
+			continue
+		}
+
+		// Check if tokens are sent to module address
+		to := common.BytesToAddress(log.Topics[2].Bytes())
+		if !bytes.Equal(to.Bytes(), types.ModuleAddress.Bytes()) {
+			continue
+		}
+
+		// Check that conversion for the pair is enabled. Fail
+		if !pair.Enabled {
+			// continue to allow transfers for the ERC20 in case the token pair is
+			// disabled
+			k.Logger(ctx).Debug(
+				"ERC20 token -> Cosmos coin conversion is disabled for pair",
+				"coin", pair.Denom, "contract", pair.Erc20Address,
+			)
+			continue
+		}
+
+		// create the corresponding sdk.Coin that is paired with ERC20
+		coins := sdk.Coins{{Denom: pair.Denom, Amount: math.NewIntFromBigInt(tokens)}}
+
+		// Perform token conversion. We can now assume that the sender of a
+		// registered token wants to mint a Cosmos coin.
+		switch pair.ContractOwner {
+		case types.OWNER_MODULE:
+			_, err = k.CallEVM(ctx, erc20, types.ModuleAddress, contractAddr, true, "burn", tokens)
+		case types.OWNER_EXTERNAL:
+			err = k.bankKeeper.MintCoins(ctx, types.ModuleName, coins)
+		default:
+			err = types.ErrUndefinedOwner
+		}
+
+		if err != nil {
+			k.Logger(ctx).Debug(
+				"failed to process EVM hook for ER20 -> coin conversion",
+				"coin", pair.Denom, "contract", pair.Erc20Address, "error", err.Error(),
+			)
+			continue
+		}
+
+		// Only need last 20 bytes from log.topics
+		from := common.BytesToAddress(log.Topics[1].Bytes())
+		recipient := sdk.AccAddress(from.Bytes())
+
+		// transfer the tokens from ModuleAccount to sender address
+		if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipient, coins); err != nil {
+			k.Logger(ctx).Debug(
+				"failed to process EVM hook for ER20 -> coin conversion",
+				"tx-hash", receipt.TxHash.Hex(), "log-idx", i,
+				"coin", pair.Denom, "contract", pair.Erc20Address, "error", err.Error(),
+			)
+			continue
+		}
+	}
+
+	return nil
+}

--- a/x/erc20/keeper/evm_hooks_test.go
+++ b/x/erc20/keeper/evm_hooks_test.go
@@ -1,0 +1,431 @@
+package keeper_test
+
+import (
+	"fmt"
+	"math/big"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/evmos/evmos/v18/contracts"
+	utiltx "github.com/evmos/evmos/v18/testutil/tx"
+	"github.com/evmos/evmos/v18/x/erc20/types"
+)
+
+// ensureHooksSet tries to set the hooks on EVMKeeper, this will fail if the erc20 hook is already set
+func (suite *KeeperTestSuite) ensureHooksSet() {
+	// TODO: PR to Ethermint to add the functionality `GetHooks` or `areHooksSet` to avoid catching a panic
+	defer func() {
+		err := recover()
+		suite.Require().NotNil(err)
+	}()
+	suite.app.EvmKeeper.SetHooks(suite.app.Erc20Keeper.Hooks())
+}
+
+func (suite *KeeperTestSuite) TestEvmHooksRegisteredERC20() {
+	testCases := []struct {
+		name     string
+		malleate func(common.Address)
+		result   bool
+	}{
+		{
+			"correct execution",
+			func(contractAddr common.Address) {
+				_, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				// Mint 10 tokens to suite.address (owner)
+				_ = suite.MintERC20Token(contractAddr, suite.address, suite.address, big.NewInt(10))
+				suite.Commit()
+
+				// Burn the 10 tokens of suite.address (owner)
+				_ = suite.TransferERC20TokenToModule(contractAddr, suite.address, big.NewInt(10))
+			},
+			true,
+		},
+		{
+			"unregistered pair",
+			func(contractAddr common.Address) {
+				// Mint 10 tokens to suite.address (owner)
+				_ = suite.MintERC20Token(contractAddr, suite.address, suite.address, big.NewInt(10))
+				suite.Commit()
+
+				// Burn the 10 tokens of suite.address (owner)
+				_ = suite.TransferERC20TokenToModule(contractAddr, suite.address, big.NewInt(10))
+			},
+			false,
+		},
+		{
+			"wrong event",
+			func(contractAddr common.Address) {
+				_, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				// Mint 10 tokens to suite.address (owner)
+				_ = suite.MintERC20Token(contractAddr, suite.address, suite.address, big.NewInt(10))
+			},
+			false,
+		},
+		{
+			"Pair is disabled",
+			func(contractAddr common.Address) {
+				pair, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				pair.Enabled = false
+				suite.app.Erc20Keeper.SetTokenPair(suite.ctx, *pair)
+				// Mint 10 tokens to suite.address (owner)
+				_ = suite.MintERC20Token(contractAddr, suite.address, suite.address, big.NewInt(10))
+				suite.Commit()
+
+				// Burn the 10 tokens of suite.address (owner)
+				_ = suite.TransferERC20TokenToModule(contractAddr, suite.address, big.NewInt(10))
+			},
+			false,
+		},
+		{
+			"Pair is incorrectly loaded",
+			func(contractAddr common.Address) {
+				pair, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				suite.app.Erc20Keeper.DeleteTokenPair(suite.ctx, *pair)
+
+				suite.app.Erc20Keeper.SetDenomMap(suite.ctx, pair.Denom, pair.GetID())
+				suite.app.Erc20Keeper.SetERC20Map(suite.ctx, pair.GetERC20Contract(), pair.GetID())
+				// Mint 10 tokens to suite.address (owner)
+				_ = suite.MintERC20Token(contractAddr, suite.address, suite.address, big.NewInt(10))
+				suite.Commit()
+
+				// Burn the 10 tokens of suite.address (owner)
+				_ = suite.TransferERC20TokenToModule(contractAddr, suite.address, big.NewInt(10))
+			},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.mintFeeCollector = true
+			suite.SetupTest()
+
+			suite.ensureHooksSet()
+
+			contractAddr, err := suite.DeployContract("coin test erc20", "token", erc20Decimals)
+			suite.Require().NoError(err)
+
+			tc.malleate(contractAddr)
+
+			balance := suite.app.BankKeeper.GetBalance(suite.ctx, sdk.AccAddress(suite.address.Bytes()), types.CreateDenom(contractAddr.String()))
+			suite.Commit()
+			if tc.result {
+				// Check if the execution was successful
+				suite.Require().Equal(int64(10), balance.Amount.Int64())
+			} else {
+				// Check that no changes were made to the account
+				suite.Require().Equal(int64(0), balance.Amount.Int64())
+			}
+		})
+	}
+	suite.mintFeeCollector = false
+}
+
+func (suite *KeeperTestSuite) TestEvmHooksRegisteredCoin() {
+	testCases := []struct {
+		name      string
+		mint      int64
+		burn      int64
+		reconvert int64
+
+		result bool
+	}{
+		{"correct execution", 100, 10, 5, true},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.mintFeeCollector = true
+			suite.SetupTest()
+
+			suite.ensureHooksSet()
+
+			pair := suite.setupRegisterCoin(metadataCoin)
+			suite.Require().NotNil(metadataCoin)
+			suite.Require().NotNil(pair)
+
+			sender := sdk.AccAddress(suite.address.Bytes())
+			contractAddr := common.HexToAddress(pair.Erc20Address)
+
+			coins := sdk.NewCoins(sdk.NewCoin(cosmosTokenBase, math.NewInt(tc.mint)))
+			err := suite.app.BankKeeper.MintCoins(suite.ctx, types.ModuleName, coins)
+			suite.Require().NoError(err, tc.name)
+			err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, types.ModuleName, sender, coins)
+			suite.Require().NoError(err, tc.name)
+
+			convertCoin := types.NewMsgConvertCoin(
+				sdk.NewCoin(cosmosTokenBase, math.NewInt(tc.burn)),
+				suite.address,
+				sender,
+			)
+
+			ctx := sdk.WrapSDKContext(suite.ctx)
+			_, err = suite.app.Erc20Keeper.ConvertCoin(ctx, convertCoin)
+			suite.Require().NoError(err, tc.name)
+			suite.Commit()
+
+			balance := suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
+			cosmosBalance := suite.app.BankKeeper.GetBalance(suite.ctx, sender, metadataCoin.Base)
+			suite.Require().Equal(cosmosBalance.Amount.Int64(), math.NewInt(tc.mint-tc.burn).Int64())
+			suite.Require().Equal(balance, big.NewInt(tc.burn))
+
+			// Burn the 10 tokens of suite.address (owner)
+			_ = suite.TransferERC20TokenToModule(contractAddr, suite.address, big.NewInt(tc.reconvert))
+
+			balance = suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
+			cosmosBalance = suite.app.BankKeeper.GetBalance(suite.ctx, sender, metadataCoin.Base)
+
+			if tc.result {
+				suite.Require().Equal(balance, big.NewInt(tc.burn-tc.reconvert))
+				// Check if the execution was successful
+				suite.Require().NoError(err)
+				suite.Require().Equal(cosmosBalance.Amount, math.NewInt(tc.mint-tc.burn+tc.reconvert))
+			} else {
+				// Check that no changes were made to the account
+				suite.Require().Error(err)
+				suite.Require().Equal(cosmosBalance.Amount, math.NewInt(tc.mint-tc.burn))
+			}
+		})
+	}
+	suite.mintFeeCollector = false
+}
+
+func (suite *KeeperTestSuite) TestPostTxProcessing() {
+	var (
+		receipt *ethtypes.Receipt
+		pair    *types.TokenPair
+	)
+
+	msg := ethtypes.NewMessage(
+		types.ModuleAddress,
+		&common.Address{},
+		0,
+		big.NewInt(0), // amount
+		uint64(0),     // gasLimit
+		big.NewInt(0), // gasFeeCap
+		big.NewInt(0), // gasTipCap
+		big.NewInt(0), // gasPrice
+		[]byte{},
+		ethtypes.AccessList{}, // AccessList
+		true,                  // checkNonce
+	)
+
+	account := utiltx.GenerateAddress()
+
+	transferData := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	transferData[31] = uint8(10)
+	erc20 := contracts.ERC20BurnableContract.ABI
+
+	transferEvent := erc20.Events["Transfer"]
+
+	testCases := []struct {
+		name          string
+		malleate      func()
+		expConversion bool
+	}{
+		{
+			"Empty logs",
+			func() {
+				log := ethtypes.Log{}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"No log data",
+			func() {
+				topics := []common.Hash{transferEvent.ID, account.Hash(), types.ModuleAddress.Hash()}
+				log := ethtypes.Log{
+					Topics: topics,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"Non recognized event",
+			func() {
+				topics := []common.Hash{{}, account.Hash(), account.Hash()}
+				log := ethtypes.Log{
+					Topics: topics,
+					Data:   transferData,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"Non transfer event",
+			func() {
+				aprovalEvent := erc20.Events["Approval"]
+				topics := []common.Hash{aprovalEvent.ID, account.Hash(), account.Hash()}
+				log := ethtypes.Log{
+					Topics: topics,
+					Data:   transferData,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"No log address",
+			func() {
+				topics := []common.Hash{transferEvent.ID, account.Hash(), types.ModuleAddress.Hash()}
+				log := ethtypes.Log{
+					Topics: topics,
+					Data:   transferData,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"No data on topic",
+			func() {
+				topics := []common.Hash{transferEvent.ID}
+				log := ethtypes.Log{
+					Topics: topics,
+					Data:   transferData,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"transfer to non-evm-module account",
+			func() {
+				contractAddr, err := suite.DeployContract("coin", "token", erc20Decimals)
+				suite.Require().NoError(err)
+
+				_, err = suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				topics := []common.Hash{transferEvent.ID, account.Hash(), account.Hash()}
+				log := ethtypes.Log{
+					Topics:  topics,
+					Data:    transferData,
+					Address: contractAddr,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"correct burn",
+			func() {
+				contractAddr, err := suite.DeployContract("coin", "token", erc20Decimals)
+				suite.Require().NoError(err)
+
+				pair, err = suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				topics := []common.Hash{transferEvent.ID, account.Hash(), types.ModuleAddress.Hash()}
+				log := ethtypes.Log{
+					Topics:  topics,
+					Data:    transferData,
+					Address: contractAddr,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			true,
+		},
+		{
+			"Unspecified Owner",
+			func() {
+				contractAddr, err := suite.DeployContract("coin", "token", erc20Decimals)
+				suite.Require().NoError(err)
+
+				pair, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				pair.ContractOwner = types.OWNER_UNSPECIFIED
+				suite.app.Erc20Keeper.SetTokenPair(suite.ctx, *pair)
+
+				topics := []common.Hash{transferEvent.ID, account.Hash(), types.ModuleAddress.Hash()}
+				log := ethtypes.Log{
+					Topics:  topics,
+					Data:    transferData,
+					Address: contractAddr,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+		{
+			"Fail Evm",
+			func() {
+				contractAddr, err := suite.DeployContract("coin", "token", erc20Decimals)
+				suite.Require().NoError(err)
+
+				pair, err := suite.app.Erc20Keeper.RegisterERC20(suite.ctx, contractAddr)
+				suite.Require().NoError(err)
+
+				pair.ContractOwner = types.OWNER_MODULE
+				suite.app.Erc20Keeper.SetTokenPair(suite.ctx, *pair)
+
+				topics := []common.Hash{transferEvent.ID, account.Hash(), types.ModuleAddress.Hash()}
+				log := ethtypes.Log{
+					Topics:  topics,
+					Data:    transferData,
+					Address: contractAddr,
+				}
+				receipt = &ethtypes.Receipt{
+					Logs: []*ethtypes.Log{&log},
+				}
+			},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
+			suite.mintFeeCollector = true
+			suite.SetupTest()
+			suite.ensureHooksSet()
+			suite.Commit()
+
+			tc.malleate()
+
+			err := suite.app.Erc20Keeper.Hooks().PostTxProcessing(suite.ctx, msg, receipt)
+			suite.Require().NoError(err)
+
+			if tc.expConversion {
+				sender := sdk.AccAddress(account.Bytes())
+				cosmosBalance := suite.app.BankKeeper.GetBalance(suite.ctx, sender, pair.Denom)
+
+				transferEvent, err := erc20.Unpack("Transfer", transferData)
+				suite.Require().NoError(err)
+
+				tokens, _ := transferEvent[0].(*big.Int)
+				suite.Require().Equal(cosmosBalance.Amount.String(), tokens.String())
+			}
+		})
+	}
+	suite.mintFeeCollector = false
+}

--- a/x/erc20/types/events.go
+++ b/x/erc20/types/events.go
@@ -24,6 +24,9 @@ const (
 	AttributeKeyCosmosCoin = "cosmos_coin"
 	AttributeKeyERC20Token = "erc20_token" // #nosec
 	AttributeKeyReceiver   = "receiver"
+
+	// ERC20EventTransfer defines the transfer event for ERC20
+	ERC20EventTransfer = "Transfer"
 )
 
 // LogTransfer Event type for Transfer(address from, address to, uint256 value)


### PR DESCRIPTION
# Description

erc20 evm hooks where deleted prior to STRV2, we need to re introduce them, since they are needed for migration logic

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
