### PR TITLE
add evm base fee event

### DIFF
--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -5,7 +5,6 @@ package backend
 import (
 	"fmt"
 	"math/big"
-	"strconv"
 
 	"cosmossdk.io/math"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
@@ -76,9 +75,9 @@ func (b *Backend) BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, er
 		for i := len(blockRes.BeginBlockEvents) - 1; i >= 0; i-- {
 			evt := blockRes.BeginBlockEvents[i]
 			if evt.Type == evmtypes.EventTypeFeeMarket && len(evt.Attributes) > 0 {
-				baseFee, err := strconv.ParseInt(evt.Attributes[0].Value, 10, 64)
-				if err == nil {
-					return big.NewInt(baseFee), nil
+				baseFee, ok := math.NewIntFromString(evt.Attributes[0].Value)
+				if ok {
+					return baseFee.BigInt(), nil
 				}
 				break
 			}

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -75,12 +75,11 @@ func (b *Backend) BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, er
 		// faster to iterate reversely
 		for i := len(blockRes.BeginBlockEvents) - 1; i >= 0; i-- {
 			evt := blockRes.BeginBlockEvents[i]
-			if evt.Type == feemarkettypes.EventTypeFeeMarket && len(evt.Attributes) > 0 {
+			if evt.Type == evmtypes.EventTypeFeeMarket && len(evt.Attributes) > 0 {
 				baseFee, err := strconv.ParseInt(evt.Attributes[0].Value, 10, 64)
 				if err == nil {
 					return big.NewInt(baseFee), nil
 				}
-				break
 			}
 		}
 		return nil, err

--- a/rpc/backend/chain_info.go
+++ b/rpc/backend/chain_info.go
@@ -80,6 +80,7 @@ func (b *Backend) BaseFee(blockRes *tmrpctypes.ResultBlockResults) (*big.Int, er
 				if err == nil {
 					return big.NewInt(baseFee), nil
 				}
+				break
 			}
 		}
 		return nil, err

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -19,7 +19,6 @@ import (
 	rpc "github.com/evmos/evmos/v19/rpc/types"
 	utiltx "github.com/evmos/evmos/v19/testutil/tx"
 	evmtypes "github.com/evmos/evmos/v19/x/evm/types"
-	feemarkettypes "github.com/evmos/evmos/v19/x/feemarket/types"
 )
 
 func (suite *BackendTestSuite) TestBaseFee() {
@@ -65,7 +64,7 @@ func (suite *BackendTestSuite) TestBaseFee() {
 				Height: 1,
 				BeginBlockEvents: []types.Event{
 					{
-						Type: feemarkettypes.EventTypeFeeMarket,
+						Type: evmtypes.EventTypeFeeMarket,
 					},
 				},
 			},
@@ -82,7 +81,7 @@ func (suite *BackendTestSuite) TestBaseFee() {
 				Height: 1,
 				BeginBlockEvents: []types.Event{
 					{
-						Type: feemarkettypes.EventTypeFeeMarket,
+						Type: evmtypes.EventTypeFeeMarket,
 						Attributes: []types.EventAttribute{
 							{Value: "/1"},
 						},
@@ -102,7 +101,7 @@ func (suite *BackendTestSuite) TestBaseFee() {
 				Height: 1,
 				BeginBlockEvents: []types.Event{
 					{
-						Type: feemarkettypes.EventTypeFeeMarket,
+						Type: evmtypes.EventTypeFeeMarket,
 						Attributes: []types.EventAttribute{
 							{Value: baseFee.String()},
 						},

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -12,12 +12,12 @@ import (
 	tmtypes "github.com/cometbft/cometbft/types"
 
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	tmrpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/cosmos/cosmos-sdk/client"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 
 	evmtypes "github.com/evmos/evmos/v19/x/evm/types"
-	feemarkettypes "github.com/evmos/evmos/v19/x/feemarket/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -228,15 +228,15 @@ func NewRPCTransaction(
 // BaseFeeFromEvents parses the feemarket basefee from cosmos events
 func BaseFeeFromEvents(events []abci.Event) *big.Int {
 	for _, event := range events {
-		if event.Type != feemarkettypes.EventTypeFeeMarket {
+		if event.Type != evmtypes.EventTypeFeeMarket {
 			continue
 		}
 
 		for _, attr := range event.Attributes {
-			if attr.Key == feemarkettypes.AttributeKeyBaseFee {
-				result, success := new(big.Int).SetString(attr.Value, 10)
+			if attr.Key == evmtypes.AttributeKeyBaseFee {
+				result, success := sdkmath.NewIntFromString(attr.Value)
 				if success {
-					return result
+					return result.BigInt()
 				}
 
 				return nil

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -31,7 +31,7 @@ func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	if err != nil {
 		logger.Error("error when getting base fee", "error", err.Error())
 	}
-	if !res.BaseFee.IsNil() {
+	if res != nil && !res.BaseFee.IsNil() {
 		// Store current base fee in event
 		ctx.EventManager().EmitEvents(sdk.Events{
 			sdk.NewEvent(

--- a/x/evm/types/events.go
+++ b/x/evm/types/events.go
@@ -7,7 +7,9 @@ const (
 	EventTypeEthereumTx = TypeMsgEthereumTx
 	EventTypeBlockBloom = "block_bloom"
 	EventTypeTxLog      = "tx_log"
+	EventTypeFeeMarket  = "evm_fee_market"
 
+	AttributeKeyBaseFee         = "base_fee"
 	AttributeKeyContractAddress = "contract"
 	AttributeKeyRecipient       = "recipient"
 	AttributeKeyTxHash          = "txHash"


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

When querying a block via the JSON-RPC, if there's no base fee got from the queryClient because the node was pruned, it [gets the base fee from the feemarket event emitted on begin block](https://github.com/evmos/evmos/blob/48fc61a3ff02b157a9e05fa2cfd57fbcb2b7d47e/rpc/backend/chain_info.go#L71-L85). A potential solution would be to query the evm params at the current height, but could happen that on the block queried, the evm denom decimals param is different than the current. If we want to keep this logic, I propose adding a base fee event on the begin block of the evm module, with the EVM base fee and use that. 

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
