### PR TITLE
imp(app): Split chain configuration template into EVM config and MemIAVL config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (tests) [#2635](https://github.com/evmos/evmos/pull/2635) Add function to get ERC-20 balance to integration utils.
 - (ci) [#2630](https://github.com/evmos/evmos/pull/2630) Add PebbleDB image to docker-push workflow.
 - (ci) [#2639](https://github.com/evmos/evmos/pull/2639) Ignore Swagger JSON in CheckOV linter.
+- (app) [#2644](https://github.com/evmos/evmos/pull/2644) Split full chain configuration template into EVM and MemIAVL templates.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -223,7 +223,9 @@ func AppConfig(denom string) (string, interface{}) {
 		customAppConfig.Config.MinGasPrices = "0" + denom
 	}
 
-	customAppTemplate := config.DefaultConfigTemplate + DefaultEvmosConfigTemplate
+	customAppTemplate := config.DefaultConfigTemplate +
+		DefaultEVMConfigTemplate +
+		memiavlcfg.DefaultConfigTemplate
 
 	return customAppTemplate, *customAppConfig
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -223,7 +223,7 @@ func AppConfig(denom string) (string, interface{}) {
 		customAppConfig.Config.MinGasPrices = "0" + denom
 	}
 
-	customAppTemplate := config.DefaultConfigTemplate + DefaultConfigTemplate
+	customAppTemplate := config.DefaultConfigTemplate + DefaultEvmosConfigTemplate
 
 	return customAppTemplate, *customAppConfig
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -6,8 +6,8 @@ import (
 	memiavlcfg "github.com/crypto-org-chain/cronos/store/config"
 )
 
-// DefaultConfigTemplate defines the configuration template for the EVM RPC configuration
-const DefaultConfigTemplate = `
+// EVMConfigTemplate defines the configuration template for the EVM RPC configuration.
+const EVMConfigTemplate = `
 ###############################################################################
 ###                             EVM Configuration                           ###
 ###############################################################################
@@ -100,4 +100,8 @@ certificate-path = "{{ .TLS.CertificatePath }}"
 
 # Key path defines the key.pem file path for the TLS configuration.
 key-path = "{{ .TLS.KeyPath }}"
-` + memiavlcfg.DefaultConfigTemplate
+`
+
+// DefaultEvmosConfigTemplate defines the configuration template for the full Evmos chain configuration
+// which contains the EVM RPC configuration plus the MemIAVL configuration.
+const DefaultEvmosConfigTemplate = EVMConfigTemplate + memiavlcfg.DefaultConfigTemplate

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
 package config
 
-import (
-	memiavlcfg "github.com/crypto-org-chain/cronos/store/config"
-)
-
-// EVMConfigTemplate defines the configuration template for the EVM RPC configuration.
-const EVMConfigTemplate = `
+// DefaultEVMConfigTemplate defines the configuration template for the EVM RPC configuration.
+const DefaultEVMConfigTemplate = `
 ###############################################################################
 ###                             EVM Configuration                           ###
 ###############################################################################
@@ -101,7 +97,3 @@ certificate-path = "{{ .TLS.CertificatePath }}"
 # Key path defines the key.pem file path for the TLS configuration.
 key-path = "{{ .TLS.KeyPath }}"
 `
-
-// DefaultEvmosConfigTemplate defines the configuration template for the full Evmos chain configuration
-// which contains the EVM RPC configuration plus the MemIAVL configuration.
-const DefaultEvmosConfigTemplate = EVMConfigTemplate + memiavlcfg.DefaultConfigTemplate


### PR DESCRIPTION
This PR splits the existing application configuration template, which will eventually be written to `app.toml`, to have individual access to only the EVM related part of the template too.
This is required to enable other repositories integrate this without minding the MemIAVL stuff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Split the full chain configuration template into EVM and MemIAVL templates for improved configuration management.

- **Refactor**
  - Updated internal configuration templates to use `DefaultEvmosConfigTemplate` for better template organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->