### PR TITLE
chore: add selector for gaiad binary in Nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -77,7 +77,7 @@ import sources.nixpkgs {
         appName = "gaiad";
         version = "v11.0.0";
         binUrl = gaiadBinUrl;
-        sha256 =gaiadSha256;
+        sha256 = gaiadSha256;
       };
     }) # update to a version that supports eip-1559
     # https://github.com/NixOS/nixpkgs/pull/179622

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,18 @@ let
   # get the rustPlatform used to build the hermes relayer
   # This rustPlatform uses rust v1.77
   rustPlatform = nixpkgs.pkgs.rustPlatform;
+  gaiadBinUrl = if system == "x86_64-linux" then
+      "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-amd64"
+    else if system == "aarch64-darwin" then
+      "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-arm64"
+    else
+      throw "Unsupported architecture: ${system}";
+  gaiadSha256 = if system == "x86_64-linux" then
+      "sha256-JY3y7sWyL4uq3JiOGE+/0q5vn4iOn0RhoRDMNl/oYwA="
+    else if system == "aarch64-darwin" then
+      "sha256-U9D/5Ng1PlHQvlQ+33ZN4DPiTXA9TECCRKFB5jWydig="
+    else
+      throw "Unsupported architecture: ${system}";
 in
 import sources.nixpkgs {
   overlays = [
@@ -64,8 +76,8 @@ import sources.nixpkgs {
       gaiad = pkgs.callPackage ./bin.nix {
         appName = "gaiad";
         version = "v11.0.0";
-        binUrl = "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-amd64";
-        sha256 = "sha256-JY3y7sWyL4uq3JiOGE+/0q5vn4iOn0RhoRDMNl/oYwA=";
+        binUrl = gaiadBinUrl;
+        sha256 =gaiadSha256;
       };
     }) # update to a version that supports eip-1559
     # https://github.com/NixOS/nixpkgs/pull/179622


### PR DESCRIPTION
Add a selector in the default.nix file to use the proper binary for gaiad based on the hosting system.

Notice that the binary and sha256 used work only for the currently specified version of the binary. 

Tested with MacOS darwin-arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for downloading the `gaiad` binary by supporting multiple system architectures.
	- Improved error handling for unsupported architectures to ensure user clarity.

- **Refactor**
	- Replaced hardcoded values with dynamic variables for better maintainability and adaptability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->