### PR TITLE
chore(app): Ensure the decimals used is the one registered

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -7,6 +7,8 @@
 package app
 
 import (
+	"errors"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/evmos/evmos/v20/app/eips"
@@ -34,13 +36,17 @@ func InitializeAppConfiguration(chainID string) error {
 	if err != nil {
 		return err
 	}
+	baseDenomUnit, found := sdk.GetDenomUnit(baseDenom)
+	if !found {
+		return errors.New("base denom unit not registered")
+	}
 
 	ethCfg := evmtypes.DefaultChainConfig(chainID)
 
 	err = evmtypes.NewEVMConfigurator().
 		WithExtendedEips(evmosActivators).
 		WithChainConfig(ethCfg).
-		WithEVMCoinInfo(baseDenom, evmtypes.EighteenDecimals).
+		WithEVMCoinInfo(baseDenom, evmtypes.Decimals(baseDenomUnit.RoundInt64())).
 		Configure()
 	if err != nil {
 		return err

--- a/app/config_testing.go
+++ b/app/config_testing.go
@@ -7,6 +7,8 @@
 package app
 
 import (
+	"errors"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/evmos/evmos/v20/app/eips"
@@ -29,6 +31,10 @@ func InitializeAppConfiguration(chainID string) error {
 	if err != nil {
 		return err
 	}
+	baseDenomUnit, found := sdk.GetDenomUnit(baseDenom)
+	if !found {
+		return errors.New("base denom unit not registered")
+	}
 
 	ethCfg := evmtypes.DefaultChainConfig(chainID)
 
@@ -38,7 +44,7 @@ func InitializeAppConfiguration(chainID string) error {
 	err = configurator.
 		WithExtendedEips(evmosActivators).
 		WithChainConfig(ethCfg).
-		WithEVMCoinInfo(baseDenom, evmtypes.EighteenDecimals).
+		WithEVMCoinInfo(baseDenom, evmtypes.Decimals(baseDenomUnit.RoundInt64())).
 		Configure()
 	if err != nil {
 		return err

--- a/x/evm/types/chain_config.go
+++ b/x/evm/types/chain_config.go
@@ -25,6 +25,11 @@ const testChainID string = "evmos_9002-1"
 // opcodes are active based on Ethereum upgrades.
 var chainConfig *geth.ChainConfig
 
+// GetChainConfig returns the `chainConfig` used in the EVM.
+func GetChainConfig() *geth.ChainConfig {
+	return chainConfig
+}
+
 // EthereumConfig returns an Ethereum ChainConfig for EVM state transitions.
 // All the negative or nil values are converted to nil
 func (cc ChainConfig) EthereumConfig(chainID *big.Int) *geth.ChainConfig {

--- a/x/evm/types/configurator.go
+++ b/x/evm/types/configurator.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"slices"
 
-	geth "github.com/ethereum/go-ethereum/params"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 )
 
@@ -102,9 +101,4 @@ func (ec *EVMConfigurator) Configure() error {
 
 func (ec *EVMConfigurator) ResetTestChainConfig() {
 	panic("this is only implemented with the 'test' build flag. Make sure you're running your tests using the '-tags=test' flag.")
-}
-
-// GetChainConfig returns the `chainConfig` used in the EVM.
-func GetChainConfig() *geth.ChainConfig {
-	return chainConfig
 }

--- a/x/evm/types/denom_config.go
+++ b/x/evm/types/denom_config.go
@@ -27,7 +27,20 @@ const (
 
 // Decimals is a wrapper around uint32 to represent the decimal representation
 // of a Cosmos coin.
-type Decimals uint32
+type Decimals uint64
+
+// Validate checks if the Decimals instance represent a supported decimals value
+// or not.
+func (d Decimals) Validate() error {
+	switch d {
+	case SixDecimals:
+		return nil
+	case EighteenDecimals:
+		return nil
+	default:
+		return fmt.Errorf("received unsupported decimals: %d", d)
+	}
+}
 
 // ConversionFactor returns the conversion factor between the Decimals value and
 // the 18 decimals representation, i.e. `EighteenDecimals`.
@@ -58,8 +71,8 @@ var evmCoinInfo *EvmCoinInfo
 // setEVMCoinDecimals allows to define the decimals used in the representation
 // of the EVM coin.
 func setEVMCoinDecimals(d Decimals) {
-	if d != SixDecimals && d != EighteenDecimals {
-		panic(fmt.Errorf("invalid decimal value %d; the evm supports only 6 and 18 decimals", d))
+	if err := d.Validate(); err != nil {
+		panic(err)
 	}
 
 	evmCoinInfo.Decimals = d

--- a/x/evm/types/denom_config_test.go
+++ b/x/evm/types/denom_config_test.go
@@ -1,0 +1,41 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package types_test
+
+import (
+	"testing"
+
+	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimalsValidate(t *testing.T) {
+	testCases := []struct {
+		decimals evmtypes.Decimals
+		expPass  bool
+	}{
+		{
+			decimals: evmtypes.EighteenDecimals,
+			expPass:  true,
+		},
+		{
+			decimals: evmtypes.SixDecimals,
+			expPass:  true,
+		},
+		{
+			decimals: evmtypes.Decimals(0),
+			expPass:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := tc.decimals.Validate()
+
+		if tc.expPass {
+			require.NoError(t, err, "expected decimals to be valid")
+		} else {
+			require.Error(t, err, "expected decimals to be not valid")
+		}
+	}
+}


### PR DESCRIPTION
# Description

- Ensure the Decimals used for the evm coin id the same registered for the base denom.
- Add a Validate() method to the Decimals type.