### PR TITLE
refactor: eliminate unnecessary nil check in BigEndianToUint64 function

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -167,12 +167,7 @@ func (k Keeper) SetTxIndexTransient(ctx sdk.Context, index uint64) {
 // GetTxIndexTransient returns EVM transaction index on the current block.
 func (k Keeper) GetTxIndexTransient(ctx sdk.Context) uint64 {
 	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(types.KeyPrefixTransientTxIndex)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixTransientTxIndex))
 }
 
 // ----------------------------------------------------------------------------
@@ -182,12 +177,7 @@ func (k Keeper) GetTxIndexTransient(ctx sdk.Context) uint64 {
 // GetLogSizeTransient returns EVM log index on the current block.
 func (k Keeper) GetLogSizeTransient(ctx sdk.Context) uint64 {
 	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(types.KeyPrefixTransientLogSize)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixTransientLogSize))
 }
 
 // SetLogSizeTransient fetches the current EVM log index from the transient store, increases its
@@ -311,11 +301,7 @@ func (k Keeper) ResetTransientGasUsed(ctx sdk.Context) {
 // GetTransientGasUsed returns the gas used by current cosmos tx.
 func (k Keeper) GetTransientGasUsed(ctx sdk.Context) uint64 {
 	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(types.KeyPrefixTransientGasUsed)
-	if len(bz) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixTransientGasUsed))
 }
 
 // SetTransientGasUsed sets the gas used by current cosmos tx.

--- a/x/feemarket/keeper/keeper.go
+++ b/x/feemarket/keeper/keeper.go
@@ -69,22 +69,13 @@ func (k Keeper) SetBlockGasWanted(ctx sdk.Context, gas uint64) {
 // GetBlockGasWanted returns the last block gas wanted value from the store.
 func (k Keeper) GetBlockGasWanted(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.KeyPrefixBlockGasWanted)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixBlockGasWanted))
 }
 
 // GetTransientGasWanted returns the gas wanted in the current block from transient store.
 func (k Keeper) GetTransientGasWanted(ctx sdk.Context) uint64 {
 	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(types.KeyPrefixTransientBlockGasWanted)
-	if len(bz) == 0 {
-		return 0
-	}
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixTransientBlockGasWanted))
 }
 
 // SetTransientBlockGasWanted sets the block gas wanted to the transient store.

--- a/x/inflation/v1/keeper/epoch_info.go
+++ b/x/inflation/v1/keeper/epoch_info.go
@@ -28,12 +28,7 @@ func (k Keeper) SetEpochIdentifier(ctx sdk.Context, epochIdentifier string) {
 // GetEpochsPerPeriod gets the epochs per period
 func (k Keeper) GetEpochsPerPeriod(ctx sdk.Context) int64 {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.KeyPrefixEpochsPerPeriod)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return int64(sdk.BigEndianToUint64(bz)) //#nosec G115
+	return int64(sdk.BigEndianToUint64(store.Get(types.KeyPrefixEpochsPerPeriod))) //#nosec G115
 }
 
 // SetEpochsPerPeriod stores the epochs per period
@@ -45,12 +40,7 @@ func (k Keeper) SetEpochsPerPeriod(ctx sdk.Context, epochsPerPeriod int64) {
 // GetSkippedEpochs gets the number of skipped epochs
 func (k Keeper) GetSkippedEpochs(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.KeyPrefixSkippedEpochs)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixSkippedEpochs))
 }
 
 // SetSkippedEpochs stores the number of skipped epochs

--- a/x/inflation/v1/keeper/periods.go
+++ b/x/inflation/v1/keeper/periods.go
@@ -11,12 +11,7 @@ import (
 // GetPeriod gets current period
 func (k Keeper) GetPeriod(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.KeyPrefixPeriod)
-	if len(bz) == 0 {
-		return 0
-	}
-
-	return sdk.BigEndianToUint64(bz)
+	return sdk.BigEndianToUint64(store.Get(types.KeyPrefixPeriod))
 }
 
 // SetPeriod stores the current period


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The `BigEndianToUint64` method already has a check to return 0 if bz is empty, so the additional check is redundant.

https://github.com/evmos/cosmos-sdk/blob/9b3e85a956471ff13866c67d77cc0922c5f32dec/types/utils.go#L51-L59

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined retrieval of transient values across various modules for improved efficiency.
  
- **Bug Fixes**
	- Eliminated unnecessary checks in data retrieval methods, enhancing performance and readability.

- **Refactor**
	- Simplified control flow in multiple methods by removing redundant checks and intermediate variables, ensuring more concise code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->