### PR TITLE
chore(evm): refactor getBaseFee to avoid redundant call to get params

### DIFF
--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/evmos/evmos/v19/x/evm/core/vm"
 
 	"github.com/evmos/evmos/v19/x/evm/statedb"
@@ -31,7 +30,7 @@ type EVMKeeper interface { //nolint: revive
 	GetParams(ctx sdk.Context) evmtypes.Params
 	// GetBaseFee returns the BaseFee param from the fee market module
 	// adapted according to the evm denom decimals
-	GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int
+	GetBaseFee(ctx sdk.Context, params evmtypes.Params) *big.Int
 	// GetMinGasPrice returns the MinGasPrice param from the fee market module
 	// adapted according to the evm denom decimals
 	GetMinGasPrice(ctx sdk.Context) (math.LegacyDec, error)

--- a/app/ante/evm/mono.go
+++ b/app/ante/evm/mono.go
@@ -84,7 +84,7 @@ func NewMonoDecoratorUtils(
 	ethCfg := chainCfg.EthereumConfig(ek.ChainID())
 	blockHeight := big.NewInt(ctx.BlockHeight())
 	rules := ethCfg.Rules(blockHeight, true)
-	baseFee := ek.GetBaseFee(ctx, ethCfg)
+	baseFee := ek.GetBaseFee(ctx, evmParams)
 
 	// get the gas prices adapted accordingly
 	// to the evm denom decimals

--- a/x/evm/keeper/config.go
+++ b/x/evm/keeper/config.go
@@ -25,7 +25,7 @@ func (k *Keeper) EVMConfig(ctx sdk.Context, proposerAddress sdk.ConsAddress, cha
 		return nil, errorsmod.Wrap(err, "failed to obtain coinbase address")
 	}
 
-	baseFee := k.GetBaseFee(ctx, ethCfg)
+	baseFee := k.GetBaseFee(ctx, params)
 	return &statedb.EVMConfig{
 		Params:      params,
 		ChainConfig: ethCfg,

--- a/x/evm/keeper/fees_test.go
+++ b/x/evm/keeper/fees_test.go
@@ -499,8 +499,7 @@ func (suite *KeeperTestSuite) TestVerifyFeeAndDeductTxCostsFromUserBalance() {
 			txData, _ := evmtypes.UnpackTxData(tx.Data)
 
 			evmParams := suite.app.EvmKeeper.GetParams(suite.ctx)
-			ethCfg := evmParams.GetChainConfig().EthereumConfig(nil)
-			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx, ethCfg)
+			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx, evmParams)
 			priority := evmtypes.GetTxPriority(txData, baseFee)
 
 			fees, err := keeper.VerifyFee(txData, evmtypes.DefaultEVMDenom, baseFee, false, false, suite.ctx.IsCheckTx())

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -692,8 +692,7 @@ func (k Keeper) BaseFee(c context.Context, _ *types.QueryBaseFeeRequest) (*types
 	ctx := sdk.UnwrapSDKContext(c)
 
 	params := k.GetParams(ctx)
-	ethCfg := params.ChainConfig.EthereumConfig(k.eip155ChainID)
-	baseFee := k.GetBaseFee(ctx, ethCfg)
+	baseFee := k.GetBaseFee(ctx, params)
 
 	res := &types.QueryBaseFeeResponse{}
 	if baseFee != nil {

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -27,10 +27,10 @@ import (
 const invalidAddress = "0x0000"
 
 // expGasConsumed is the gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee)
-const expGasConsumed = 10308
+const expGasConsumed = 7661
 
 // expGasConsumedWithFeeMkt is the gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) with enabled feemarket
-const expGasConsumedWithFeeMkt = 10302
+const expGasConsumedWithFeeMkt = 7655
 
 func (suite *KeeperTestSuite) TestQueryAccount() {
 	var (
@@ -954,7 +954,7 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			},
 			expPass:       true,
 			traceResponse: "{\"gas\":34828,\"failed\":false,\"returnValue\":\"0000000000000000000000000000000000000000000000000000000000000001\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":",
-			expFinalGas:   31497, // gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) + gas consumed in malleate func
+			expFinalGas:   28844, // gas consumed in traceTx setup (GetProposerAddr + CalculateBaseFee) + gas consumed in malleate func
 		},
 		{
 			msg: "invalid chain id",

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -305,15 +305,12 @@ func (k *Keeper) GetBalance(ctx sdk.Context, addr common.Address) *big.Int {
 // - `nil`: london hardfork not enabled.
 // - `0`: london hardfork enabled but feemarket is not enabled.
 // - `n`: both london hardfork and feemarket are enabled.
-func (k Keeper) GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int {
-	return k.getBaseFee(ctx, types.IsLondon(ethCfg, ctx.BlockHeight()))
-}
-
-func (k Keeper) getBaseFee(ctx sdk.Context, london bool) *big.Int {
-	if !london {
+func (k Keeper) GetBaseFee(ctx sdk.Context, params types.Params) *big.Int {
+	chainCfg := params.GetChainConfig()
+	ethCfg := chainCfg.EthereumConfig(k.ChainID())
+	if !types.IsLondon(ethCfg, ctx.BlockHeight()) {
 		return nil
 	}
-	params := k.GetParams(ctx)
 	if err := k.feeMarketWrapper.WithDecimals(params.DenomDecimals); err != nil {
 		k.Logger(ctx).Error("error while setting feemarket wrapper decimals", "error", err)
 	}

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -82,8 +82,7 @@ func (suite *KeeperTestSuite) TestBaseFee() {
 			suite.SetupTest()
 			suite.app.EvmKeeper.BeginBlock(suite.ctx, abci.RequestBeginBlock{})
 			params := suite.app.EvmKeeper.GetParams(suite.ctx)
-			ethCfg := params.ChainConfig.EthereumConfig(suite.app.EvmKeeper.ChainID())
-			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx, ethCfg)
+			baseFee := suite.app.EvmKeeper.GetBaseFee(suite.ctx, params)
 			suite.Require().Equal(tc.expectBaseFee, baseFee)
 		})
 	}


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

In the getFee function we call the GetParams to get the evm denom decimals. But the params are always queried before to get the chain config (EthereumConfig). So this PR introduces the changes to directly pass the params, which are used to get the EthConfig and  the denom decimals. In this way, we just query the params only once instead of twice

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
