### PR TITLE
imp(changelog): Minor changelog clean ups to fix linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#2633](https://github.com/evmos/evmos/pull/2633) Remove `EthAccount` type and use `BaseAccount` instead.
 - (precompiles) [GHSA-68fc-7mhg-6f6c](https://github.com/evmos/evmos/commit/bb2d504eec9078d6eff6981fc0cb214e8a3ca496) Refactor precompiles to use journal entries.
 - (vesting-precompile) [GHSA-q6hg-6m9x-5g9c](https://github.com/evmos/evmos/commit/0a620e176617a835ac697eea494afea09185dfaf) Update vesting precompile authorization checks.
-- (str) [#2607](https://github.com/evmos/evmos/pull/2607) Introduce changes necessary for strv2.
+- (erc20) [#2607](https://github.com/evmos/evmos/pull/2607) Implement Single Token Representation v2.
 
 ### Bug Fixes
 

--- a/scripts/changelog_checker/config.py
+++ b/scripts/changelog_checker/config.py
@@ -75,6 +75,7 @@ def get_allowed_categories() -> List[str]:
         "revenue",
         "osmosis-outpost",
         "stride-outpost",
+        "werc20-precompile",
     ]
 
     base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
Cleans up the changelog to make the linter pass.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented Single Token Representation v2 for ERC20 in the `evmos` project.

- **Chores**
	- Updated changelog configuration to allow the category "werc20-precompile."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->