### PR TITLE
fix(erc20): keep RegisterCoinProposal in codec for backwards compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (inflation) [#2299](https://github.com/evmos/evmos/pull/2299) Fix emission function and tests.
 - (tests) [#2642](https://github.com/evmos/evmos/pull/2642) Fix Dockerfile by bumping dependency and fix E2E tests by adjusting used Docker image.
+- (gov) [#2703](https://github.com/evmos/evmos/pull/2703) Keep `RegisterCoinProposal` registered as interface for backwards compatibility on gov proposals query.
 
 ### Improvements
 

--- a/local_node.sh
+++ b/local_node.sh
@@ -206,11 +206,11 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	fi
 fi
 
-# Start the node
-evmosd start \
-	--metrics "$TRACE" \
-	--log_level $LOGLEVEL \
-	--minimum-gas-prices=0.0001aevmos \
-	--json-rpc.api eth,txpool,personal,net,debug,web3 \
-	--home "$HOMEDIR" \
-	--chain-id "$CHAINID"
+# # Start the node
+# evmosd start \
+# 	--metrics "$TRACE" \
+# 	--log_level $LOGLEVEL \
+# 	--minimum-gas-prices=0.0001aevmos \
+# 	--json-rpc.api eth,txpool,personal,net,debug,web3 \
+# 	--home "$HOMEDIR" \
+# 	--chain-id "$CHAINID"

--- a/local_node.sh
+++ b/local_node.sh
@@ -206,11 +206,11 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	fi
 fi
 
-# # Start the node
-# evmosd start \
-# 	--metrics "$TRACE" \
-# 	--log_level $LOGLEVEL \
-# 	--minimum-gas-prices=0.0001aevmos \
-# 	--json-rpc.api eth,txpool,personal,net,debug,web3 \
-# 	--home "$HOMEDIR" \
-# 	--chain-id "$CHAINID"
+# Start the node
+evmosd start \
+	--metrics "$TRACE" \
+	--log_level $LOGLEVEL \
+	--minimum-gas-prices=0.0001aevmos \
+	--json-rpc.api eth,txpool,personal,net,debug,web3 \
+	--home "$HOMEDIR" \
+	--chain-id "$CHAINID"

--- a/x/erc20/types/codec.go
+++ b/x/erc20/types/codec.go
@@ -46,6 +46,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	)
 	registry.RegisterImplementations(
 		(*govv1beta1.Content)(nil),
+		&RegisterCoinProposal{}, // Keep interface for backwards compatibility on proposals query
 		&RegisterERC20Proposal{},
 		&ToggleTokenConversionProposal{},
 	)


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

When querying the governance proposals, we get the following error:

```
evmosd q gov proposals  --node https://tm.evmos-testnet.lava.build:443
Error: unable to resolve type URL /evmos.erc20.v1.RegisterCoinProposal
```

The reason for this is that for STRv2 we removed the corresponding interface.
This PR registers the interface again to be able to query this type of proposals.

You can test the fix querying a RegisterCoinProposal:

```
evmosd q gov proposal 216 --node https://tm.evmos-testnet.lava.build:443
```

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Added a new entry to the CHANGELOG to document enhancements ensuring backwards compatibility for governance proposals.
	- Updated the implementation to maintain accessibility of older proposal types alongside new ones, enhancing the stability and reliability of governance functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->