### PR TITLE
chore(cli): re-introduce convert coin txn for erc20 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (docs) [#2478](https://github.com/evmos/evmos/pull/2478) Change Evmos SDK with evmOS.
 - (build) [#2484](https://github.com/evmos/evmos/pull/2484) Bump golang version to v1.22.
 - (client) [#2481](https://github.com/evmos/evmos/pull/2481) Replace path.Join with filepath.Join.
+- (cli) [#2503](https://github.com/evmos/evmos/pull/2503) Revert deletion of ConvertCoin for erc20 module (#2155).
 
 ## [v18.0.0](https://github.com/evmos/evmos/releases/tag/v18.0.0) - 2024-04-22
 

--- a/x/erc20/client/cli/tx.go
+++ b/x/erc20/client/cli/tx.go
@@ -35,6 +35,7 @@ func NewTxCmd() *cobra.Command {
 	}
 
 	txCmd.AddCommand(
+		NewConvertCoinCmd(),
 		NewConvertERC20Cmd(),
 	)
 	return txCmd
@@ -208,5 +209,52 @@ func NewToggleTokenConversionProposalCmd() *cobra.Command {
 	if err := cmd.MarkFlagRequired(cli.FlagDeposit); err != nil {
 		panic(err)
 	}
+	return cmd
+}
+
+// NewConvertCoinCmd returns a CLI command handler for converting a Cosmos coin
+func NewConvertCoinCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "convert-coin COIN [RECEIVER_HEX]",
+		Short: "Convert a Cosmos coin to ERC20. When the receiver [optional] is omitted, the ERC20 tokens are transferred to the sender.",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			coin, err := sdk.ParseCoinNormalized(args[0])
+			if err != nil {
+				return err
+			}
+
+			var receiver string
+			sender := cliCtx.GetFromAddress()
+
+			if len(args) == 2 {
+				receiver = args[1]
+				if err := evmostypes.ValidateAddress(receiver); err != nil {
+					return fmt.Errorf("invalid receiver hex address %w", err)
+				}
+			} else {
+				receiver = common.BytesToAddress(sender).Hex()
+			}
+
+			msg := &types.MsgConvertCoin{
+				Coin:     coin,
+				Receiver: receiver,
+				Sender:   sender.String(),
+			}
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }


### PR DESCRIPTION
# Description

re-introduce the convert coin txns that was deleted ahead of strv2, but its still needed 

removed on pr https://github.com/evmos/evmos/pull/2155

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
