### PR TITLE
fix(tests): Bump Dockerfile dependency and fix make test-e2e target in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - (inflation) [#2299](https://github.com/evmos/evmos/pull/2299) Fix emission function and tests.
+- (tests) [#2642](https://github.com/evmos/evmos/pull/2642) Fix Dockerfile by bumping dependency and fix E2E tests by adjusting used Docker image.
 
 ### Improvements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=build-env /target/usr/lib /usr/lib
 COPY --from=build-env /target/usr/local/lib /usr/local/lib
 COPY --from=build-env /target/usr/include /usr/include
 
-RUN apk add --no-cache ca-certificates=20240226-r0 jq=1.7.1-r0 curl=8.7.1-r0 bash=5.2.26-r0 vim=9.1.0414-r0 lz4=1.9.4-r5 rclone=1.66.0-r3 \
+RUN apk add --no-cache ca-certificates=20240226-r0 jq=1.7.1-r0 curl=8.8.0-r0 bash=5.2.26-r0 vim=9.1.0414-r0 lz4=1.9.4-r5 rclone=1.66.0-r3 \
     && addgroup -g 1000 evmos \
     && adduser -S -h /home/evmos -D evmos -u 1000 -G evmos
 

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ test-unit-cover: TEST_PACKAGES=$(PACKAGES_UNIT)
 test-e2e:
 	@if [ -z "$(TARGET_VERSION)" ]; then \
 		echo "Building docker image from local codebase"; \
-		make build-docker; \
+		make build-docker-pebbledb; \
 	fi
 	@mkdir -p ./build
 	@rm -rf build/.evmosd

--- a/tests/e2e/upgrade/constants.go
+++ b/tests/e2e/upgrade/constants.go
@@ -8,7 +8,9 @@ const (
 	defaultChainID = "evmos_9000-1"
 
 	// LocalVersionTag defines the docker image ImageTag when building locally
-	LocalVersionTag = "latest"
+	//
+	// NOTE: For upgrade tests we're using the PebbleDB build
+	LocalVersionTag = "latest-pebble"
 
 	// tharsisRepo is the docker hub repository that contains the Evmos images pulled during tests
 	tharsisRepo = "tharsishq/evmos"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `curl` package to version `8.8.0-r0` in the Dockerfile.
	- Updated `test-e2e` target in the Makefile to invoke `make build-docker-pebbledb`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->