### PR TITLE
refactor: Repeated parsing of packetData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (build) [#2484](https://github.com/evmos/evmos/pull/2484) Bump golang version to v1.22.
 - (client) [#2481](https://github.com/evmos/evmos/pull/2481) Replace path.Join with filepath.Join.
 - (cli) [#2503](https://github.com/evmos/evmos/pull/2503) Revert deletion of ConvertCoin for erc20 module (#2155).
+- (ibc) [#2504](https://github.com/evmos/evmos/pull/2504) Refactor repeated unpacking of IBC packet data.
 
 ## [v18.0.0](https://github.com/evmos/evmos/releases/tag/v18.0.0) - 2024-04-22
 

--- a/ibc/utils.go
+++ b/ibc/utils.go
@@ -24,17 +24,11 @@ import (
 //   - the packet data is not FungibleTokenPacketData
 //   - sender address is invalid
 //   - recipient address is invalid
-func GetTransferSenderRecipient(packet channeltypes.Packet) (
+func GetTransferSenderRecipient(data transfertypes.FungibleTokenPacketData) (
 	sender, recipient sdk.AccAddress,
 	senderBech32, recipientBech32 string,
 	err error,
 ) {
-	// unmarshal packet data to obtain the sender and recipient
-	var data transfertypes.FungibleTokenPacketData
-	if err := transfertypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
-		return nil, nil, "", "", errorsmod.Wrapf(errortypes.ErrUnknownRequest, "cannot unmarshal ICS-20 transfer packet data")
-	}
-
 	// validate the sender bech32 address from the counterparty chain
 	// and change the bech32 human readable prefix (HRP) of the sender to `evmos`
 	sender, err = utils.GetEvmosAddressFromBech32(data.Sender)

--- a/ibc/utils_test.go
+++ b/ibc/utils_test.go
@@ -22,48 +22,24 @@ func init() {
 func TestGetTransferSenderRecipient(t *testing.T) {
 	testCases := []struct {
 		name         string
-		packet       channeltypes.Packet
+		data         transfertypes.FungibleTokenPacketData
 		expSender    string
 		expRecipient string
 		expError     bool
 	}{
 		{
-			name:         "empty packet",
-			packet:       channeltypes.Packet{},
-			expSender:    "",
-			expRecipient: "",
-			expError:     true,
-		},
-		{
-			name: "invalid packet data",
-			packet: channeltypes.Packet{
-				Data: ibctesting.MockFailPacketData,
-			},
-			expSender:    "",
-			expRecipient: "",
-			expError:     true,
-		},
-		{
-			name: "empty FungibleTokenPacketData",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{},
-				),
-			},
+			name:         "empty FungibleTokenPacketData",
+			data:         transfertypes.FungibleTokenPacketData{},
 			expSender:    "",
 			expRecipient: "",
 			expError:     true,
 		},
 		{
 			name: "invalid sender",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{
-						Sender:   "cosmos1",
-						Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
-						Amount:   "123456",
-					},
-				),
+			data: transfertypes.FungibleTokenPacketData{
+				Sender:   "cosmos1",
+				Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
+				Amount:   "123456",
 			},
 			expSender:    "",
 			expRecipient: "",
@@ -71,14 +47,10 @@ func TestGetTransferSenderRecipient(t *testing.T) {
 		},
 		{
 			name: "invalid recipient",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{
-						Sender:   "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
-						Receiver: "evmos1",
-						Amount:   "123456",
-					},
-				),
+			data: transfertypes.FungibleTokenPacketData{
+				Sender:   "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
+				Receiver: "evmos1",
+				Amount:   "123456",
 			},
 			expSender:    "",
 			expRecipient: "",
@@ -86,14 +58,10 @@ func TestGetTransferSenderRecipient(t *testing.T) {
 		},
 		{
 			name: "valid - cosmos sender, evmos recipient",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{
-						Sender:   "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
-						Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
-						Amount:   "123456",
-					},
-				),
+			data: transfertypes.FungibleTokenPacketData{
+				Sender:   "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
+				Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
+				Amount:   "123456",
 			},
 			expSender:    "evmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueuafmxps",
 			expRecipient: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
@@ -101,14 +69,10 @@ func TestGetTransferSenderRecipient(t *testing.T) {
 		},
 		{
 			name: "valid - evmos sender, cosmos recipient",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{
-						Sender:   "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
-						Receiver: "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
-						Amount:   "123456",
-					},
-				),
+			data: transfertypes.FungibleTokenPacketData{
+				Sender:   "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
+				Receiver: "cosmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueulg2gmc",
+				Amount:   "123456",
 			},
 			expSender:    "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
 			expRecipient: "evmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueuafmxps",
@@ -116,14 +80,10 @@ func TestGetTransferSenderRecipient(t *testing.T) {
 		},
 		{
 			name: "valid - osmosis sender, evmos recipient",
-			packet: channeltypes.Packet{
-				Data: transfertypes.ModuleCdc.MustMarshalJSON(
-					&transfertypes.FungibleTokenPacketData{
-						Sender:   "osmo1qql8ag4cluz6r4dz28p3w00dnc9w8ueuhnecd2",
-						Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
-						Amount:   "123456",
-					},
-				),
+			data: transfertypes.FungibleTokenPacketData{
+				Sender:   "osmo1qql8ag4cluz6r4dz28p3w00dnc9w8ueuhnecd2",
+				Receiver: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
+				Amount:   "123456",
 			},
 			expSender:    "evmos1qql8ag4cluz6r4dz28p3w00dnc9w8ueuafmxps",
 			expRecipient: "evmos1x2w87cvt5mqjncav4lxy8yfreynn273xn5335v",
@@ -132,7 +92,7 @@ func TestGetTransferSenderRecipient(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		sender, recipient, _, _, err := GetTransferSenderRecipient(tc.packet)
+		sender, recipient, _, _, err := GetTransferSenderRecipient(tc.data)
 		if tc.expError {
 			require.Error(t, err, tc.name)
 		} else {

--- a/x/erc20/keeper/ibc_callbacks.go
+++ b/x/erc20/keeper/ibc_callbacks.go
@@ -55,7 +55,7 @@ func (k Keeper) OnRecvPacket(
 	}
 
 	// Get addresses in `evmos1` and the original bech32 format
-	sender, recipient, _, _, err := ibc.GetTransferSenderRecipient(packet)
+	sender, recipient, _, _, err := ibc.GetTransferSenderRecipient(data)
 	if err != nil {
 		return channeltypes.NewErrorAcknowledgement(err)
 	}


### PR DESCRIPTION
# Description

Repeated parsing of packetData

The packetData has already been parsed in ibc_callbacks.go, so it is better to pass data into the method to reduce repetitive parsing
https://github.com/evmos/evmos/blob/5a5278898c1795f8f9d140a131398578564c75e8/x/erc20/keeper/ibc_callbacks.go#L40-L46

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until its ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
