### PR TITLE
imp(tests): Add function to get ERC-20 balance to integration utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (app) [#2597](https://github.com/evmos/evmos/pull/2597) Remove hardcoded Bech32 conversions for blocked precompile addresses.
 - (contracts) [#2613](https://github.com/evmos/evmos/pull/2613) Remove unused contract and make script useable with Python <3.12.
 - (ante) [#2619](https://github.com/evmos/evmos/pull/2619) Change anteutils.TxFeeChecker to authante.TxFeeChecker.
+- (tests) [#2635](https://github.com/evmos/evmos/pull/2635) Add function to get ERC-20 balance to integration utils.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/testutil/integration/evmos/utils/evm.go
+++ b/testutil/integration/evmos/utils/evm.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package utils
 
 import (

--- a/testutil/integration/evmos/utils/evm.go
+++ b/testutil/integration/evmos/utils/evm.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/evmos/evmos/v18/contracts"
+	"github.com/evmos/evmos/v18/testutil/integration/evmos/network"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+)
+
+// GetERC20Balance returns the token balance of a given account address for
+// an ERC-20 token at the given contract address.
+func GetERC20Balance(nw network.Network, tokenAddress, accountAddress common.Address) (*big.Int, error) {
+	input, err := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack(
+		"balanceOf",
+		accountAddress,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	callData, err := json.Marshal(evmtypes.TransactionArgs{
+		To:    &tokenAddress,
+		Input: (*hexutil.Bytes)(&input),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ethRes, err := nw.GetEvmClient().EthCall(
+		nw.GetContext(),
+		&evmtypes.EthCallRequest{
+			Args: callData,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var balance *big.Int
+	err = contracts.ERC20MinterBurnerDecimalsContract.ABI.UnpackIntoInterface(&balance, "balanceOf", ethRes.Ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return balance, nil
+}

--- a/testutil/integration/evmos/utils/evm_test.go
+++ b/testutil/integration/evmos/utils/evm_test.go
@@ -1,0 +1,64 @@
+package utils_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/evmos/evmos/v18/contracts"
+	testfactory "github.com/evmos/evmos/v18/testutil/integration/evmos/factory"
+	testhandler "github.com/evmos/evmos/v18/testutil/integration/evmos/grpc"
+	testkeyring "github.com/evmos/evmos/v18/testutil/integration/evmos/keyring"
+	testnetwork "github.com/evmos/evmos/v18/testutil/integration/evmos/network"
+	"github.com/evmos/evmos/v18/testutil/integration/evmos/utils"
+	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetERC20Balance(t *testing.T) {
+	keyring := testkeyring.New(1)
+	network := testnetwork.NewUnitTestNetwork(
+		testnetwork.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
+	)
+	handler := testhandler.NewIntegrationHandler(network)
+	factory := testfactory.New(network, handler)
+
+	sender := keyring.GetKey(0)
+	mintAmount := big.NewInt(100)
+
+	// Deploy an ERC-20 contract
+	erc20Addr, err := factory.DeployContract(
+		sender.Priv,
+		evmtypes.EvmTxArgs{},
+		testfactory.ContractDeploymentData{
+			Contract:        contracts.ERC20MinterBurnerDecimalsContract,
+			ConstructorArgs: []interface{}{"TestToken", "TT", uint8(18)},
+		},
+	)
+	require.NoError(t, err, "failed to deploy contract")
+	require.NoError(t, network.NextBlock(), "failed to advance block")
+
+	balance, err := utils.GetERC20Balance(network, erc20Addr, sender.Addr)
+	require.NoError(t, err, "failed to get ERC20 balance")
+	require.Equal(t, common.Big0.Int64(), balance.Int64(), "expected no balance before minting")
+
+	// Mint some tokens
+	_, err = factory.ExecuteContractCall(
+		sender.Priv,
+		evmtypes.EvmTxArgs{
+			To: &erc20Addr,
+		},
+		testfactory.CallArgs{
+			ContractABI: contracts.ERC20MinterBurnerDecimalsContract.ABI,
+			MethodName:  "mint",
+			Args:        []interface{}{sender.Addr, mintAmount},
+		},
+	)
+	require.NoError(t, err, "failed to mint tokens")
+
+	require.NoError(t, network.NextBlock(), "failed to advance block")
+
+	balance, err = utils.GetERC20Balance(network, erc20Addr, sender.Addr)
+	require.NoError(t, err, "failed to get ERC20 balance")
+	require.Equal(t, mintAmount.Int64(), balance.Int64(), "expected different balance after minting")
+}


### PR DESCRIPTION
This PR adds a utility function to retrieve the ERC-20 balance with the integration test utilities, that is using the `EthCall` method of the EVM module's `QueryClient`.
