### PR TITLE
imp(ante): Fix typos in ante package

### DIFF
--- a/app/ante/cosmos/authz.go
+++ b/app/ante/cosmos/authz.go
@@ -38,7 +38,7 @@ func (ald AuthzLimiterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 // checkDisabledMsgs iterates through the msgs and returns an error if it finds any unauthorized msgs.
 //
 // When searchOnlyInAuthzMsgs is enabled, only authz MsgGrant and MsgExec are blocked, if they contain unauthorized msg types.
-// Otherwise any msg matching the disabled types are blocked, regardless of being in an authz msg or not.
+// Otherwise, any msg matching the disabled types are blocked, regardless of being in an authz msg or not.
 //
 // This method is recursive as MsgExec's can wrap other MsgExecs. The check for nested messages is performed up to the
 // maxNestedMsgs threshold. If there are more than that limit, it returns an error

--- a/app/ante/cosmos/authz_test.go
+++ b/app/ante/cosmos/authz_test.go
@@ -19,7 +19,7 @@ import (
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	cosmosante "github.com/evmos/evmos/v18/app/ante/cosmos"
-	testutil "github.com/evmos/evmos/v18/testutil"
+	"github.com/evmos/evmos/v18/testutil"
 	utiltx "github.com/evmos/evmos/v18/testutil/tx"
 	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
 )

--- a/app/ante/doc.go
+++ b/app/ante/doc.go
@@ -3,7 +3,7 @@
 
 /*
 Package ante defines the SDK auth module's AnteHandler as well as an internal
-AnteHandler for an Ethereum transaction (i.e MsgEthereumTx).
+AnteHandler for an Ethereum transaction (i.e. MsgEthereumTx).
 
 During CheckTx, the transaction is passed through a series of
 pre-message execution validation checks such as signature and account

--- a/app/ante/evm/01_setup_ctx.go
+++ b/app/ante/evm/01_setup_ctx.go
@@ -40,7 +40,7 @@ func SetupContext(ctx sdktypes.Context, tx sdktypes.Tx, evmKeeper EVMKeeper) (sd
 		return ctx, errorsmod.Wrapf(errortypes.ErrInvalidType, "invalid transaction type %T, expected GasTx", tx)
 	}
 
-	// We need to setup an empty gas config so that the gas is consistent with Ethereum.
+	// We need to set up an empty gas config so that the gas is consistent with Ethereum.
 	newCtx := evmante.BuildEvmExecutionCtx(ctx).
 		WithGasMeter(sdktypes.NewInfiniteGasMeter())
 	// Reset transient gas used to prepare the execution of current cosmos tx.

--- a/app/ante/evm/03_global_fee.go
+++ b/app/ante/evm/03_global_fee.go
@@ -8,6 +8,9 @@ import (
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// CheckGlobalFee is used to validate the provided fee value against the
+// required global fee.
+//
 // For dynamic transactions, GetFee() uses the GasFeeCap value, which
 // is the maximum gas price that the signer can pay. In practice, the
 // signer can pay less, if the block's BaseFee is lower. So, in this case,

--- a/app/ante/evm/04_validate.go
+++ b/app/ante/evm/04_validate.go
@@ -32,8 +32,8 @@ func ValidateMsg(
 	)
 }
 
-// checkDisabledCreateCall checks if the transaction is a contract creation or call
-// and it is disabled through governance
+// checkDisabledCreateCall checks if the transaction is a contract creation or call,
+// and it is disabled through governance.
 func checkDisabledCreateCall(
 	txData evmtypes.TxData,
 	permissions *evmtypes.AccessControl,
@@ -52,6 +52,8 @@ func checkDisabledCreateCall(
 	return nil
 }
 
+// ValidateTx validates an Ethereum specific transaction type and returns an error if invalid.
+//
 // FIXME: this shouldn't be required if the tx was an Ethereum transaction type
 func ValidateTx(tx sdktypes.Tx) (*tx.Fee, error) {
 	err := tx.ValidateBasic()

--- a/app/ante/evm/06_account_verification_test.go
+++ b/app/ante/evm/06_account_verification_test.go
@@ -56,8 +56,8 @@ func (suite *EvmAnteTestSuite) TestVerifyAccountBalance() {
 				balanceResp, err := grpcHandler.GetBalance(senderKey.AccAddr, unitNetwork.GetDenom())
 				suite.Require().NoError(err)
 
-				invalidaAmount := balanceResp.Balance.Amount.Add(math.NewInt(100))
-				txArgs.Amount = invalidaAmount.BigInt()
+				invalidAmount := balanceResp.Balance.Amount.Add(math.NewInt(100))
+				txArgs.Amount = invalidAmount.BigInt()
 				return statedbAccount, txArgs
 			},
 		},
@@ -69,15 +69,15 @@ func (suite *EvmAnteTestSuite) TestVerifyAccountBalance() {
 				txArgs, err := txFactory.GenerateDefaultTxTypeArgs(senderKey.Addr, suite.ethTxType)
 				suite.Require().NoError(err)
 
-				// Make tx cost is negative. This has to be a big value because the
+				// Make tx cost is negative. This has to be a big value because
 				// it has to be bigger than the fee for the full cost to be negative
-				invalidaAmount := big.NewInt(-1e18)
-				txArgs.Amount = invalidaAmount
+				invalidAmount := big.NewInt(-1e18)
+				txArgs.Amount = invalidAmount
 				return statedbAccount, txArgs
 			},
 		},
 		{
-			name:          "success: tx is succesfull and account is created if its nil",
+			name:          "success: tx is successful and account is created if its nil",
 			expectedError: errortypes.ErrInsufficientFunds,
 			generateAccountAndArgs: func() (*statedb.Account, evmtypes.EvmTxArgs) {
 				txArgs, err := txFactory.GenerateDefaultTxTypeArgs(senderKey.Addr, suite.ethTxType)
@@ -86,7 +86,7 @@ func (suite *EvmAnteTestSuite) TestVerifyAccountBalance() {
 			},
 		},
 		{
-			name:          "success: tx is succesfull if account is EOA and exists",
+			name:          "success: tx is successful if account is EOA and exists",
 			expectedError: nil,
 			generateAccountAndArgs: func() (*statedb.Account, evmtypes.EvmTxArgs) {
 				statedbAccount := getDefaultStateDBAccount(unitNetwork, senderKey.Addr)

--- a/app/ante/evm/08_vesting.go
+++ b/app/ante/evm/08_vesting.go
@@ -31,8 +31,9 @@ type EthVestingExpenseTracker struct {
 	Spendable *big.Int
 }
 
-// NOTE: Can't delete the legacy decorator yet because vesting module's tests would have to be refactored
 // NewEthVestingTransactionDecorator returns a new EthVestingTransactionDecorator.
+//
+// NOTE: Can't delete the legacy decorator yet because vesting module's tests would have to be refactored
 func NewEthVestingTransactionDecorator(ak evmtypes.AccountKeeper, bk evmtypes.BankKeeper, ek EVMKeeper) EthVestingTransactionDecorator {
 	return EthVestingTransactionDecorator{
 		ak: ak,

--- a/app/ante/evm/08_vesting_test.go
+++ b/app/ante/evm/08_vesting_test.go
@@ -87,7 +87,7 @@ func (suite *EvmAnteTestSuite) TestCheckVesting() {
 			},
 		},
 		{
-			name:          "error: clawback account with not enough bank + not enough vested unlocked balance < total + previosExpenses should fail",
+			name:          "error: clawback account with not enough bank + not enough vested unlocked balance < total + previousExpenses should fail",
 			expectedError: vestingtypes.ErrInsufficientUnlockedCoins,
 			getAccountAndExpenses: func() (authtypes.AccountI, AccountExpenses) {
 				newIndex := keyring.AddKey()

--- a/app/ante/evm/09_gas_consume.go
+++ b/app/ante/evm/09_gas_consume.go
@@ -15,8 +15,8 @@ import (
 	evmtypes "github.com/evmos/evmos/v18/x/evm/types"
 )
 
-// UpdateComulativeGasWanted updates the cumulative gas wanted
-func UpdateComulativeGasWanted(
+// UpdateCumulativeGasWanted updates the cumulative gas wanted
+func UpdateCumulativeGasWanted(
 	ctx sdktypes.Context,
 	msgGasWanted uint64,
 	maxTxGasWanted uint64,
@@ -101,7 +101,7 @@ func deductFees(
 	return nil
 }
 
-// GetMsgPriority returns the priority of a Eth Tx capped by the minimum priority
+// GetMsgPriority returns the priority of an Eth Tx capped by the minimum priority
 func GetMsgPriority(
 	txData evmtypes.TxData,
 	minPriority int64,

--- a/app/ante/evm/09_gas_consume_test.go
+++ b/app/ante/evm/09_gas_consume_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/evmos/evmos/v18/testutil/integration/evmos/network"
 )
 
-func (suite *EvmAnteTestSuite) TestUpdateComulativeGasWanted() {
+func (suite *EvmAnteTestSuite) TestUpdateCumulativeGasWanted() {
 	keyring := testkeyring.New(1)
 	unitNetwork := network.NewUnitTestNetwork(
 		network.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
@@ -70,7 +70,7 @@ func (suite *EvmAnteTestSuite) TestUpdateComulativeGasWanted() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			// Function under test
-			gasWanted := evmante.UpdateComulativeGasWanted(
+			gasWanted := evmante.UpdateCumulativeGasWanted(
 				tc.getCtx(),
 				tc.msgGasWanted,
 				tc.maxTxGasWanted,

--- a/app/ante/evm/mono.go
+++ b/app/ante/evm/mono.go
@@ -262,7 +262,7 @@ func (md MonoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 			return ctx, err
 		}
 
-		gasWanted := UpdateComulativeGasWanted(
+		gasWanted := UpdateCumulativeGasWanted(
 			ctx,
 			txData.GetGas(),
 			md.maxGasWanted,

--- a/app/ante/evm/signverify_test.go
+++ b/app/ante/evm/signverify_test.go
@@ -26,13 +26,13 @@ func (suite *AnteTestSuite) TestEthSigVerificationDecorator() {
 	err := signedTx.Sign(suite.ethSigner, testutiltx.NewSigner(privKey))
 	suite.Require().NoError(err)
 
-	uprotectedEthTxParams := &evmtypes.EvmTxArgs{
+	unprotectedEthTxParams := &evmtypes.EvmTxArgs{
 		Nonce:    1,
 		Amount:   big.NewInt(10),
 		GasLimit: 1000,
 		GasPrice: big.NewInt(1),
 	}
-	unprotectedTx := evmtypes.NewTx(uprotectedEthTxParams)
+	unprotectedTx := evmtypes.NewTx(unprotectedEthTxParams)
 	unprotectedTx.From = addr.Hex()
 	err = unprotectedTx.Sign(ethtypes.HomesteadSigner{}, testutiltx.NewSigner(privKey))
 	suite.Require().NoError(err)

--- a/app/ante/evm/sigs_test.go
+++ b/app/ante/evm/sigs_test.go
@@ -48,7 +48,7 @@ func (suite *AnteTestSuite) TestSignatures() {
 	ethTx := msgEthereumTx.AsTransaction()
 	ethV, ethR, ethS := ethTx.RawSignatureValues()
 
-	// The signatures of MsgehtereumTx should be the same with the corresponding eth tx
+	// The signatures of MsgEthereumTx should be the same with the corresponding eth tx
 	suite.Require().Equal(msgV, ethV)
 	suite.Require().Equal(msgR, ethR)
 	suite.Require().Equal(msgS, ethS)

--- a/app/ante/evm/utils_test.go
+++ b/app/ante/evm/utils_test.go
@@ -215,7 +215,7 @@ func (suite *AnteTestSuite) CreateTestEIP712MsgCreateValidator(from sdk.AccAddre
 		valAddr,
 		privEd.PubKey(),
 		sdk.NewCoin(evmtypes.DefaultEVMDenom, math.NewInt(20)),
-		stakingtypes.NewDescription("moniker", "indentity", "website", "security_contract", "details"),
+		stakingtypes.NewDescription("moniker", "identity", "website", "security_contract", "details"),
 		stakingtypes.NewCommissionRates(math.LegacyOneDec(), math.LegacyOneDec(), math.LegacyOneDec()),
 		math.OneInt(),
 	)
@@ -232,7 +232,7 @@ func (suite *AnteTestSuite) CreateTestEIP712MsgCreateValidator2(from sdk.AccAddr
 		privEd.PubKey(),
 		sdk.NewCoin(evmtypes.DefaultEVMDenom, math.NewInt(20)),
 		// Ensure optional fields can be left blank
-		stakingtypes.NewDescription("moniker", "indentity", "", "", ""),
+		stakingtypes.NewDescription("moniker", "identity", "", "", ""),
 		stakingtypes.NewCommissionRates(math.LegacyOneDec(), math.LegacyOneDec(), math.LegacyOneDec()),
 		math.OneInt(),
 	)
@@ -654,7 +654,7 @@ func (suite *AnteTestSuite) CreateTestSingleSignedTx(privKey cryptotypes.PrivKey
 	return txBuilder
 }
 
-// prepareAccount is a helper function that asigns the corresponding
+// prepareAccount is a helper function that assigns the corresponding
 // balance and rewards to the provided account
 func (suite *AnteTestSuite) prepareAccount(ctx sdk.Context, addr sdk.AccAddress, balance, rewards math.Int) sdk.Context {
 	ctx, err := testutil.PrepareAccountsForDelegationRewards(

--- a/app/ante/utils/claim_rewards_test.go
+++ b/app/ante/utils/claim_rewards_test.go
@@ -56,7 +56,7 @@ func (suite *AnteTestSuite) TestClaimStakingRewardsIfNecessary() {
 				// assigned rewards, of which one is sufficient to cover the transaction fees and the other
 				// is not. This is because the iteration over rewards is done in a non-deterministic fashion,
 				// This means, that e.g. if reward C is sufficient, but A and B are not,
-				// all of the options [A], [B-A], [B-C-A] or [C-A] are possible to be withdrawn, which
+				// All options [A], [B-A], [B-C-A] or [C-A] are possible to be withdrawn, which
 				// increases the complexity of assertions.
 				var err error
 				suite.ctx, err = testutil.PrepareAccountsForDelegationRewards(


### PR DESCRIPTION
This PR addresses a bunch of typos and formatting requirements like expected godoc strings in the `ante` package.
