### PR TITLE
imp(ante): Decouple EVM decorator utilities from decorator struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (ci) [#2630](https://github.com/evmos/evmos/pull/2630) Add PebbleDB image to docker-push workflow.
 - (ci) [#2639](https://github.com/evmos/evmos/pull/2639) Ignore Swagger JSON in CheckOV linter.
 - (app) [#2644](https://github.com/evmos/evmos/pull/2644) Split full chain configuration template into EVM and MemIAVL templates.
+- (ante) [#2648](https://github.com/evmos/evmos/pull/2648) Decouple EVM mono decorator utilities from concrete decorator implementation.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 


### PR DESCRIPTION
In order to support evmOS partner chains making use of our EVM mono decorator approach, it's necessary to decouple the implementation of the `MonoDecorator` itself from the available utilities method, which can be reused for other implementations too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved transaction processing speed by decoupling EVM mono decorator utilities from concrete decorator implementation.
  - Replaced `NewUtils` method with `NewMonoDecoratorUtils` function in `MonoDecorator` for better utility extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->