### PR TITLE
ci: use loopvar instead of exportloopref

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - unused
     - nolintlint
     - asciicheck
-    - exportloopref
+    - loopvar
     - gofumpt
     - gomodguard
 


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated linting rules by replacing the `exportloopref` linter with `loopvar`.
	- Corrected indentation for `unused` and `nolintlint` entries for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->