### PR TITLE
Revert "ci: use loopvar instead of exportloopref"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - unused
     - nolintlint
     - asciicheck
-    - loopvar
+    - exportloopref
     - gofumpt
     - gomodguard
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
-    - exportloopref
+    - copyloopvar
     - staticcheck
     - stylecheck
     - typecheck
@@ -31,7 +31,6 @@ linters:
     - unused
     - nolintlint
     - asciicheck
-    - exportloopref
     - gofumpt
     - gomodguard
 


### PR DESCRIPTION
this is breaking the golangci-lint ci action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated linting strategy by removing the `exportloopref` linter and adding `copyloopvar`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->