### PR TITLE
fix(ci): Ignore Swagger docs in CheckOV linter

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,2 @@
+skip-path:
+  - client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (contracts) [#2613](https://github.com/evmos/evmos/pull/2613) Remove unused contract and make script useable with Python <3.12.
 - (ante) [#2619](https://github.com/evmos/evmos/pull/2619) Change anteutils.TxFeeChecker to authante.TxFeeChecker.
 - (tests) [#2635](https://github.com/evmos/evmos/pull/2635) Add function to get ERC-20 balance to integration utils.
+- (ci) [#2639](https://github.com/evmos/evmos/pull/2639) Ignore Swagger JSON in CheckOV linter.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -1,5 +1,6 @@
 // Copyright Tharsis Labs Ltd.(Evmos)
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package ante
 
 import (


### PR DESCRIPTION
This PR adds a configuration file for the [CheckOV](https://github.com/bridgecrewio/checkov) linter that was added with the super-linter v6 bump on our CI.
For now, we are specifically ignoring the auto-generated Swagger JSON contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Configured `.checkov.yml` to skip scanning files within the `client` directory.
	- Updated CI pipeline to ignore Swagger JSON in the CheckOV linter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->