### PR TITLE
remove eip 0001, 0002 and base fee from migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1165,7 +1165,6 @@ func (app *Evmos) setupUpgradeHandlers() {
 			app.StakingKeeper,
 			app.Erc20Keeper,
 			app.EvmKeeper,
-			app.FeeMarketKeeper,
 		),
 	)
 

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -25,7 +25,7 @@ import (
 	stakingkeeper "github.com/evmos/evmos/v19/x/staking/keeper"
 )
 
-var newExtraEIPs = []string{"evmos_0", "evmos_1", "evmos_2"}
+var newExtraEIPs = []string{"evmos_0"}
 
 // CreateUpgradeHandler creates an SDK upgrade handler for v19
 func CreateUpgradeHandler(
@@ -91,13 +91,6 @@ func CreateUpgradeHandler(
 			} else {
 				logger.Error("error setting wevmos testnet contract", "error", err)
 			}
-		}
-
-		ctxCache, writeFn = ctx.CacheContext()
-		if err := UpdateBaseFee(ctxCache, fee); err == nil {
-			writeFn()
-		} else {
-			logger.Error("error setting new base fee", "error", err)
 		}
 
 		return migrationRes, err

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	errorsmod "cosmossdk.io/errors"
-	"cosmossdk.io/math"
 	"github.com/cometbft/cometbft/libs/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -21,7 +20,6 @@ import (
 	erc20types "github.com/evmos/evmos/v19/x/erc20/types"
 	evmkeeper "github.com/evmos/evmos/v19/x/evm/keeper"
 	evmtypes "github.com/evmos/evmos/v19/x/evm/types"
-	feemarketkeeper "github.com/evmos/evmos/v19/x/feemarket/keeper"
 	stakingkeeper "github.com/evmos/evmos/v19/x/staking/keeper"
 )
 
@@ -36,7 +34,6 @@ func CreateUpgradeHandler(
 	sk stakingkeeper.Keeper,
 	erc20k erc20keeper.Keeper,
 	ek *evmkeeper.Keeper,
-	fee feemarketkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
@@ -212,10 +209,4 @@ func ReplaceTestnetWevmosContract(ctx sdk.Context, erc erc20keeper.Keeper) error
 	erc20params := erc.GetParams(ctx)
 	erc20params.NativePrecompiles = []string{erc20types.WEVMOSContractTestnet}
 	return erc.SetParams(ctx, erc20params)
-}
-
-func UpdateBaseFee(ctx sdk.Context, fee feemarketkeeper.Keeper) error {
-	feeparams := fee.GetParams(ctx)
-	feeparams.BaseFee = feeparams.BaseFee.Mul(math.NewInt(100))
-	return fee.SetParams(ctx, feeparams)
 }

--- a/app/upgrades/v19/upgrades_test.go
+++ b/app/upgrades/v19/upgrades_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEnableCustomEIPs(t *testing.T) {
-	upgradeEIPs := []string{"evmos_0", "evmos_1", "evmos_2"}
+	upgradeEIPs := []string{"evmos_0"}
 
 	testCases := []struct {
 		name       string
@@ -19,12 +19,12 @@ func TestEnableCustomEIPs(t *testing.T) {
 		{
 			name:       "repeated EIP - skip",
 			activeEIPs: []string{"evmos_0"},
-			expEIPsNum: 3,
+			expEIPsNum: 1,
 		},
 		{
 			name:       "all new EIP",
 			activeEIPs: []string{"ethereum_3855"},
-			expEIPsNum: 4,
+			expEIPsNum: 2,
 		},
 	}
 


### PR DESCRIPTION
Change migrations that will be execute:

- Remove base fee logic

- Remove EIPs: evmos_0001 and evmos_0002