### PR TITLE
chore(app): Remove redundant base denom registration

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -85,6 +85,6 @@ func setMainnetBaseDenom() error {
 	if err := sdk.RegisterDenom(types.DisplayDenom, math.LegacyOneDec()); err != nil {
 		return err
 	}
-	// the registration of the base denom automatically set the base denom.
+	// sdk.RegisterDenom will automatically overwrite the base denom when the new denom units are lower than the current base denom's units.
 	return sdk.RegisterDenom(types.BaseDenom, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit))
 }

--- a/app/config.go
+++ b/app/config.go
@@ -77,18 +77,14 @@ func setTestnetBaseDenom() error {
 	if err := sdk.RegisterDenom(types.DisplayDenomTestnet, math.LegacyOneDec()); err != nil {
 		return err
 	}
-	if err := sdk.RegisterDenom(types.BaseDenomTestnet, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit)); err != nil {
-		return err
-	}
-	return sdk.SetBaseDenom(types.BaseDenomTestnet)
+	// the registration of the base denom automatically set the base denom.
+	return sdk.RegisterDenom(types.BaseDenomTestnet, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit))
 }
 
 func setMainnetBaseDenom() error {
 	if err := sdk.RegisterDenom(types.DisplayDenom, math.LegacyOneDec()); err != nil {
 		return err
 	}
-	if err := sdk.RegisterDenom(types.BaseDenom, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit)); err != nil {
-		return err
-	}
-	return sdk.SetBaseDenom(types.BaseDenom)
+	// the registration of the base denom automatically set the base denom.
+	return sdk.RegisterDenom(types.BaseDenom, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit))
 }

--- a/app/config.go
+++ b/app/config.go
@@ -77,7 +77,7 @@ func setTestnetBaseDenom() error {
 	if err := sdk.RegisterDenom(types.DisplayDenomTestnet, math.LegacyOneDec()); err != nil {
 		return err
 	}
-	// the registration of the base denom automatically set the base denom.
+	// sdk.RegisterDenom will automatically overwrite the base denom when the new denom units are lower than the current base denom's units.
 	return sdk.RegisterDenom(types.BaseDenomTestnet, math.LegacyNewDecWithPrec(1, types.BaseDenomUnit))
 }
 


### PR DESCRIPTION
# Description

Remove redundant registration of the base denom. The base denom is automatically set when registered, we don't need to set it again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Simplified the logic for setting base denominations by streamlining error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->