### PR TITLE
chore(evm): Remove unused ChainID from Evm keeper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (app) [#2838](https://github.com/evmos/evmos/pull/2838) Bump repository version to `v20`.
 - (testnet) [#2826](https://github.com/evmos/evmos/pull/2826) Fix command `evmosd testnet init-files` for validator_address is error.
 - (evm) [#2836](https://github.com/evmos/evmos/pull/2836) Recap the highest gas limit with account's available balance.
+- (evm) [#2873](https://github.com/evmos/evmos/pull/2873) Remove `BeginBlock` and replace `ChainID` with global config.
 
 ## [v19.2.0](https://github.com/evmos/evmos/releases/tag/v19.2.0) - 2024-08-19
 

--- a/app/ante/evm/ante_test.go
+++ b/app/ante/evm/ante_test.go
@@ -43,8 +43,9 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 		ctx = suite.GetNetwork().GetContext()
 	}
 
+	evmChainID := config.GetChainConfig().ChainID
 	ethContractCreationTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
 		GasLimit:  100000,
@@ -53,7 +54,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 	}
 
 	ethTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		To:        &to,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
@@ -166,7 +167,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				nonce, err := suite.GetNetwork().App.AccountKeeper.GetSequence(ctx, suite.GetKeyring().GetAccAddr(0))
 				suite.Require().NoError(err)
 				ethTxParams := evmtypes.EvmTxArgs{
-					ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+					ChainID:  config.GetChainConfig().ChainID,
 					To:       &to,
 					Nonce:    nonce,
 					Amount:   big.NewInt(10),
@@ -185,7 +186,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				nonce, err := suite.GetNetwork().App.AccountKeeper.GetSequence(ctx, suite.GetKeyring().GetAccAddr(0))
 				suite.Require().NoError(err)
 				ethTxParams := evmtypes.EvmTxArgs{
-					ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+					ChainID:  config.GetChainConfig().ChainID,
 					To:       &to,
 					Nonce:    nonce,
 					Amount:   big.NewInt(10),
@@ -203,7 +204,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				nonce, err := suite.GetNetwork().App.AccountKeeper.GetSequence(ctx, suite.GetKeyring().GetAccAddr(0))
 				suite.Require().NoError(err)
 				ethTxParams := evmtypes.EvmTxArgs{
-					ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+					ChainID:  config.GetChainConfig().ChainID,
 					To:       &to,
 					Nonce:    nonce,
 					Amount:   big.NewInt(10),
@@ -221,7 +222,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				nonce, err := suite.GetNetwork().App.AccountKeeper.GetSequence(ctx, suite.GetKeyring().GetAccAddr(0))
 				suite.Require().NoError(err)
 				ethTxParams := evmtypes.EvmTxArgs{
-					ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+					ChainID:  config.GetChainConfig().ChainID,
 					To:       &to,
 					Nonce:    nonce,
 					Amount:   big.NewInt(10),
@@ -243,7 +244,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 				nonce, err := suite.GetNetwork().App.AccountKeeper.GetSequence(ctx, suite.GetKeyring().GetAccAddr(0))
 				suite.Require().NoError(err)
 				ethTxParams := evmtypes.EvmTxArgs{
-					ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+					ChainID:  config.GetChainConfig().ChainID,
 					To:       &to,
 					Nonce:    nonce,
 					Amount:   big.NewInt(10),
@@ -919,9 +920,10 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 func (suite *AnteTestSuite) TestAnteHandlerWithDynamicTxFee() {
 	addr, privKey := utiltx.NewAddrKey()
 	to := utiltx.GenerateAddress()
+	evmChainID := config.GetChainConfig().ChainID
 
 	ethContractCreationTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
 		GasLimit:  100000,
@@ -931,7 +933,7 @@ func (suite *AnteTestSuite) TestAnteHandlerWithDynamicTxFee() {
 	}
 
 	ethTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
 		GasLimit:  100000,
@@ -1082,9 +1084,10 @@ func (suite *AnteTestSuite) TestAnteHandlerWithDynamicTxFee() {
 func (suite *AnteTestSuite) TestAnteHandlerWithParams() {
 	addr, privKey := utiltx.NewAddrKey()
 	to := utiltx.GenerateAddress()
+	evmChainID := config.GetChainConfig().ChainID
 
 	ethContractCreationTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
 		GasLimit:  100000,
@@ -1095,7 +1098,7 @@ func (suite *AnteTestSuite) TestAnteHandlerWithParams() {
 	}
 
 	ethTxParams := evmtypes.EvmTxArgs{
-		ChainID:   suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:   evmChainID,
 		Nonce:     0,
 		Amount:    big.NewInt(10),
 		GasLimit:  100000,

--- a/app/ante/evm/eth_benchmark_test.go
+++ b/app/ante/evm/eth_benchmark_test.go
@@ -29,8 +29,10 @@ func BenchmarkEthGasConsumeDecorator(b *testing.B) {
 	s.SetupTest()
 	ctx := s.GetNetwork().GetContext()
 
+	evmChainID := config.GetChainConfig().ChainID
+
 	args := &evmtypes.EvmTxArgs{
-		ChainID:  s.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:  evmChainID,
 		Nonce:    1,
 		Amount:   big.NewInt(10),
 		GasLimit: uint64(1_000_000),

--- a/app/ante/evm/interfaces.go
+++ b/app/ante/evm/interfaces.go
@@ -38,7 +38,6 @@ type FeeMarketKeeper interface {
 
 // DynamicFeeEVMKeeper is a subset of EVMKeeper interface that supports dynamic fee checker
 type DynamicFeeEVMKeeper interface {
-	ChainID() *big.Int
 	GetParams(ctx sdk.Context) evmtypes.Params
 	GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int
 }

--- a/app/ante/evm/setup_ctx_test.go
+++ b/app/ante/evm/setup_ctx_test.go
@@ -9,13 +9,17 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	testutiltx "github.com/evmos/evmos/v20/testutil/tx"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
 func (suite *AnteTestSuite) TestEthSetupContextDecorator() {
 	dec := evmante.NewEthSetUpContextDecorator(suite.GetNetwork().App.EvmKeeper)
+
+	evmChainID := config.GetChainConfig().ChainID
+
 	ethContractCreationTxParams := &evmtypes.EvmTxArgs{
-		ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:  evmChainID,
 		Nonce:    1,
 		Amount:   big.NewInt(10),
 		GasLimit: 1000,

--- a/app/ante/evm/signverify_test.go
+++ b/app/ante/evm/signverify_test.go
@@ -8,15 +8,19 @@ import (
 	ethante "github.com/evmos/evmos/v20/app/ante/evm"
 	"github.com/evmos/evmos/v20/testutil"
 	testutiltx "github.com/evmos/evmos/v20/testutil/tx"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
 func (suite *AnteTestSuite) TestEthSigVerificationDecorator() {
 	addr, privKey := testutiltx.NewAddrKey()
-	ethSigner := ethtypes.LatestSignerForChainID(suite.GetNetwork().App.EvmKeeper.ChainID())
+
+	evmChainID := config.GetChainConfig().ChainID
+
+	ethSigner := ethtypes.LatestSignerForChainID(evmChainID)
 
 	ethContractCreationTxParams := &evmtypes.EvmTxArgs{
-		ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:  evmChainID,
 		Nonce:    1,
 		Amount:   big.NewInt(10),
 		GasLimit: 1000,

--- a/app/ante/evm/sigs_test.go
+++ b/app/ante/evm/sigs_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	utiltx "github.com/evmos/evmos/v20/testutil/tx"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
@@ -14,8 +15,10 @@ func (suite *AnteTestSuite) TestSignatures() {
 	privKey := suite.GetKeyring().GetPrivKey(0)
 	to := utiltx.GenerateAddress()
 
+	evmChainID := config.GetChainConfig().ChainID
+
 	txArgs := evmtypes.EvmTxArgs{
-		ChainID:  suite.GetNetwork().App.EvmKeeper.ChainID(),
+		ChainID:  evmChainID,
 		Nonce:    0,
 		To:       &to,
 		Amount:   big.NewInt(10),

--- a/app/app.go
+++ b/app/app.go
@@ -682,7 +682,6 @@ func NewEvmos(
 		// Note: epochs' begin should be "real" start of epochs, we keep epochs beginblock at the beginning
 		epochstypes.ModuleName,
 		feemarkettypes.ModuleName,
-		evmtypes.ModuleName,
 		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
 		evidencetypes.ModuleName,

--- a/app/post/setup_test.go
+++ b/app/post/setup_test.go
@@ -20,6 +20,8 @@ import (
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 	inflationtypes "github.com/evmos/evmos/v20/x/inflation/v1/types"
 
+	"github.com/evmos/evmos/v20/x/evm/config"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/stretchr/testify/suite"
 )
@@ -68,7 +70,8 @@ func TestPostTestSuite(t *testing.T) {
 }
 
 func (s *PostTestSuite) BuildEthTx() sdk.Tx {
-	chainID := s.unitNetwork.App.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
+
 	nonce := s.unitNetwork.App.EvmKeeper.GetNonce(
 		s.unitNetwork.GetContext(),
 		common.BytesToAddress(s.from.Bytes()),

--- a/precompiles/distribution/distribution_test.go
+++ b/precompiles/distribution/distribution_test.go
@@ -11,6 +11,7 @@ import (
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/evmos/v20/app"
 	"github.com/evmos/evmos/v20/precompiles/distribution"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
@@ -221,9 +222,11 @@ func (s *PrecompileTestSuite) TestRun() {
 			contract.Input = input
 
 			contractAddr := contract.Address()
+
+			evmChainID := config.GetChainConfig().ChainID
 			// Build and sign Ethereum transaction
 			txArgs := evmtypes.EvmTxArgs{
-				ChainID:   s.network.App.EvmKeeper.ChainID(),
+				ChainID:   evmChainID,
 				Nonce:     0,
 				To:        &contractAddr,
 				Amount:    nil,

--- a/precompiles/gov/gov_test.go
+++ b/precompiles/gov/gov_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evmos/evmos/v20/app"
 	"github.com/evmos/evmos/v20/precompiles/gov"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
@@ -86,8 +87,10 @@ func (s *PrecompileTestSuite) TestRun() {
 
 			contractAddr := contract.Address()
 			// Build and sign Ethereum transaction
+
+			evmChainID := config.GetChainConfig().ChainID
 			txArgs := evmtypes.EvmTxArgs{
-				ChainID:   s.network.App.EvmKeeper.ChainID(),
+				ChainID:   evmChainID,
 				Nonce:     0,
 				To:        &contractAddr,
 				Amount:    nil,

--- a/precompiles/staking/staking_test.go
+++ b/precompiles/staking/staking_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -445,7 +446,7 @@ func (s *PrecompileTestSuite) TestRun() {
 
 			// Build and sign Ethereum transaction
 			txArgs := evmtypes.EvmTxArgs{
-				ChainID:   s.network.App.EvmKeeper.ChainID(),
+				ChainID:   config.GetChainConfig().ChainID,
 				Nonce:     0,
 				To:        &contractAddr,
 				Amount:    nil,

--- a/precompiles/testutil/contracts/contracts.go
+++ b/precompiles/testutil/contracts/contracts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evmos/evmos/v20/crypto/ethsecp256k1"
 	"github.com/evmos/evmos/v20/precompiles/testutil"
 	evmosutil "github.com/evmos/evmos/v20/testutil"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
@@ -69,7 +70,7 @@ func Call(ctx sdk.Context, app *evmosapp.Evmos, args CallArgs) (res abci.ExecTxR
 
 	// Create MsgEthereumTx that calls the contract
 	msg := evmtypes.NewTx(&evmtypes.EvmTxArgs{
-		ChainID:   app.EvmKeeper.ChainID(),
+		ChainID:   config.GetChainConfig().ChainID,
 		Nonce:     nonce,
 		To:        &args.ContractAddr,
 		Amount:    args.Amount,

--- a/testutil/abci.go
+++ b/testutil/abci.go
@@ -93,7 +93,7 @@ func DeliverEthTx(
 ) (abci.ExecTxResult, error) {
 	txConfig := appEvmos.GetTxConfig()
 
-	tx, err := tx.PrepareEthTx(txConfig, appEvmos, priv, msgs...)
+	tx, err := tx.PrepareEthTx(txConfig, priv, msgs...)
 	if err != nil {
 		return abci.ExecTxResult{}, err
 	}
@@ -120,7 +120,7 @@ func DeliverEthTxWithoutCheck(
 ) (abci.ExecTxResult, error) {
 	txConfig := appEvmos.GetTxConfig()
 
-	tx, err := tx.PrepareEthTx(txConfig, appEvmos, priv, msgs...)
+	tx, err := tx.PrepareEthTx(txConfig, priv, msgs...)
 	if err != nil {
 		return abci.ExecTxResult{}, err
 	}
@@ -169,7 +169,7 @@ func CheckEthTx(
 ) (abci.ResponseCheckTx, error) {
 	txConfig := appEvmos.GetTxConfig()
 
-	tx, err := tx.PrepareEthTx(txConfig, appEvmos, priv, msgs...)
+	tx, err := tx.PrepareEthTx(txConfig, priv, msgs...)
 	if err != nil {
 		return abci.ResponseCheckTx{}, err
 	}

--- a/testutil/contract.go
+++ b/testutil/contract.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/evmos/evmos/v20/app"
 	"github.com/evmos/evmos/v20/testutil/tx"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	evm "github.com/evmos/evmos/v20/x/evm/types"
 )
 
@@ -59,7 +60,7 @@ func DeployContract(
 	contract evm.CompiledContract,
 	constructorArgs ...interface{},
 ) (common.Address, error) {
-	chainID := evmosApp.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
 	from := common.BytesToAddress(priv.PubKey().Address().Bytes())
 	nonce := evmosApp.EvmKeeper.GetNonce(ctx, from)
 
@@ -105,7 +106,7 @@ func DeployContractWithFactory(
 	priv cryptotypes.PrivKey,
 	factoryAddress common.Address,
 ) (common.Address, abci.ExecTxResult, error) {
-	chainID := evmosApp.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
 	from := common.BytesToAddress(priv.PubKey().Address().Bytes())
 	factoryNonce := evmosApp.EvmKeeper.GetNonce(ctx, factoryAddress)
 	nonce := evmosApp.EvmKeeper.GetNonce(ctx, from)

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -29,7 +29,6 @@ import (
 // It returns the signed transaction and an error
 func PrepareEthTx(
 	txCfg client.TxConfig,
-	_ *app.Evmos,
 	priv cryptotypes.PrivKey,
 	msgs ...sdk.Msg,
 ) (authsigning.Tx, error) {

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -29,7 +29,7 @@ import (
 // It returns the signed transaction and an error
 func PrepareEthTx(
 	txCfg client.TxConfig,
-	_appEvmos *app.Evmos,
+	_ *app.Evmos,
 	priv cryptotypes.PrivKey,
 	msgs ...sdk.Msg,
 ) (authsigning.Tx, error) {

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -29,7 +29,7 @@ import (
 // It returns the signed transaction and an error
 func PrepareEthTx(
 	txCfg client.TxConfig,
-	appEvmos *app.Evmos,
+	_appEvmos *app.Evmos,
 	priv cryptotypes.PrivKey,
 	msgs ...sdk.Msg,
 ) (authsigning.Tx, error) {

--- a/testutil/tx/eth.go
+++ b/testutil/tx/eth.go
@@ -35,7 +35,7 @@ func PrepareEthTx(
 ) (authsigning.Tx, error) {
 	txBuilder := txCfg.NewTxBuilder()
 
-	signer := ethtypes.LatestSignerForChainID(appEvmos.EvmKeeper.ChainID())
+	signer := ethtypes.LatestSignerForChainID(evmconfig.GetChainConfig().ChainID)
 	txFee := sdk.Coins{}
 	txGasLimit := uint64(0)
 
@@ -103,7 +103,7 @@ func CreateEthTx(
 ) (*evmtypes.MsgEthereumTx, error) {
 	toAddr := common.BytesToAddress(dest.Bytes())
 	fromAddr := common.BytesToAddress(from.Bytes())
-	chainID := appEvmos.EvmKeeper.ChainID()
+	chainID := evmconfig.GetChainConfig().ChainID
 
 	// When we send multiple Ethereum Tx's in one Cosmos Tx, we need to increment the nonce for each one.
 	nonce := appEvmos.EvmKeeper.GetNonce(ctx, fromAddr) + uint64(nonceIncrement) //nolint:gosec // G115
@@ -122,7 +122,7 @@ func CreateEthTx(
 
 	// If we are creating multiple eth Tx's with different senders, we need to sign here rather than later.
 	if privKey != nil {
-		signer := ethtypes.LatestSignerForChainID(appEvmos.EvmKeeper.ChainID())
+		signer := ethtypes.LatestSignerForChainID(evmconfig.GetChainConfig().ChainID)
 		err := msgEthereumTx.Sign(signer, NewSigner(privKey))
 		if err != nil {
 			return nil, err

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -21,8 +21,6 @@ func InitGenesis(
 	accountKeeper types.AccountKeeper,
 	data types.GenesisState,
 ) []abci.ValidatorUpdate {
-	k.WithChainID(ctx)
-
 	err := k.SetParams(ctx, data.Params)
 	if err != nil {
 		panic(fmt.Errorf("error setting params %s", err))

--- a/x/evm/keeper/abci.go
+++ b/x/evm/keeper/abci.go
@@ -9,12 +9,6 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// BeginBlock sets the sdk Context and EIP155 chain id to the Keeper.
-func (k *Keeper) BeginBlock(ctx sdk.Context) error {
-	k.WithChainID(ctx)
-	return nil
-}
-
 // EndBlock also retrieves the bloom filter value from the transient store and commits it to the
 // KVStore. The EVM end block logic doesn't update the validator set, thus it returns
 // an empty slice.

--- a/x/evm/keeper/benchmark_test.go
+++ b/x/evm/keeper/benchmark_test.go
@@ -84,7 +84,7 @@ func DoBenchmark(b *testing.B, txBuilder TxBuilder) {
 	}
 }
 
-func BenchmarkTokenTransfer(b *testing.B) { //nolint:dupl
+func BenchmarkTokenTransfer(b *testing.B) {
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(b, err, "failed to load erc20 contract")
 
@@ -147,7 +147,7 @@ func BenchmarkTokenTransferFrom(b *testing.B) {
 	})
 }
 
-func BenchmarkTokenMint(b *testing.B) { //nolint:dupl
+func BenchmarkTokenMint(b *testing.B) {
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(b, err, "failed to load erc20 contract")
 

--- a/x/evm/keeper/benchmark_test.go
+++ b/x/evm/keeper/benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/keeper/testdata"
 
 	sdkmath "cosmossdk.io/math"
@@ -61,7 +62,7 @@ func DoBenchmark(b *testing.B, txBuilder TxBuilder) {
 	krSigner := utiltx.NewSigner(suite.keyring.GetPrivKey(0))
 	msg := txBuilder(suite, contractAddr)
 	msg.From = suite.keyring.GetAddr(0).Hex()
-	err := msg.Sign(ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID()), krSigner)
+	err := msg.Sign(ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID), krSigner)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -92,7 +93,7 @@ func BenchmarkTokenTransfer(b *testing.B) { //nolint:dupl
 		require.NoError(b, err)
 		nonce := suite.network.App.EvmKeeper.GetNonce(suite.network.GetContext(), suite.keyring.GetAddr(0))
 		ethTxParams := &types.EvmTxArgs{
-			ChainID:  suite.network.App.EvmKeeper.ChainID(),
+			ChainID:  config.GetChainConfig().ChainID,
 			Nonce:    nonce,
 			To:       &contract,
 			Amount:   big.NewInt(0),
@@ -113,7 +114,7 @@ func BenchmarkEmitLogs(b *testing.B) {
 		require.NoError(b, err)
 		nonce := suite.network.App.EvmKeeper.GetNonce(suite.network.GetContext(), suite.keyring.GetAddr(0))
 		ethTxParams := &types.EvmTxArgs{
-			ChainID:  suite.network.App.EvmKeeper.ChainID(),
+			ChainID:  config.GetChainConfig().ChainID,
 			Nonce:    nonce,
 			To:       &contract,
 			Amount:   big.NewInt(0),
@@ -134,7 +135,7 @@ func BenchmarkTokenTransferFrom(b *testing.B) {
 		require.NoError(b, err)
 		nonce := suite.network.App.EvmKeeper.GetNonce(suite.network.GetContext(), suite.keyring.GetAddr(0))
 		ethTxParams := &types.EvmTxArgs{
-			ChainID:  suite.network.App.EvmKeeper.ChainID(),
+			ChainID:  config.GetChainConfig().ChainID,
 			Nonce:    nonce,
 			To:       &contract,
 			Amount:   big.NewInt(0),
@@ -155,7 +156,7 @@ func BenchmarkTokenMint(b *testing.B) { //nolint:dupl
 		require.NoError(b, err)
 		nonce := suite.network.App.EvmKeeper.GetNonce(suite.network.GetContext(), suite.keyring.GetAddr(0))
 		ethTxParams := &types.EvmTxArgs{
-			ChainID:  suite.network.App.EvmKeeper.ChainID(),
+			ChainID:  config.GetChainConfig().ChainID,
 			Nonce:    nonce,
 			To:       &contract,
 			Amount:   big.NewInt(0),
@@ -177,7 +178,7 @@ func BenchmarkMessageCall(b *testing.B) {
 	require.NoError(b, err)
 	nonce := suite.network.App.EvmKeeper.GetNonce(suite.network.GetContext(), suite.keyring.GetAddr(0))
 	ethTxParams := &types.EvmTxArgs{
-		ChainID:  suite.network.App.EvmKeeper.ChainID(),
+		ChainID:  config.GetChainConfig().ChainID,
 		Nonce:    nonce,
 		To:       &contract,
 		Amount:   big.NewInt(0),
@@ -189,7 +190,7 @@ func BenchmarkMessageCall(b *testing.B) {
 
 	msg.From = suite.keyring.GetAddr(0).Hex()
 	krSigner := utiltx.NewSigner(suite.keyring.GetPrivKey(0))
-	err = msg.Sign(ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID()), krSigner)
+	err = msg.Sign(ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID), krSigner)
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -20,7 +20,6 @@ import (
 	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 
-	evmostypes "github.com/evmos/evmos/v20/types"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	"github.com/evmos/evmos/v20/x/evm/types"
 )
@@ -110,25 +109,6 @@ func NewKeeper(
 // Logger returns a module-specific logger.
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", types.ModuleName)
-}
-
-// WithChainID sets the chain id to the local variable in the keeper
-func (k *Keeper) WithChainID(ctx sdk.Context) {
-	chainID, err := evmostypes.ParseChainID(ctx.ChainID())
-	if err != nil {
-		panic(err)
-	}
-
-	if k.eip155ChainID != nil && k.eip155ChainID.Cmp(chainID) != 0 {
-		panic("chain id already set")
-	}
-
-	k.eip155ChainID = chainID
-}
-
-// ChainID returns the EIP155 chain ID for the EVM context
-func (k Keeper) ChainID() *big.Int {
-	return k.eip155ChainID
 }
 
 // ----------------------------------------------------------------------------

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -52,9 +52,6 @@ type Keeper struct {
 	// erc20Keeper interface needed to instantiate erc20 precompiles
 	erc20Keeper types.Erc20Keeper
 
-	// chain ID number obtained from the context's chain id
-	eip155ChainID *big.Int
-
 	// Tracer used to collect execution traces from the EVM transaction execution
 	tracer string
 

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -9,58 +9,11 @@ import (
 
 	"github.com/evmos/evmos/v20/utils"
 	"github.com/evmos/evmos/v20/x/evm/config"
-	"github.com/evmos/evmos/v20/x/evm/keeper"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 
 	"github.com/ethereum/go-ethereum/common"
 )
-
-func (suite *KeeperTestSuite) TestWithChainID() {
-	testCases := []struct {
-		name       string
-		chainID    string
-		expChainID int64
-		expPanic   bool
-	}{
-		{
-			"fail - chainID is empty",
-			"",
-			0,
-			true,
-		},
-		{
-			"success - Evmos mainnet chain ID",
-			"evmos_9001-2",
-			9001,
-			false,
-		},
-		{
-			"success - Evmos testnet chain ID",
-			"evmos_9000-4",
-			9000,
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		suite.Run(tc.name, func() {
-			keeper := keeper.Keeper{}
-			ctx := suite.network.GetContext().WithChainID(tc.chainID)
-
-			if tc.expPanic {
-				suite.Require().Panics(func() {
-					keeper.WithChainID(ctx)
-				})
-			} else {
-				suite.Require().NotPanics(func() {
-					keeper.WithChainID(ctx)
-					suite.Require().Equal(tc.expChainID, keeper.ChainID().Int64())
-				})
-			}
-		})
-	}
-}
 
 func (suite *KeeperTestSuite) TestBaseFee() {
 	testCases := []struct {
@@ -80,7 +33,6 @@ func (suite *KeeperTestSuite) TestBaseFee() {
 			suite.enableFeemarket = tc.enableFeemarket
 			suite.enableLondonHF = tc.enableLondonHF
 			suite.SetupTest()
-			suite.Require().NoError(suite.network.App.EvmKeeper.BeginBlock(suite.network.GetContext()))
 			ethCfg := config.GetChainConfig()
 			baseFee := suite.network.App.EvmKeeper.GetBaseFee(suite.network.GetContext(), ethCfg)
 			suite.Require().Equal(tc.expectBaseFee, baseFee)

--- a/x/evm/keeper/state_transition_benchmark_test.go
+++ b/x/evm/keeper/state_transition_benchmark_test.go
@@ -164,7 +164,7 @@ func BenchmarkApplyTransaction(b *testing.B) { //nolint:dupl
 	suite := KeeperTestSuite{enableLondonHF: true}
 	suite.SetupTest()
 
-	ethSigner := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	ethSigner := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -193,7 +193,7 @@ func BenchmarkApplyTransactionWithLegacyTx(b *testing.B) { //nolint:dupl
 	suite := KeeperTestSuite{enableLondonHF: true}
 	suite.SetupTest()
 
-	ethSigner := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	ethSigner := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -222,7 +222,7 @@ func BenchmarkApplyTransactionWithDynamicFeeTx(b *testing.B) {
 	suite := KeeperTestSuite{enableFeemarket: true, enableLondonHF: true}
 	suite.SetupTest()
 
-	ethSigner := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	ethSigner := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -253,7 +253,7 @@ func BenchmarkApplyMessage(b *testing.B) {
 	suite.SetupTest()
 
 	ethCfg := config.GetChainConfig()
-	signer := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	signer := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -289,7 +289,7 @@ func BenchmarkApplyMessageWithLegacyTx(b *testing.B) {
 	suite.SetupTest()
 
 	ethCfg := config.GetChainConfig()
-	signer := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	signer := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -324,7 +324,7 @@ func BenchmarkApplyMessageWithDynamicFeeTx(b *testing.B) {
 	suite.SetupTest()
 
 	ethCfg := config.GetChainConfig()
-	signer := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	signer := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/x/evm/keeper/state_transition_test.go
+++ b/x/evm/keeper/state_transition_test.go
@@ -259,7 +259,7 @@ func (suite *KeeperTestSuite) TestGetEthIntrinsicGas() {
 			ethCfg := config.GetChainConfig()
 			ethCfg.HomesteadBlock = big.NewInt(2)
 			ethCfg.IstanbulBlock = big.NewInt(3)
-			signer := gethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+			signer := gethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 			ctx := suite.network.GetContext().WithBlockHeight(tc.height)
 

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -23,6 +23,7 @@ import (
 	testkeyring "github.com/evmos/evmos/v20/testutil/integration/evmos/keyring"
 	"github.com/evmos/evmos/v20/testutil/integration/evmos/network"
 	utiltx "github.com/evmos/evmos/v20/testutil/tx"
+	"github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	"github.com/evmos/evmos/v20/x/evm/types"
@@ -689,7 +690,7 @@ func (suite *KeeperTestSuite) CreateTestTx(msg *types.MsgEthereumTx, priv crypto
 	suite.Require().NoError(err)
 
 	clientCtx := client.Context{}.WithTxConfig(suite.network.App.GetTxConfig())
-	ethSigner := ethtypes.LatestSignerForChainID(suite.network.App.EvmKeeper.ChainID())
+	ethSigner := ethtypes.LatestSignerForChainID(config.GetChainConfig().ChainID)
 
 	txBuilder := clientCtx.TxConfig.NewTxBuilder()
 	builder, ok := txBuilder.(authtx.ExtensionOptionsTxBuilder)

--- a/x/evm/keeper/utils_test.go
+++ b/x/evm/keeper/utils_test.go
@@ -4,20 +4,21 @@ import (
 	"encoding/json"
 	"math/big"
 
+	"github.com/stretchr/testify/require"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+
 	servercfg "github.com/evmos/evmos/v20/server/config"
 	utiltx "github.com/evmos/evmos/v20/testutil/tx"
 	evmconfig "github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/keeper/testdata"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
-	"github.com/stretchr/testify/require"
-
-	"github.com/evmos/evmos/v20/x/evm/config"
 )
 
 func (suite *KeeperTestSuite) EvmDenom() string {
@@ -30,7 +31,7 @@ func (suite *KeeperTestSuite) StateDB() *statedb.StateDB {
 
 // DeployTestContract deploy a test erc20 contract and returns the contract address
 func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Context, owner common.Address, supply *big.Int) common.Address {
-	chainID := config.GetChainConfig().ChainID
+	chainID := evmconfig.GetChainConfig().ChainID
 
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(t, err, "failed to load contract")
@@ -89,7 +90,7 @@ func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Con
 
 func (suite *KeeperTestSuite) TransferERC20Token(t require.TestingT, contractAddr, from, to common.Address, amount *big.Int) *evmtypes.MsgEthereumTx {
 	ctx := suite.network.GetContext()
-	chainID := config.GetChainConfig().ChainID
+	chainID := evmconfig.GetChainConfig().ChainID
 
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(t, err, "failed to load contract")
@@ -145,7 +146,7 @@ func (suite *KeeperTestSuite) TransferERC20Token(t require.TestingT, contractAdd
 // DeployTestMessageCall deploy a test erc20 contract and returns the contract address
 func (suite *KeeperTestSuite) DeployTestMessageCall(t require.TestingT) common.Address {
 	ctx := suite.network.GetContext()
-	chainID := config.GetChainConfig().ChainID
+	chainID := evmconfig.GetChainConfig().ChainID
 
 	testMsgCall, err := testdata.LoadMessageCallContract()
 	require.NoError(t, err)

--- a/x/evm/keeper/utils_test.go
+++ b/x/evm/keeper/utils_test.go
@@ -9,13 +9,15 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/evmos/evmos/v20/server/config"
+	servercfg "github.com/evmos/evmos/v20/server/config"
 	utiltx "github.com/evmos/evmos/v20/testutil/tx"
 	evmconfig "github.com/evmos/evmos/v20/x/evm/config"
 	"github.com/evmos/evmos/v20/x/evm/keeper/testdata"
 	"github.com/evmos/evmos/v20/x/evm/statedb"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/evmos/evmos/v20/x/evm/config"
 )
 
 func (suite *KeeperTestSuite) EvmDenom() string {
@@ -28,7 +30,7 @@ func (suite *KeeperTestSuite) StateDB() *statedb.StateDB {
 
 // DeployTestContract deploy a test erc20 contract and returns the contract address
 func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Context, owner common.Address, supply *big.Int) common.Address {
-	chainID := suite.network.App.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
 
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(t, err, "failed to load contract")
@@ -48,7 +50,7 @@ func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Con
 	require.NoError(t, err)
 	res, err := suite.network.GetEvmClient().EstimateGas(ctx, &evmtypes.EthCallRequest{
 		Args:            args,
-		GasCap:          config.DefaultGasCap,
+		GasCap:          servercfg.DefaultGasCap,
 		ProposerAddress: suite.network.GetContext().BlockHeader().ProposerAddress,
 	})
 	require.NoError(t, err)
@@ -87,7 +89,7 @@ func (suite *KeeperTestSuite) DeployTestContract(t require.TestingT, ctx sdk.Con
 
 func (suite *KeeperTestSuite) TransferERC20Token(t require.TestingT, contractAddr, from, to common.Address, amount *big.Int) *evmtypes.MsgEthereumTx {
 	ctx := suite.network.GetContext()
-	chainID := suite.network.App.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
 
 	erc20Contract, err := testdata.LoadERC20Contract()
 	require.NoError(t, err, "failed to load contract")
@@ -143,7 +145,7 @@ func (suite *KeeperTestSuite) TransferERC20Token(t require.TestingT, contractAdd
 // DeployTestMessageCall deploy a test erc20 contract and returns the contract address
 func (suite *KeeperTestSuite) DeployTestMessageCall(t require.TestingT) common.Address {
 	ctx := suite.network.GetContext()
-	chainID := suite.network.App.EvmKeeper.ChainID()
+	chainID := config.GetChainConfig().ChainID
 
 	testMsgCall, err := testdata.LoadMessageCallContract()
 	require.NoError(t, err)
@@ -158,7 +160,7 @@ func (suite *KeeperTestSuite) DeployTestMessageCall(t require.TestingT) common.A
 
 	res, err := suite.network.GetEvmClient().EstimateGas(ctx, &evmtypes.EthCallRequest{
 		Args:            args,
-		GasCap:          config.DefaultGasCap,
+		GasCap:          servercfg.DefaultGasCap,
 		ProposerAddress: suite.network.GetContext().BlockHeader().ProposerAddress,
 	})
 	require.NoError(t, err)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -34,8 +34,7 @@ var (
 	_ module.AppModuleBasic = AppModuleBasic{}
 	_ module.HasABCIGenesis = AppModule{}
 
-	_ appmodule.HasEndBlocker   = AppModule{}
-	_ appmodule.HasBeginBlocker = AppModule{}
+	_ appmodule.HasEndBlocker = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the evm module.
@@ -140,12 +139,6 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err := cfg.RegisterMigration(types.ModuleName, 7, m.Migrate7to8); err != nil {
 		panic(err)
 	}
-}
-
-// BeginBlock returns the begin block for the evm module.
-func (am AppModule) BeginBlock(ctx context.Context) error {
-	c := sdk.UnwrapSDKContext(ctx)
-	return am.keeper.BeginBlock(c)
 }
 
 // EndBlock returns the end blocker for the evm module. It returns no validator

--- a/x/vesting/keeper/integration_test.go
+++ b/x/vesting/keeper/integration_test.go
@@ -564,7 +564,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			}
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -605,7 +605,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			}
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -642,7 +642,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			}
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -668,7 +668,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			Expect(err).To(BeNil())
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, &msg)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, &msg)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -694,7 +694,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			}
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -722,7 +722,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			msgs[numVestAccounts] = &msg
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -752,7 +752,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			msgs = append(msgs, &msg)
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)
@@ -779,7 +779,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			msgs := []sdk.Msg{&normAccMsg, &vestAccMsg}
 
 			txConfig := s.network.GetEncodingConfig().TxConfig
-			tx, err := utiltx.PrepareEthTx(txConfig, s.network.App, nil, msgs...)
+			tx, err := utiltx.PrepareEthTx(txConfig, nil, msgs...)
 			Expect(err).To(BeNil())
 
 			txBytes, err := txConfig.TxEncoder()(tx)


### PR DESCRIPTION
Given the refactor made with https://github.com/evmos/evmos/pull/2860, we do not need the `ChainID` in the EVM keeper anymore. This PR:

- Remove the `BeginBlock` of `x/evm`.
- Remove `ChainID` tests.
- Replace  getter to evm `ChainID` with getters to global config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Centralized configuration for ChainID management across the application.

- **Bug Fixes**
	- Removed deprecated `BeginBlock` functionality in the EVM component.

- **Refactor**
	- Updated various components to retrieve ChainID from the new configuration method, enhancing consistency and maintainability.
	- Simplified the `AppModule` interface by eliminating the `BeginBlock` functionality.

- **Chores**
	- Cleaned up test cases and removed unnecessary methods related to ChainID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->