### PR TITLE
feat(precompile): add precompile skeleton and vote tx for gov module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (precompiles) [#2550](https://github.com/evmos/evmos/pull/2550) Update secp256r1 curve precompile bech32 address to its corresponding value.
 - (staking) [#2051](https://github.com/evmos/evmos/pull/2051) Implement the `EditValidator` function for staking precompiled contract.
 - (evm) [#2373](https://github.com/evmos/evmos/pull/2373) Remove check on hardcoded ChainID identifier.
+- (precompiles) [#2573](https://github.com/evmos/evmos/pull/2573) Add precompile skeleton and vote tx for gov module.
 
 ### Bug Fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -498,19 +498,6 @@ func NewEvmos(
 		app.AccountKeeper, app.BankKeeper, scopedTransferKeeper,
 		app.Erc20Keeper, // Add ERC20 Keeper for ERC20 transfers
 	)
-	// We call this after setting the hooks to ensure that the hooks are set on the keeper
-	evmKeeper.WithPrecompiles(
-		evmkeeper.AvailablePrecompiles(
-			*stakingKeeper,
-			app.DistrKeeper,
-			app.BankKeeper,
-			app.Erc20Keeper,
-			app.VestingKeeper,
-			app.AuthzKeeper,
-			app.TransferKeeper,
-			app.IBCKeeper.ChannelKeeper,
-		),
-	)
 
 	epochsKeeper := epochskeeper.NewKeeper(appCodec, keys[epochstypes.StoreKey])
 	app.EpochsKeeper = *epochsKeeper.SetHooks(
@@ -529,6 +516,21 @@ func NewEvmos(
 	app.EvmKeeper = app.EvmKeeper.SetHooks(
 		evmkeeper.NewMultiEvmHooks(
 			app.Erc20Keeper.Hooks(),
+		),
+	)
+
+	// We call this after setting the hooks to ensure that the hooks are set on the keeper
+	evmKeeper.WithPrecompiles(
+		evmkeeper.AvailablePrecompiles(
+			*stakingKeeper,
+			app.DistrKeeper,
+			app.BankKeeper,
+			app.Erc20Keeper,
+			app.VestingKeeper,
+			app.AuthzKeeper,
+			app.TransferKeeper,
+			app.IBCKeeper.ChannelKeeper,
+			app.GovKeeper,
 		),
 	)
 

--- a/precompiles/gov/GovI.sol
+++ b/precompiles/gov/GovI.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.17;
+
+/// @dev The GovI contract's address.
+address constant GOV_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000805;
+
+/// @dev Define all the available gov methods.
+string constant MSG_VOTE = "/cosmos.gov.v1.MsgVote";
+
+/// @dev The GovI contract's instance.
+GovI constant GOV_CONTRACT = GovI(
+    GOV_PRECOMPILE_ADDRESS
+);
+
+/**
+ * @dev VoteOption enumerates the valid vote options for a given governance proposal.
+ */
+enum VoteOption {
+    // Unspecified defines a no-op vote option.
+    Unspecified,
+    // Yes defines a yes vote option.
+    Yes,
+    // Abstain defines an abstain vote option.
+    Abstain,
+    // No defines a no vote option.
+    No,
+    // NoWithWeto defines a no with veto vote option.
+    NoWithWeto
+}
+
+/// @author Luke
+/// @title Gov Precompile Contract
+/// @dev The interface through which solidity contracts will interact with Gov
+/// @custom:address 0x0000000000000000000000000000000000000805
+interface GovI {
+    /// @dev Vote defines an Event emitted when a proposal voted.
+    /// @param voter the address of the voter
+    /// @param proposalId the proposal of id
+    /// @param option the option for voter
+    event Vote(
+        address indexed voter,
+        uint64 proposalId,
+        uint8 option
+    );
+
+    /// TRANSACTIONS
+
+    /// @dev vote defines a method to add a vote on a specific proposal.
+    /// @param voter The address of the voter
+    /// @param proposalId the proposal of id
+    /// @param option the option for voter
+    /// @param metadata the metadata for voter send
+    /// @return success Whether the transaction was successful or not
+    function vote(
+        address voter,
+        uint64 proposalId,
+        VoteOption option,
+        string memory metadata
+    ) external returns (bool success);
+
+    /// QUERIES
+}

--- a/precompiles/gov/IGov.sol
+++ b/precompiles/gov/IGov.sol
@@ -8,7 +8,7 @@ address constant GOV_PRECOMPILE_ADDRESS = 0x000000000000000000000000000000000000
 string constant MSG_VOTE = "/cosmos.gov.v1.MsgVote";
 
 /// @dev The GovI contract's instance.
-GovI constant GOV_CONTRACT = GovI(
+IGov constant GOV_CONTRACT = IGov(
     GOV_PRECOMPILE_ADDRESS
 );
 
@@ -32,7 +32,7 @@ enum VoteOption {
 /// @title Gov Precompile Contract
 /// @dev The interface through which solidity contracts will interact with Gov
 /// @custom:address 0x0000000000000000000000000000000000000805
-interface GovI {
+interface IGov {
     /// @dev Vote defines an Event emitted when a proposal voted.
     /// @param voter the address of the voter
     /// @param proposalId the proposal of id

--- a/precompiles/gov/IGov.sol
+++ b/precompiles/gov/IGov.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.17;
 
-/// @dev The GovI contract's address.
+/// @dev The IGov contract's address.
 address constant GOV_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000805;
 
 /// @dev Define all the available gov methods.
 string constant MSG_VOTE = "/cosmos.gov.v1.MsgVote";
 
-/// @dev The GovI contract's instance.
+/// @dev The IGov contract's instance.
 IGov constant GOV_CONTRACT = IGov(
     GOV_PRECOMPILE_ADDRESS
 );

--- a/precompiles/gov/abi.json
+++ b/precompiles/gov/abi.json
@@ -1,0 +1,61 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "option",
+        "type": "uint8"
+      }
+    ],
+    "name": "Vote",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "enum VoteOption",
+        "name": "option",
+        "type": "uint8"
+      },
+      {
+        "internalType": "string",
+        "name": "metadata",
+        "type": "string"
+      }
+    ],
+    "name": "vote",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/precompiles/gov/errors.go
+++ b/precompiles/gov/errors.go
@@ -1,0 +1,16 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+package gov
+
+const (
+	// ErrDifferentOrigin is raised when the origin address is not the same as the voter address.
+	ErrDifferentOrigin = "tx origin address %s does not match the voter address %s"
+	// ErrInvalidVoter is raised when the voter address is not valid.
+	ErrInvalidVoter = "invalid voter address: %s"
+	// ErrInvalidProposalId invalid proposal id.
+	ErrInvalidProposalId = "invalid proposal id %d "
+	// ErrInvalidOption invalid option.
+	ErrInvalidOption = "invalid proposal id %d "
+	// ErrInvalidMetadata invalid metadata.
+	ErrInvalidMetadata = "invalid metadata %s "
+)

--- a/precompiles/gov/events.go
+++ b/precompiles/gov/events.go
@@ -1,0 +1,45 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package gov
+
+import (
+	"bytes"
+	"reflect"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+)
+
+const (
+	// EventTypeVote defines the event type for the gov VoteMethod transaction.
+	EventTypeVote = "Vote"
+)
+
+// EmitVoteEvent creates a new event emitted on a Vote transaction.
+func (p Precompile) EmitVoteEvent(ctx sdk.Context, stateDB vm.StateDB, voterAddress common.Address, proposalId uint64, option uint8) error {
+	// Prepare the event topics
+	event := p.ABI.Events[EventTypeVote]
+	topics := make([]common.Hash, 2)
+
+	// The first topic is always the signature of the event.
+	topics[0] = event.ID
+	topics[1] = common.BytesToHash(voterAddress.Bytes())
+
+	// Prepare the event data
+	var b bytes.Buffer
+	b.Write(cmn.PackNum(reflect.ValueOf(proposalId)))
+	b.Write(cmn.PackNum(reflect.ValueOf(option)))
+
+	stateDB.AddLog(&ethtypes.Log{
+		Address:     p.Address(),
+		Topics:      topics,
+		Data:        b.Bytes(),
+		BlockNumber: uint64(ctx.BlockHeight()),
+	})
+
+	return nil
+}

--- a/precompiles/gov/events_test.go
+++ b/precompiles/gov/events_test.go
@@ -1,0 +1,75 @@
+package gov_test
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+	"github.com/evmos/evmos/v18/precompiles/gov"
+)
+
+func (s *PrecompileTestSuite) TestVoteEvent() {
+	method := s.precompile.Methods[gov.VoteMethod]
+	testCases := []struct {
+		name        string
+		malleate    func(voter common.Address, proposalId uint64, option uint8, metadata string) []interface{}
+		postCheck   func()
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"success - the correct event is emitted",
+			func(voter common.Address, proposalId uint64, option uint8, metadata string) []interface{} {
+				return []interface{}{
+					voter,
+					proposalId,
+					option,
+					metadata,
+				}
+			},
+			func() {
+				log := s.stateDB.Logs()[0]
+				s.Require().Equal(log.Address, s.precompile.Address())
+
+				// Check event signature matches the one emitted
+				event := s.precompile.ABI.Events[gov.EventTypeVote]
+				s.Require().Equal(crypto.Keccak256Hash([]byte(event.Sig)), common.HexToHash(log.Topics[0].Hex()))
+				s.Require().Equal(log.BlockNumber, uint64(s.ctx.BlockHeight()))
+
+				// Check the fully unpacked event matches the one emitted
+				var voteEvent gov.EventVote
+				err := cmn.UnpackLog(s.precompile.ABI, &voteEvent, gov.EventTypeVote, *log)
+				s.Require().NoError(err)
+				s.Require().Equal(s.address, voteEvent.Voter)
+				s.Require().Equal(uint64(1), voteEvent.ProposalId)
+				s.Require().Equal(uint8(1), voteEvent.Option)
+			},
+			20000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.SetupTest()
+
+		contract := vm.NewContract(vm.AccountRef(s.address), s.precompile, big.NewInt(0), tc.gas)
+		s.ctx = s.ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+		initialGas := s.ctx.GasMeter().GasConsumed()
+		s.Require().Zero(initialGas)
+
+		_, err := s.precompile.Vote(s.ctx, s.address, contract, s.stateDB, &method, tc.malleate(s.address, 1, 1, "metadata"))
+
+		if tc.expError {
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), tc.errContains)
+		} else {
+			s.Require().NoError(err)
+			tc.postCheck()
+		}
+	}
+}

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -1,0 +1,128 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package gov
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+)
+
+var _ vm.PrecompiledContract = &Precompile{}
+
+// Embed abi json file to the executable binary. Needed when importing as dependency.
+//
+//go:embed abi.json
+var f embed.FS
+
+// Precompile defines the precompiled contract for gov.
+type Precompile struct {
+	cmn.Precompile
+	govKeeper govkeeper.Keeper
+}
+
+// NewPrecompile creates a new gov Precompile instance as a
+// PrecompiledContract interface.
+func NewPrecompile(
+	govKeeper govkeeper.Keeper,
+	authzKeeper authzkeeper.Keeper,
+) (*Precompile, error) {
+	abiBz, err := f.ReadFile("abi.json")
+	if err != nil {
+		return nil, fmt.Errorf("error loading the gov ABI %s", err)
+	}
+
+	newAbi, err := abi.JSON(bytes.NewReader(abiBz))
+	if err != nil {
+		return nil, fmt.Errorf(cmn.ErrInvalidABI, err)
+	}
+
+	return &Precompile{
+		Precompile: cmn.Precompile{
+			ABI:                  newAbi,
+			AuthzKeeper:          authzKeeper,
+			KvGasConfig:          storetypes.KVGasConfig(),
+			TransientKVGasConfig: storetypes.TransientGasConfig(),
+			ApprovalExpiration:   cmn.DefaultExpirationDuration, // should be configurable in the future.
+		},
+		govKeeper: govKeeper,
+	}, nil
+}
+
+// Address defines the address of the gov compile contract.
+// address: 0x0000000000000000000000000000000000000805
+func (p Precompile) Address() common.Address {
+	return common.HexToAddress("0x0000000000000000000000000000000000000805")
+}
+
+// RequiredGas calculates the precompiled contract's base gas rate.
+func (p Precompile) RequiredGas(input []byte) uint64 {
+	methodID := input[:4]
+
+	method, err := p.MethodById(methodID)
+	if err != nil {
+		// This should never happen since this method is going to fail during Run
+		return 0
+	}
+
+	return p.Precompile.RequiredGas(input, p.IsTransaction(method.Name))
+}
+
+// Run executes the precompiled contract gov methods defined in the ABI.
+func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	if err != nil {
+		return nil, err
+	}
+
+	// This handles any out of gas errors that may occur during the execution of a precompile tx or query.
+	// It avoids panics and returns the out of gas error so the EVM can continue gracefully.
+	defer cmn.HandleGasError(ctx, contract, initialGas, &err)()
+
+	if err := stateDB.Commit(); err != nil {
+		return nil, err
+	}
+
+	switch method.Name {
+	// gov transactions
+	case VoteMethod:
+		bz, err = p.Vote(ctx, evm.Origin, contract, stateDB, method, args)
+	// gov queries
+	case ProposalMethod:
+		bz, err = p.Proposal(ctx, contract, method, args)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	cost := ctx.GasMeter().GasConsumed() - initialGas
+
+	if !contract.UseGas(cost) {
+		return nil, vm.ErrOutOfGas
+	}
+
+	return bz, nil
+}
+
+// IsTransaction checks if the given method name corresponds to a transaction or query.
+//
+// Available gov transactions are:
+//   - Vote
+func (Precompile) IsTransaction(methodName string) bool {
+	switch methodName {
+	case VoteMethod:
+		return true
+	default:
+		return false
+	}
+}

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -96,9 +96,10 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	// gov transactions
 	case VoteMethod:
 		bz, err = p.Vote(ctx, evm.Origin, contract, stateDB, method, args)
-	// gov queries
-	case ProposalMethod:
-		bz, err = p.Proposal(ctx, contract, method, args)
+		// gov queries
+		// next task
+		// case ProposalMethod:
+		//	bz, err = p.Proposal(ctx, contract, method, args)
 	}
 
 	if err != nil {

--- a/precompiles/gov/gov_test.go
+++ b/precompiles/gov/gov_test.go
@@ -1,0 +1,138 @@
+package gov_test
+
+import (
+	"math/big"
+
+	"github.com/evmos/evmos/v18/precompiles/gov"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/evmos/evmos/v18/app"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+)
+
+func (s *PrecompileTestSuite) TestIsTransaction() {
+	testCases := []struct {
+		name   string
+		method string
+		isTx   bool
+	}{
+		{
+			gov.VoteMethod,
+			s.precompile.Methods[gov.VoteMethod].Name,
+			true,
+		},
+		{
+			"invalid",
+			"invalid",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.Require().Equal(s.precompile.IsTransaction(tc.method), tc.isTx)
+		})
+	}
+}
+
+// TestRun tests the precompile's Run method.
+func (s *PrecompileTestSuite) TestRun() {
+	testcases := []struct {
+		name        string
+		malleate    func() (common.Address, []byte)
+		readOnly    bool
+		expPass     bool
+		errContains string
+	}{
+		{
+			name: "pass - vote transaction",
+			malleate: func() (common.Address, []byte) {
+				const proposalId uint64 = 1
+				const option uint8 = 1
+				const metadata = "metadata"
+
+				input, err := s.precompile.Pack(
+					gov.VoteMethod,
+					s.address,
+					proposalId,
+					option,
+					metadata,
+				)
+				s.Require().NoError(err, "failed to pack input")
+				return s.address, input
+			},
+			readOnly: false,
+			expPass:  true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		s.Run(tc.name, func() {
+			// setup basic test suite
+			s.SetupTest()
+
+			baseFee := s.app.FeeMarketKeeper.GetBaseFee(s.ctx)
+
+			// malleate testcase
+			caller, input := tc.malleate()
+
+			contract := vm.NewPrecompile(vm.AccountRef(caller), s.precompile, big.NewInt(0), uint64(1e6))
+			contract.Input = input
+
+			contractAddr := contract.Address()
+			// Build and sign Ethereum transaction
+			txArgs := evmtypes.EvmTxArgs{
+				ChainID:   s.app.EvmKeeper.ChainID(),
+				Nonce:     0,
+				To:        &contractAddr,
+				Amount:    nil,
+				GasLimit:  100000,
+				GasPrice:  app.MainnetMinGasPrices.BigInt(),
+				GasFeeCap: baseFee,
+				GasTipCap: big.NewInt(1),
+				Accesses:  &ethtypes.AccessList{},
+			}
+			msgEthereumTx := evmtypes.NewTx(&txArgs)
+
+			msgEthereumTx.From = s.address.String()
+			err := msgEthereumTx.Sign(s.ethSigner, s.signer)
+			s.Require().NoError(err, "failed to sign Ethereum message")
+
+			// Instantiate config
+			proposerAddress := s.ctx.BlockHeader().ProposerAddress
+			cfg, err := s.app.EvmKeeper.EVMConfig(s.ctx, proposerAddress, s.app.EvmKeeper.ChainID())
+			s.Require().NoError(err, "failed to instantiate EVM config")
+
+			msg, err := msgEthereumTx.AsMessage(s.ethSigner, baseFee)
+			s.Require().NoError(err, "failed to instantiate Ethereum message")
+
+			// Instantiate EVM
+			evm := s.app.EvmKeeper.NewEVM(
+				s.ctx, msg, cfg, nil, s.stateDB,
+			)
+
+			params := s.app.EvmKeeper.GetParams(s.ctx)
+			activePrecompiles := params.GetActivePrecompilesAddrs()
+			precompileMap := s.app.EvmKeeper.Precompiles(activePrecompiles...)
+			err = vm.ValidatePrecompiles(precompileMap, activePrecompiles)
+			s.Require().NoError(err, "invalid precompiles", activePrecompiles)
+			evm.WithPrecompiles(precompileMap, activePrecompiles)
+
+			// Run precompiled contract
+			bz, err := s.precompile.Run(evm, contract, tc.readOnly)
+
+			// Check results
+			if tc.expPass {
+				s.Require().NoError(err, "expected no error when running the precompile")
+				s.Require().NotNil(bz, "expected returned bytes not to be nil")
+			} else {
+				s.Require().Error(err, "expected error to be returned when running the precompile")
+				s.Require().Nil(bz, "expected returned bytes to be nil")
+				s.Require().ErrorContains(err, tc.errContains)
+			}
+		})
+	}
+}

--- a/precompiles/gov/integration_test.go
+++ b/precompiles/gov/integration_test.go
@@ -4,13 +4,11 @@ package gov_test
 
 import (
 	"fmt"
-	"math/big"
-
-	"github.com/evmos/evmos/v18/precompiles/gov"
 
 	"cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/core/vm"
 	cmn "github.com/evmos/evmos/v18/precompiles/common"
+	"github.com/evmos/evmos/v18/precompiles/gov"
 	"github.com/evmos/evmos/v18/precompiles/testutil"
 	"github.com/evmos/evmos/v18/precompiles/testutil/contracts"
 	testutiltx "github.com/evmos/evmos/v18/testutil/tx"
@@ -24,10 +22,6 @@ import (
 var (
 	// differentAddr is an address generated for testing purposes that e.g. raises the different origin error
 	differentAddr = testutiltx.GenerateAddress()
-	// expRewardAmt is the expected amount of rewards
-	expRewardAmt = big.NewInt(2000000000000000000)
-	// gasPrice is the gas price used for the transactions
-	gasPrice = big.NewInt(1e9)
 	// defaultCallArgs  are the default arguments for calling the smart contract
 	//
 	// NOTE: this has to be populated in a BeforeEach block because the contractAddr would otherwise be a nil address.

--- a/precompiles/gov/integration_test.go
+++ b/precompiles/gov/integration_test.go
@@ -1,0 +1,127 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+package gov_test
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/evmos/evmos/v18/precompiles/gov"
+
+	"cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/core/vm"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+	"github.com/evmos/evmos/v18/precompiles/testutil"
+	"github.com/evmos/evmos/v18/precompiles/testutil/contracts"
+	testutiltx "github.com/evmos/evmos/v18/testutil/tx"
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/ginkgo/v2"
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/gomega"
+)
+
+// General variables used for integration tests
+var (
+	// differentAddr is an address generated for testing purposes that e.g. raises the different origin error
+	differentAddr = testutiltx.GenerateAddress()
+	// expRewardAmt is the expected amount of rewards
+	expRewardAmt = big.NewInt(2000000000000000000)
+	// gasPrice is the gas price used for the transactions
+	gasPrice = big.NewInt(1e9)
+	// defaultCallArgs  are the default arguments for calling the smart contract
+	//
+	// NOTE: this has to be populated in a BeforeEach block because the contractAddr would otherwise be a nil address.
+	defaultCallArgs contracts.CallArgs
+
+	// defaultLogCheck instantiates a log check arguments struct with the precompile ABI events populated.
+	defaultLogCheck testutil.LogCheckArgs
+	// passCheck defines the arguments to check if the precompile returns no error
+	passCheck testutil.LogCheckArgs
+	// outOfGasCheck defines the arguments to check if the precompile returns out of gas error
+	outOfGasCheck testutil.LogCheckArgs
+)
+
+var _ = Describe("Calling distribution precompile from EOA", func() {
+	BeforeEach(func() {
+		s.SetupTest()
+
+		// set the default call arguments
+		defaultCallArgs = contracts.CallArgs{
+			ContractAddr: s.precompile.Address(),
+			ContractABI:  s.precompile.ABI,
+			PrivKey:      s.privKey,
+		}
+
+		defaultLogCheck = testutil.LogCheckArgs{
+			ABIEvents: s.precompile.ABI.Events,
+		}
+		passCheck = defaultLogCheck.WithExpPass(true)
+		outOfGasCheck = defaultLogCheck.WithErrContains(vm.ErrOutOfGas.Error())
+	})
+
+	// =====================================
+	// 				TRANSACTIONS
+	// =====================================
+	Describe("Execute Vote transaction", func() {
+		const method = gov.VoteMethod
+		const proposalId uint64 = 1
+		const option uint8 = 1
+		const metadata = "metadata"
+		// defaultVoteArgs are the default arguments to set the withdraw address
+		//
+		// NOTE: this has to be populated in the BeforeEach block because the private key otherwise is not yet initialized.
+		var defaultVoteArgs contracts.CallArgs
+
+		BeforeEach(func() {
+			// set the default call arguments
+			defaultVoteArgs = defaultCallArgs.WithMethodName(method)
+		})
+
+		It("should return error if the provided gasLimit is too low", func() {
+			voteArgs := defaultVoteArgs.
+				WithGasLimit(30000).
+				WithArgs(s.address, proposalId, option, metadata)
+
+			_, _, err := contracts.CallContractAndCheckLogs(s.ctx, s.app, voteArgs, outOfGasCheck)
+			Expect(err).To(HaveOccurred(), "error while calling the precompile")
+			Expect(err.Error()).To(ContainSubstring("out of gas"), "expected out of gas error")
+
+			// tally result yes count should remain unchanged
+			proposal, _ := s.app.GovKeeper.GetProposal(s.ctx, proposalId)
+			_, _, tallyResult := s.app.GovKeeper.Tally(s.ctx, proposal)
+			Expect(tallyResult.YesCount).To(Equal("0"), "expected tally result yes count to remain unchanged")
+		})
+
+		It("should return error if the origin is different than the voter", func() {
+			voteArgs := defaultVoteArgs.WithArgs(differentAddr, proposalId, option, metadata)
+
+			voterSetCheck := defaultLogCheck.WithErrContains(cmn.ErrDifferentOrigin, s.address.String(), differentAddr.String())
+
+			_, _, err := contracts.CallContractAndCheckLogs(s.ctx, s.app, voteArgs, voterSetCheck)
+			Expect(err).To(HaveOccurred(), "error while calling the precompile")
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(gov.ErrDifferentOrigin, s.address, differentAddr)), "expected different origin error")
+		})
+
+		It("should vote success", func() {
+			voteArgs := defaultVoteArgs.WithArgs(s.address, proposalId, option, metadata)
+
+			voterSetCheck := passCheck.WithExpEvents(gov.EventTypeVote)
+
+			_, _, err := contracts.CallContractAndCheckLogs(s.ctx, s.app, voteArgs, voterSetCheck)
+			Expect(err).To(BeNil(), "error while calling the precompile")
+
+			// tally result yes count should updated
+			proposal, _ := s.app.GovKeeper.GetProposal(s.ctx, proposalId)
+			_, _, tallyResult := s.app.GovKeeper.Tally(s.ctx, proposal)
+			Expect(tallyResult.YesCount).To(Equal(math.NewInt(3e18).String()), "expected tally result yes count updated")
+		})
+	})
+
+	// =====================================
+	// 				QUERIES
+	// =====================================
+	Describe("Execute queries", func() {
+		It("should get proposal info - proposal query", func() {
+		})
+	})
+})

--- a/precompiles/gov/query.go
+++ b/precompiles/gov/query.go
@@ -16,10 +16,10 @@ const (
 
 // Proposal returns the proposal info.
 func (p Precompile) Proposal(
-	ctx sdk.Context,
+	_ sdk.Context,
 	_ *vm.Contract,
-	method *abi.Method,
-	args []interface{},
+	_ *abi.Method,
+	_ []interface{},
 ) ([]byte, error) {
 	return nil, nil
 }

--- a/precompiles/gov/query.go
+++ b/precompiles/gov/query.go
@@ -1,0 +1,25 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package gov
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+const (
+	// ProposalMethod defines the ABI method name for the Proposal query.
+	ProposalMethod = "proposal"
+)
+
+// Proposal returns the proposal info.
+func (p Precompile) Proposal(
+	ctx sdk.Context,
+	_ *vm.Contract,
+	method *abi.Method,
+	args []interface{},
+) ([]byte, error) {
+	return nil, nil
+}

--- a/precompiles/gov/query_test.go
+++ b/precompiles/gov/query_test.go
@@ -1,0 +1,33 @@
+package gov_test
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+
+	"github.com/evmos/evmos/v18/precompiles/gov"
+)
+
+type proposalTestCases struct {
+	name        string
+	malleate    func() []interface{}
+	postCheck   func(bz []byte)
+	gas         uint64
+	expErr      bool
+	errContains string
+}
+
+func (s *PrecompileTestSuite) TestProposal() {
+	method := s.precompile.Methods[gov.ProposalMethod]
+
+	testCases := []proposalTestCases{}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest() // reset
+			contract := vm.NewContract(vm.AccountRef(s.address), s.precompile, big.NewInt(0), tc.gas)
+			_ = contract
+			_ = method
+		})
+	}
+}

--- a/precompiles/gov/setup_test.go
+++ b/precompiles/gov/setup_test.go
@@ -1,0 +1,58 @@
+package gov_test
+
+import (
+	"testing"
+
+	"github.com/evmos/evmos/v18/precompiles/gov"
+	"github.com/evmos/evmos/v18/x/evm/statedb"
+
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/ginkgo/v2"
+	//nolint:revive // dot imports are fine for Ginkgo
+	. "github.com/onsi/gomega"
+
+	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	evmosapp "github.com/evmos/evmos/v18/app"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+	"github.com/stretchr/testify/suite"
+)
+
+var s *PrecompileTestSuite
+
+type PrecompileTestSuite struct {
+	suite.Suite
+
+	ctx        sdk.Context
+	app        *evmosapp.Evmos
+	address    common.Address
+	validators []stakingtypes.Validator
+	valSet     *tmtypes.ValidatorSet
+	ethSigner  ethtypes.Signer
+	privKey    cryptotypes.PrivKey
+	signer     keyring.Signer
+	bondDenom  string
+
+	precompile *gov.Precompile
+	stateDB    *statedb.StateDB
+
+	queryClientEVM evmtypes.QueryClient
+}
+
+func TestPrecompileTestSuite(t *testing.T) {
+	s = new(PrecompileTestSuite)
+	suite.Run(t, s)
+
+	// Run Ginkgo integration tests
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Distribution Precompile Suite")
+}
+
+func (s *PrecompileTestSuite) SetupTest() {
+	s.DoSetupTest()
+}

--- a/precompiles/gov/tx.go
+++ b/precompiles/gov/tx.go
@@ -1,0 +1,54 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package gov
+
+import (
+	"fmt"
+
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+const (
+	// VoteMethod defines the ABI method name for the gov Vote transaction.
+	VoteMethod = "vote"
+)
+
+// Vote claims the rewards accumulated by a delegator from multiple or all validators.
+func (p Precompile) Vote(
+	ctx sdk.Context,
+	origin common.Address,
+	contract *vm.Contract,
+	stateDB vm.StateDB,
+	method *abi.Method,
+	args []interface{},
+) ([]byte, error) {
+	msg, voterHexAddr, err := NewMsgVote(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the contract is the voter, we don't need an origin check
+	// Otherwise check if the origin matches the delegator address
+	isContractVoter := contract.CallerAddress == voterHexAddr
+	if !isContractVoter && origin != voterHexAddr {
+		return nil, fmt.Errorf(ErrDifferentOrigin, origin.String(), voterHexAddr.String())
+	}
+
+	msgSrv := govkeeper.NewMsgServerImpl(&p.govKeeper)
+	if _, err = msgSrv.Vote(sdk.WrapSDKContext(ctx), msg); err != nil {
+		return nil, err
+	}
+
+	if err = p.EmitVoteEvent(ctx, stateDB, voterHexAddr, msg.ProposalId, uint8(msg.Option)); err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(true)
+}

--- a/precompiles/gov/tx_test.go
+++ b/precompiles/gov/tx_test.go
@@ -1,0 +1,125 @@
+package gov_test
+
+import (
+	"fmt"
+
+	"cosmossdk.io/math"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/evmos/evmos/v18/precompiles/testutil"
+
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+	"github.com/evmos/evmos/v18/precompiles/gov"
+	utiltx "github.com/evmos/evmos/v18/testutil/tx"
+)
+
+func (s *PrecompileTestSuite) TestVote() {
+	method := s.precompile.Methods[gov.VoteMethod]
+	newVoterAddr := utiltx.GenerateAddress()
+	const proposalId uint64 = 1
+	const option uint8 = 1
+	const metadata = "metadata"
+
+	testCases := []struct {
+		name        string
+		malleate    func() []interface{}
+		postCheck   func()
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"fail - empty input args",
+			func() []interface{} {
+				return []interface{}{}
+			},
+			func() {},
+			200000,
+			true,
+			fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 4, 0),
+		},
+		{
+			"fail - invalid voter address",
+			func() []interface{} {
+				return []interface{}{
+					"",
+					proposalId,
+					option,
+					metadata,
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"invalid voter address",
+		},
+		{
+			"fail - invalid voter address",
+			func() []interface{} {
+				return []interface{}{
+					common.Address{},
+					proposalId,
+					option,
+					metadata,
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"invalid voter address",
+		},
+		{
+			"fail - using a different voter address",
+			func() []interface{} {
+				return []interface{}{
+					newVoterAddr,
+					proposalId,
+					option,
+					metadata,
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"does not match the voter address",
+		},
+		{
+			"success - vote proposal success",
+			func() []interface{} {
+				return []interface{}{
+					s.address,
+					proposalId,
+					option,
+					metadata,
+				}
+			},
+			func() {
+				proposal, _ := s.app.GovKeeper.GetProposal(s.ctx, proposalId)
+				_, _, tallyResult := s.app.GovKeeper.Tally(s.ctx, proposal)
+				s.Require().Equal(math.NewInt(3e18).String(), tallyResult.YesCount)
+			},
+			200000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			var contract *vm.Contract
+			contract, s.ctx = testutil.NewPrecompileContract(s.T(), s.ctx, s.address, s.precompile, tc.gas)
+
+			_, err := s.precompile.Vote(s.ctx, s.address, contract, s.stateDB, &method, tc.malleate())
+
+			if tc.expError {
+				s.Require().ErrorContains(err, tc.errContains)
+			} else {
+				s.Require().NoError(err)
+				tc.postCheck()
+			}
+		})
+	}
+}

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -18,10 +18,6 @@ type EventSetWithdrawAddress struct {
 	WithdrawerAddress string
 }
 
-// address indexed voter,
-// uint64 proposalId,
-// uint8 option
-
 // EventVote defines the event data for the Vote transaction.
 type EventVote struct {
 	Voter      common.Address

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -1,0 +1,70 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package gov
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/ethereum/go-ethereum/common"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+)
+
+// EventSetWithdrawAddress defines the event data for the SetWithdrawAddress transaction.
+type EventSetWithdrawAddress struct {
+	Caller            common.Address
+	WithdrawerAddress string
+}
+
+// address indexed voter,
+// uint64 proposalId,
+// uint8 option
+
+// EventVote defines the event data for the Vote transaction.
+type EventVote struct {
+	Voter      common.Address
+	ProposalId uint64
+	Option     uint8
+}
+
+// NewMsgVote creates a new MsgVote instance.
+func NewMsgVote(args []interface{}) (*govv1.MsgVote, common.Address, error) {
+	if len(args) != 4 {
+		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 4, len(args))
+	}
+
+	voterAddress, ok := args[0].(common.Address)
+	if !ok || voterAddress == (common.Address{}) {
+		return nil, common.Address{}, fmt.Errorf(ErrInvalidVoter, args[0])
+	}
+
+	proposalId, ok := args[1].(uint64)
+	if !ok {
+		return nil, common.Address{}, fmt.Errorf(ErrInvalidProposalId, args[1])
+	}
+
+	option, ok := args[2].(uint8)
+	if !ok {
+		return nil, common.Address{}, fmt.Errorf(ErrInvalidOption, args[2])
+	}
+
+	metadata, ok := args[3].(string)
+	if !ok {
+		return nil, common.Address{}, fmt.Errorf(ErrInvalidMetadata, args[3])
+	}
+
+	msg := &govv1.MsgVote{
+		ProposalId: proposalId,
+		Voter:      sdk.AccAddress(voterAddress.Bytes()).String(),
+		Option:     govv1.VoteOption(option),
+		Metadata:   metadata,
+	}
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, common.Address{}, err
+	}
+
+	return msg, voterAddress, nil
+}

--- a/precompiles/gov/utils_test.go
+++ b/precompiles/gov/utils_test.go
@@ -1,0 +1,220 @@
+package gov_test
+
+import (
+	"encoding/json"
+	"time"
+
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+
+	"cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/testutil/mock"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	evmosapp "github.com/evmos/evmos/v18/app"
+	cmn "github.com/evmos/evmos/v18/precompiles/common"
+	"github.com/evmos/evmos/v18/precompiles/gov"
+	evmosutil "github.com/evmos/evmos/v18/testutil"
+	evmosutiltx "github.com/evmos/evmos/v18/testutil/tx"
+	evmostypes "github.com/evmos/evmos/v18/types"
+	"github.com/evmos/evmos/v18/utils"
+	"github.com/evmos/evmos/v18/x/evm/statedb"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+)
+
+// SetupWithGenesisValSet initializes a new EvmosApp with a validator set and genesis accounts
+// that also act as delegators. For simplicity, each validator is bonded with a delegation
+// of one consensus engine unit (10^6) in the default token of the simapp from first genesis
+// account. A Nop logger is set in SimApp.
+func (s *PrecompileTestSuite) SetupWithGenesisValSet(valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, balances ...banktypes.Balance) {
+	appI, genesisState := evmosapp.SetupTestingApp(cmn.DefaultChainID)()
+	app, ok := appI.(*evmosapp.Evmos)
+	s.Require().True(ok)
+
+	// set genesis accounts
+	authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), genAccs)
+	genesisState[authtypes.ModuleName] = app.AppCodec().MustMarshalJSON(authGenesis)
+
+	validators := make([]stakingtypes.Validator, 0, len(valSet.Validators))
+	delegations := make([]stakingtypes.Delegation, 0, len(valSet.Validators))
+
+	bondAmt := sdk.TokensFromConsensusPower(1, evmostypes.PowerReduction)
+
+	for _, val := range valSet.Validators {
+		pk, err := cryptocodec.FromTmPubKeyInterface(val.PubKey)
+		s.Require().NoError(err)
+		pkAny, err := codectypes.NewAnyWithValue(pk)
+		s.Require().NoError(err)
+		validator := stakingtypes.Validator{
+			OperatorAddress:   sdk.ValAddress(val.Address).String(),
+			ConsensusPubkey:   pkAny,
+			Jailed:            false,
+			Status:            stakingtypes.Bonded,
+			Tokens:            bondAmt,
+			DelegatorShares:   math.LegacyOneDec(),
+			Description:       stakingtypes.Description{},
+			UnbondingHeight:   int64(0),
+			UnbondingTime:     time.Unix(0, 0).UTC(),
+			Commission:        stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()),
+			MinSelfDelegation: math.ZeroInt(),
+		}
+		validators = append(validators, validator)
+		delegations = append(delegations, stakingtypes.NewDelegation(genAccs[0].GetAddress(), val.Address.Bytes(), math.LegacyOneDec()))
+	}
+	s.validators = validators
+
+	// set validators and delegations
+	stakingParams := stakingtypes.DefaultParams()
+	// set bond demon to be aevmos
+	stakingParams.BondDenom = utils.BaseDenom
+	stakingGenesis := stakingtypes.NewGenesisState(stakingParams, validators, delegations)
+	genesisState[stakingtypes.ModuleName] = app.AppCodec().MustMarshalJSON(stakingGenesis)
+
+	govParams := govv1.DefaultParams()
+	govParams.MinDeposit[0].Denom = utils.BaseDenom
+	govGenesis := govv1.NewGenesisState(1, govParams)
+	genesisState[govtypes.ModuleName] = app.AppCodec().MustMarshalJSON(govGenesis)
+
+	totalBondAmt := bondAmt.Add(bondAmt)
+	totalSupply := sdk.NewCoins()
+	for _, b := range balances {
+		// add genesis acc tokens and delegated tokens to total supply
+		totalSupply = totalSupply.Add(b.Coins.Add(sdk.NewCoin(utils.BaseDenom, totalBondAmt))...)
+	}
+
+	// add bonded amount to bonded pool module account
+	balances = append(balances, banktypes.Balance{
+		Address: authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String(),
+		Coins:   sdk.Coins{sdk.NewCoin(utils.BaseDenom, totalBondAmt)},
+	})
+
+	// update total supply
+	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.SendEnabled{})
+	genesisState[banktypes.ModuleName] = app.AppCodec().MustMarshalJSON(bankGenesis)
+
+	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
+	s.Require().NoError(err)
+
+	// init chain will set the validator set and initialize the genesis accounts
+	app.InitChain(
+		abci.RequestInitChain{
+			ChainId:         cmn.DefaultChainID,
+			Validators:      []abci.ValidatorUpdate{},
+			ConsensusParams: evmosapp.DefaultConsensusParams,
+			AppStateBytes:   stateBytes,
+		},
+	)
+	app.Commit()
+
+	// instantiate new header
+	header := evmosutil.NewHeader(
+		2,
+		time.Now().UTC(),
+		cmn.DefaultChainID,
+		sdk.ConsAddress(validators[0].GetOperator()),
+		tmhash.Sum([]byte("app")),
+		tmhash.Sum([]byte("validators")),
+	)
+
+	app.BeginBlock(abci.RequestBeginBlock{
+		Header: header,
+	})
+
+	// create Context
+	s.ctx = app.BaseApp.NewContext(false, header)
+	s.app = app
+}
+
+func (s *PrecompileTestSuite) DoSetupTest() {
+	// generate validator private/public key
+	privVal := mock.NewPV()
+	pubKey, err := privVal.GetPubKey()
+	s.Require().NoError(err)
+
+	privVal2 := mock.NewPV()
+	pubKey2, err := privVal2.GetPubKey()
+	s.Require().NoError(err)
+
+	// create validator set with two validators
+	validator := tmtypes.NewValidator(pubKey, 1)
+	validator2 := tmtypes.NewValidator(pubKey2, 2)
+	s.valSet = tmtypes.NewValidatorSet([]*tmtypes.Validator{validator, validator2})
+	signers := make(map[string]tmtypes.PrivValidator)
+	signers[pubKey.Address().String()] = privVal
+	signers[pubKey2.Address().String()] = privVal2
+
+	// generate genesis account
+	addr, priv := evmosutiltx.NewAddrKey()
+	s.privKey = priv
+	s.address = addr
+	s.signer = evmosutiltx.NewSigner(priv)
+
+	baseAcc := authtypes.NewBaseAccount(priv.PubKey().Address().Bytes(), priv.PubKey(), 0, 0)
+
+	acc := &evmostypes.EthAccount{
+		BaseAccount: baseAcc,
+		CodeHash:    common.BytesToHash(evmtypes.EmptyCodeHash).Hex(),
+	}
+
+	amount := sdk.TokensFromConsensusPower(5, evmostypes.PowerReduction)
+
+	balance := banktypes.Balance{
+		Address: acc.GetAddress().String(),
+		Coins:   sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, amount)),
+	}
+
+	s.SetupWithGenesisValSet(s.valSet, []authtypes.GenesisAccount{acc}, balance)
+
+	// Create StateDB
+	s.stateDB = statedb.New(s.ctx, s.app.EvmKeeper, statedb.NewEmptyTxConfig(common.BytesToHash(s.ctx.HeaderHash().Bytes())))
+
+	// bond denom
+	stakingParams := s.app.StakingKeeper.GetParams(s.ctx)
+	stakingParams.BondDenom = utils.BaseDenom
+	s.bondDenom = stakingParams.BondDenom
+	err = s.app.StakingKeeper.SetParams(s.ctx, stakingParams)
+	s.Require().NoError(err)
+
+	s.ethSigner = ethtypes.LatestSignerForChainID(s.app.EvmKeeper.ChainID())
+
+	precompile, err := gov.NewPrecompile(s.app.GovKeeper, s.app.AuthzKeeper)
+	s.Require().NoError(err)
+	s.precompile = precompile
+
+	// fund account to make delegation
+	err = evmosutil.FundAccountWithBaseDenom(s.ctx, s.app.BankKeeper, s.address.Bytes(), 5e18)
+	s.Require().NoError(err)
+
+	// make a delegation
+	_, err = s.app.StakingKeeper.Delegate(s.ctx, s.address.Bytes(), math.NewInt(1e18), stakingtypes.Unspecified, s.validators[0], true)
+	s.Require().NoError(err)
+
+	// submit a text proposal
+	initialDeposit := s.app.GovKeeper.GetParams(s.ctx).MinDeposit
+	content, _ := govv1beta1.ContentFromProposalType("proposal title", "proposal description", govv1beta1.ProposalTypeText)
+	msg, err := govv1beta1.NewMsgSubmitProposal(content, initialDeposit, s.address.Bytes())
+	s.Require().NoError(err)
+	err = msg.ValidateBasic()
+	s.Require().NoError(err)
+
+	msgServer := govkeeper.NewMsgServerImpl(&s.app.GovKeeper)
+	server := govkeeper.NewLegacyMsgServerImpl(s.app.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String(), msgServer)
+	_, err = server.SubmitProposal(s.ctx, msg)
+	s.Require().NoError(err)
+
+	queryHelperEvm := baseapp.NewQueryServerTestHelper(s.ctx, s.app.InterfaceRegistry())
+	evmtypes.RegisterQueryServer(queryHelperEvm, s.app.EvmKeeper)
+	s.queryClientEVM = evmtypes.NewQueryClient(queryHelperEvm)
+}

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -27,10 +27,10 @@ import (
 const invalidAddress = "0x0000"
 
 // expGasConsumed is the gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee)
-const expGasConsumed = 7436
+const expGasConsumed = 7568
 
 // expGasConsumedWithFeeMkt is the gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) with enabled feemarket
-const expGasConsumedWithFeeMkt = 7430
+const expGasConsumedWithFeeMkt = 7562
 
 func (suite *KeeperTestSuite) TestQueryAccount() {
 	var (
@@ -946,7 +946,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			},
 			expPass:       true,
 			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
-			expFinalGas:   26540, // gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) + gas consumed in malleate func
+			expFinalGas:   28124, // gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) + gas consumed in malleate func
 		},
 		{
 			msg: "invalid chain id",

--- a/x/evm/keeper/precompiles.go
+++ b/x/evm/keeper/precompiles.go
@@ -9,6 +9,8 @@ import (
 	"maps"
 	"sort"
 
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+
 	"github.com/evmos/evmos/v18/precompiles/bech32"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -21,6 +23,7 @@ import (
 	channelkeeper "github.com/cosmos/ibc-go/v7/modules/core/04-channel/keeper"
 	bankprecompile "github.com/evmos/evmos/v18/precompiles/bank"
 	distprecompile "github.com/evmos/evmos/v18/precompiles/distribution"
+	govprecompile "github.com/evmos/evmos/v18/precompiles/gov"
 	ics20precompile "github.com/evmos/evmos/v18/precompiles/ics20"
 	"github.com/evmos/evmos/v18/precompiles/p256"
 	stakingprecompile "github.com/evmos/evmos/v18/precompiles/staking"
@@ -42,6 +45,7 @@ func AvailablePrecompiles(
 	authzKeeper authzkeeper.Keeper,
 	transferKeeper transferkeeper.Keeper,
 	channelKeeper channelkeeper.Keeper,
+	govKeeper govkeeper.Keeper,
 ) map[common.Address]vm.PrecompiledContract {
 	// Clone the mapping from the latest EVM fork.
 	precompiles := maps.Clone(vm.PrecompiledContractsBerlin)
@@ -82,6 +86,11 @@ func AvailablePrecompiles(
 		panic(fmt.Errorf("failed to instantiate bank precompile: %w", err))
 	}
 
+	govPrecompile, err := govprecompile.NewPrecompile(govKeeper, authzKeeper)
+	if err != nil {
+		panic(fmt.Errorf("failed to instantiate gov precompile: %w", err))
+	}
+
 	// Stateless precompiles
 	precompiles[bech32Precompile.Address()] = bech32Precompile
 	precompiles[p256Precompile.Address()] = p256Precompile
@@ -92,6 +101,7 @@ func AvailablePrecompiles(
 	precompiles[vestingPrecompile.Address()] = vestingPrecompile
 	precompiles[ibcTransferPrecompile.Address()] = ibcTransferPrecompile
 	precompiles[bankPrecompile.Address()] = bankPrecompile
+	precompiles[govPrecompile.Address()] = govPrecompile
 
 	return precompiles
 }

--- a/x/evm/types/params.go
+++ b/x/evm/types/params.go
@@ -40,6 +40,7 @@ var (
 		"0x0000000000000000000000000000000000000802", // ICS20 transfer precompile
 		"0x0000000000000000000000000000000000000803", // Vesting precompile
 		"0x0000000000000000000000000000000000000804", // Bank precompile
+		"0x0000000000000000000000000000000000000805", // Gov precompile
 	}
 	// DefaultExtraEIPs defines the default extra EIPs to be included
 	// On v15, EIP 3855 was enabled


### PR DESCRIPTION
# Description

Try to complete the development of all precompile contract in the entire gov module, starting from the simplest vote transaction. 😄

below is the javascript test
```javascript
import { ethers } from 'ethers';

export const main = async () => {
  const rpc = 'http://127.0.0.1:8545';
  const abi = [
    {
      inputs: [
        {
          internalType: 'address',
          name: 'voter',
          type: 'address',
        },
        {
          internalType: 'uint64',
          name: 'proposalId',
          type: 'uint64',
        },
        {
          internalType: 'enum VoteOption',
          name: 'option',
          type: 'uint8',
        },
        {
          internalType: 'string',
          name: 'metadata',
          type: 'string',
        },
      ],
      name: 'vote',
      outputs: [
        {
          internalType: 'bool',
          name: 'success',
          type: 'bool',
        },
      ],
      stateMutability: 'nonpayable',
      type: 'function',
    },
  ];
  const provider = new ethers.JsonRpcProvider(rpc);
  const privateKey = 'YOU_PRIVATE_KEY';
  const wallet = new ethers.Wallet(privateKey, provider);
  const gov = new ethers.Contract('0x0000000000000000000000000000000000000805', abi, wallet);

  const voter = wallet.address;
  const proposalId = 1; // send a proposal using a transaction of cosmos type first. In the near future, it should support send proposals with EVM transactions.
  const option = 1; // Yes
  const metadata = 'hello world';

  const tx = await gov.vote(voter, proposalId, option, metadata);
  const receipt = await tx.wait();
  console.log('vote receipt', receipt);
};

main();

```
