### PR TITLE
Add: Support PebbleDB image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,5 @@ jobs:
             go.sum
             *.toml
       - run: |
-          make build-docker-goleveldb
-          make build-docker-pebbledb
+          make build
         if: env.GIT_DIFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - release/**
-      - Amine/**
 
 permissions: read-all
 
@@ -14,7 +13,7 @@ jobs:
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
       - release/**
-      
+      - Amine/**
+
 permissions: read-all
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   build:
@@ -33,5 +34,6 @@ jobs:
             go.sum
             *.toml
       - run: |
-          make build
+          make build-docker-goleveldb
+          make build-docker-pebbledb
         if: env.GIT_DIFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
       - run: |
           make build-docker-goleveldb
           make build-docker-pebbledb
-        if: env.GIT_DIFF
+        # if: env.GIT_DIFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
       - run: |
           make build-docker-goleveldb
           make build-docker-pebbledb
-        # if: env.GIT_DIFF
+        if: env.GIT_DIFF

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -3,42 +3,51 @@ name: Push to Docker Hub
 on:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 permissions: read-all
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Git fetch everything
+
+      - name: Git fetch everything
         run: git fetch --prune --unshallow
-      -
-        name: Get Github tag
+
+      - name: Get Github tag
         id: meta
         run: |
           echo "tag=$(git describe --always --tags --match='v*')" >> "$GITHUB_OUTPUT"
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: tharsishq
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push goleveldb image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64, linux/arm64
+          build-args: DB_BACKEND=goleveldb
           tags: tharsishq/evmos:latest, tharsishq/evmos:${{ steps.meta.outputs.tag }}
+
+      - name: Build and push pebbledb image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64, linux/arm64
+          build-args: DB_BACKEND=pebbledb
+          tags: tharsishq/evmos:latest-pebble, tharsishq/evmos:${{ steps.meta.outputs.tag }}-pebble

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -2,9 +2,8 @@ name: Push to Docker Hub
 
 on:
   push:
-    branches:
-      - 'Amine/**'
-
+    tags:
+      - 'v*.*.*'
 permissions: read-all
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
       - name: Get Github tag
         id: meta
         run: |
-          echo "tag=v18.1.0-e2etest" >> "$GITHUB_OUTPUT"
+          echo "tag=$(git describe --always --tags --match='v*')" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -42,7 +41,7 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           build-args: DB_BACKEND=goleveldb
-          tags: tharsishq/evmos:latest-e2etest, tharsishq/evmos:${{ steps.meta.outputs.tag }}
+          tags: tharsishq/evmos:latest, tharsishq/evmos:${{ steps.meta.outputs.tag }}
 
       - name: Build and push pebbledb image
         uses: docker/build-push-action@v6
@@ -51,4 +50,4 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           build-args: DB_BACKEND=pebbledb
-          tags: tharsishq/evmos:latest-e2etest-pebble, tharsishq/evmos:${{ steps.meta.outputs.tag }}-pebble
+          tags: tharsishq/evmos:latest-pebble, tharsishq/evmos:${{ steps.meta.outputs.tag }}-pebble

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -2,8 +2,9 @@ name: Push to Docker Hub
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - 'Amine/**'
+
 permissions: read-all
 
 jobs:
@@ -19,7 +20,7 @@ jobs:
       - name: Get Github tag
         id: meta
         run: |
-          echo "tag=$(git describe --always --tags --match='v*')" >> "$GITHUB_OUTPUT"
+          echo "tag=v18.1.0-e2etest" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -41,7 +42,7 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           build-args: DB_BACKEND=goleveldb
-          tags: tharsishq/evmos:latest, tharsishq/evmos:${{ steps.meta.outputs.tag }}
+          tags: tharsishq/evmos:latest-e2etest, tharsishq/evmos:${{ steps.meta.outputs.tag }}
 
       - name: Build and push pebbledb image
         uses: docker/build-push-action@v6
@@ -50,4 +51,4 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           build-args: DB_BACKEND=pebbledb
-          tags: tharsishq/evmos:latest-pebble, tharsishq/evmos:${{ steps.meta.outputs.tag }}-pebble
+          tags: tharsishq/evmos:latest-e2etest-pebble, tharsishq/evmos:${{ steps.meta.outputs.tag }}-pebble

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -3,7 +3,7 @@ name: Push to Docker Hub
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 permissions: read-all
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (app) [#2597](https://github.com/evmos/evmos/pull/2597) Remove hardcoded Bech32 conversions for blocked precompile addresses.
 - (contracts) [#2613](https://github.com/evmos/evmos/pull/2613) Remove unused contract and make script useable with Python <3.12.
 - (ante) [#2619](https://github.com/evmos/evmos/pull/2619) Change anteutils.TxFeeChecker to authante.TxFeeChecker.
+- (ci) [#2630](https://github.com/evmos/evmos/pull/2630) Support PebbleDB image.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (contracts) [#2613](https://github.com/evmos/evmos/pull/2613) Remove unused contract and make script useable with Python <3.12.
 - (ante) [#2619](https://github.com/evmos/evmos/pull/2619) Change anteutils.TxFeeChecker to authante.TxFeeChecker.
 - (tests) [#2635](https://github.com/evmos/evmos/pull/2635) Add function to get ERC-20 balance to integration utils.
-- (ci) [#2630](https://github.com/evmos/evmos/pull/2630) Support PebbleDB image.
+- (ci) [#2630](https://github.com/evmos/evmos/pull/2630) Add PebbleDB image to docker-push workflow.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ build-reproducible: go.sum
 	$(DOCKER) cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 
 
-build-docker:
+build-docker-goleveldb:
 	# TODO replace with kaniko
 	DOCKER_BUILDKIT=1 $(DOCKER) build -t ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_ARGS} .
 	$(DOCKER) tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
@@ -176,6 +176,15 @@ build-docker:
 	echo 'docker run -it --rm -v $${SCRIPT_PATH}/.evmosd:/home/evmos/.evmosd $$IMAGE_NAME evmosd "$$@"' >> ./build/evmosd
 	chmod +x ./build/evmosd
 
+build-docker-pebbledb:
+	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg DB_BACKEND=pebbledb -t ${DOCKER_IMAGE}:${DOCKER_TAG}-pebble ${DOCKER_ARGS} .
+	$(DOCKER) tag ${DOCKER_IMAGE}:${DOCKER_TAG}-pebble ${DOCKER_IMAGE}:latest-pebble
+	mkdir -p ./build/.evmosd
+	echo '#!/usr/bin/env bash' > ./build/evmosd
+	echo "IMAGE_NAME=${DOCKER_IMAGE}:${COMMIT_HASH}" >> ./build/evmosd
+	echo 'SCRIPT_PATH=$$(cd $$(dirname $$0) && pwd -P)' >> ./build/evmosd
+	echo 'docker run -it --rm -v $${SCRIPT_PATH}/.evmosd:/home/evmos/.evmosd $$IMAGE_NAME evmosd "$$@"' >> ./build/evmosd
+	chmod +x ./build/evmosd
 
 build-rocksdb:
 	# Make sure to run this command with root permission
@@ -184,9 +193,11 @@ build-rocksdb:
 	CGO_LDFLAGS="-L/usr/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd -ldl" \
 	COSMOS_BUILD_OPTIONS=rocksdb $(MAKE) build
 
-push-docker: build-docker
-	$(DOCKER) push ${DOCKER_IMAGE}:${DOCKER_TAG}
-	$(DOCKER) push ${DOCKER_IMAGE}:latest
+push-docker: build-docker-goleveldb build-docker-pebbledb
+    $(DOCKER) push ${DOCKER_IMAGE}:${DOCKER_TAG}
+    $(DOCKER) push ${DOCKER_IMAGE}:latest
+    $(DOCKER) push ${DOCKER_IMAGE}:${DOCKER_TAG}-pebble
+    $(DOCKER) push ${DOCKER_IMAGE}:latest-pebble
 
 $(MOCKS_DIR):
 	mkdir -p $(MOCKS_DIR)


### PR DESCRIPTION
# Description

This PR adds some configurations to the Makefile and the build/push workflows in order to build pebbledb images alongside goleveldb ones to cover both pruned and archive nodes.

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved CI workflow by adding support for PebbleDB image.
  - Enhanced `Makefile` with specific targets for building and pushing `goleveldb` and `pebbledb` images.
  - Updated `CHANGELOG.md` to reflect recent changes including CI support for PebbleDB and various updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->