### PR TITLE
imp(inflation): fix communityPool is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#2709](https://github.com/evmos/evmos/pull/2709) Minor improvements in precompiles related code.
 - (cli) [#2733](https://github.com/evmos/evmos/pull/2733) Use `pruning.Cmd` instead of the deprecated `pruning.PruningCmd`.
 - (ante) [#2741](https://github.com/evmos/evmos/pull/2741) Remove unnecessary fee ante handler and use Cosmos one instead.
+- (inflation) [#2813](https://github.com/evmos/evmos/pull/2813) Fix communityPool is nil.
 
 ## [v18.1.0](https://github.com/evmos/evmos/releases/tag/v18.1.0) - 2024-05-31
 

--- a/x/inflation/v1/keeper/inflation.go
+++ b/x/inflation/v1/keeper/inflation.go
@@ -77,11 +77,11 @@ func (k Keeper) AllocateExponentialInflation(
 	// Allocate community pool amount (remaining module balance) to community
 	// pool address
 	moduleAddr := k.accountKeeper.GetModuleAddress(types.ModuleName)
-	inflationBalance := k.bankKeeper.GetAllBalances(ctx, moduleAddr)
+	communityPool = k.bankKeeper.GetAllBalances(ctx, moduleAddr)
 
 	err = k.distrKeeper.FundCommunityPool(
 		ctx,
-		inflationBalance,
+		communityPool,
 		moduleAddr,
 	)
 	if err != nil {
@@ -91,7 +91,7 @@ func (k Keeper) AllocateExponentialInflation(
 	return staking, communityPool, nil
 }
 
-// GetAllocationProportion calculates the proportion of coins that is to be
+// GetProportions calculates the proportion of coins that is to be
 // allocated during inflation for a given distribution.
 func (k Keeper) GetProportions(
 	_ sdk.Context,


### PR DESCRIPTION
# Description

Fix communityPool is nil



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the community pool was previously nil, ensuring proper initialization and utilization within the inflation module.
  
- **Documentation**
	- Updated the CHANGELOG.md to reflect significant fixes and improvements related to the community pool functionality. 

- **Refactor**
	- Enhanced clarity by renaming variables in the inflation handling process, aligning names with their purposes for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->