### PR TITLE
feat(precompile): add precompile contract method submitProposal for gov module

### DIFF
--- a/precompiles/gov/IGov.sol
+++ b/precompiles/gov/IGov.sol
@@ -57,6 +57,13 @@ struct TallyResultData {
 /// @title Gov Precompile Contract
 /// @dev The interface through which solidity contracts will interact with Gov
 interface IGov {
+    /// @dev SubmitProposal defines an Event emitted when a proposal submited.
+    /// @param proposer is the account address of the proposer
+    /// @param proposalId the proposal of id
+    event SubmitProposal(
+        address indexed proposer,
+        uint64 proposalId
+    );
 
     /// @dev Vote defines an Event emitted when a proposal voted.
     /// @param voter the address of the voter
@@ -71,6 +78,25 @@ interface IGov {
     event VoteWeighted(address indexed voter, uint64 proposalId, WeightedVoteOption[] options);
 
     /// TRANSACTIONS
+
+    /// @dev submitProposal defines a method to create new proposal given the messages.
+    /// @param messages are the arbitrary messages to be executed if proposal passes
+    /// @param initialDeposit is the deposit value that must be paid at proposal submission
+    /// @param proposer is the account address of the proposer
+    /// @param metadata is any arbitrary metadata attached to the proposal
+    /// @param title is the title of the proposal
+    /// @param summary is the summary of the proposal
+    /// @param expedited defines if the proposal is expedited or not
+    /// @return proposalId defines the unique id of the proposal
+    function submitProposal(
+        string memory messages,
+        Coin[] memory initialDeposit,
+        address proposer,
+        string memory metadata,
+        string memory title,
+        string memory summary,
+        bool expedited
+    ) external returns (uint64 proposalId);
 
     /// @dev vote defines a method to add a vote on a specific proposal.
     /// @param voter The address of the voter

--- a/precompiles/gov/IGov.sol
+++ b/precompiles/gov/IGov.sol
@@ -90,7 +90,7 @@ interface IGov {
     /// @return proposalId defines the unique id of the proposal
     function submitProposal(
         string memory messages,
-        Coin[] memory initialDeposit,
+        uint256 initialDeposit,
         address proposer,
         string memory metadata,
         string memory title,

--- a/precompiles/gov/abi.json
+++ b/precompiles/gov/abi.json
@@ -1,504 +1,575 @@
-{
-  "_format": "hh-sol-artifact-1",
-  "contractName": "IGov",
-  "sourceName": "solidity/precompiles/gov/IGov.sol",
-  "abi": [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "voter",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint8",
-          "name": "option",
-          "type": "uint8"
-        }
-      ],
-      "name": "Vote",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "voter",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "components": [
-            {
-              "internalType": "enum VoteOption",
-              "name": "option",
-              "type": "uint8"
-            },
-            {
-              "internalType": "string",
-              "name": "weight",
-              "type": "string"
-            }
-          ],
-          "indexed": false,
-          "internalType": "struct WeightedVoteOption[]",
-          "name": "options",
-          "type": "tuple[]"
-        }
-      ],
-      "name": "VoteWeighted",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "internalType": "address",
-          "name": "depositor",
-          "type": "address"
-        }
-      ],
-      "name": "getDeposit",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "proposalId",
-              "type": "uint64"
-            },
-            {
-              "internalType": "address",
-              "name": "depositor",
-              "type": "address"
-            },
-            {
-              "components": [
-                {
-                  "internalType": "string",
-                  "name": "denom",
-                  "type": "string"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                }
-              ],
-              "internalType": "struct Coin[]",
-              "name": "amount",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct DepositData",
-          "name": "deposit",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "key",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "offset",
-              "type": "uint64"
-            },
-            {
-              "internalType": "uint64",
-              "name": "limit",
-              "type": "uint64"
-            },
-            {
-              "internalType": "bool",
-              "name": "countTotal",
-              "type": "bool"
-            },
-            {
-              "internalType": "bool",
-              "name": "reverse",
-              "type": "bool"
-            }
-          ],
-          "internalType": "struct PageRequest",
-          "name": "pagination",
-          "type": "tuple"
-        }
-      ],
-      "name": "getDeposits",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "proposalId",
-              "type": "uint64"
-            },
-            {
-              "internalType": "address",
-              "name": "depositor",
-              "type": "address"
-            },
-            {
-              "components": [
-                {
-                  "internalType": "string",
-                  "name": "denom",
-                  "type": "string"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "amount",
-                  "type": "uint256"
-                }
-              ],
-              "internalType": "struct Coin[]",
-              "name": "amount",
-              "type": "tuple[]"
-            }
-          ],
-          "internalType": "struct DepositData[]",
-          "name": "deposits",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "nextKey",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "total",
-              "type": "uint64"
-            }
-          ],
-          "internalType": "struct PageResponse",
-          "name": "pageResponse",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        }
-      ],
-      "name": "getTallyResult",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "yes",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "abstain",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "no",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "noWithVeto",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct TallyResultData",
-          "name": "tallyResult",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "internalType": "address",
-          "name": "voter",
-          "type": "address"
-        }
-      ],
-      "name": "getVote",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "proposalId",
-              "type": "uint64"
-            },
-            {
-              "internalType": "address",
-              "name": "voter",
-              "type": "address"
-            },
-            {
-              "components": [
-                {
-                  "internalType": "enum VoteOption",
-                  "name": "option",
-                  "type": "uint8"
-                },
-                {
-                  "internalType": "string",
-                  "name": "weight",
-                  "type": "string"
-                }
-              ],
-              "internalType": "struct WeightedVoteOption[]",
-              "name": "options",
-              "type": "tuple[]"
-            },
-            {
-              "internalType": "string",
-              "name": "metadata",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct WeightedVote",
-          "name": "vote",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "key",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "offset",
-              "type": "uint64"
-            },
-            {
-              "internalType": "uint64",
-              "name": "limit",
-              "type": "uint64"
-            },
-            {
-              "internalType": "bool",
-              "name": "countTotal",
-              "type": "bool"
-            },
-            {
-              "internalType": "bool",
-              "name": "reverse",
-              "type": "bool"
-            }
-          ],
-          "internalType": "struct PageRequest",
-          "name": "pagination",
-          "type": "tuple"
-        }
-      ],
-      "name": "getVotes",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "proposalId",
-              "type": "uint64"
-            },
-            {
-              "internalType": "address",
-              "name": "voter",
-              "type": "address"
-            },
-            {
-              "components": [
-                {
-                  "internalType": "enum VoteOption",
-                  "name": "option",
-                  "type": "uint8"
-                },
-                {
-                  "internalType": "string",
-                  "name": "weight",
-                  "type": "string"
-                }
-              ],
-              "internalType": "struct WeightedVoteOption[]",
-              "name": "options",
-              "type": "tuple[]"
-            },
-            {
-              "internalType": "string",
-              "name": "metadata",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct WeightedVote[]",
-          "name": "votes",
-          "type": "tuple[]"
-        },
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "nextKey",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "total",
-              "type": "uint64"
-            }
-          ],
-          "internalType": "struct PageResponse",
-          "name": "pageResponse",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "voter",
-          "type": "address"
-        },
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "internalType": "enum VoteOption",
-          "name": "option",
-          "type": "uint8"
-        },
-        {
-          "internalType": "string",
-          "name": "metadata",
-          "type": "string"
-        }
-      ],
-      "name": "vote",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "success",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "voter",
-          "type": "address"
-        },
-        {
-          "internalType": "uint64",
-          "name": "proposalId",
-          "type": "uint64"
-        },
-        {
-          "components": [
-            {
-              "internalType": "enum VoteOption",
-              "name": "option",
-              "type": "uint8"
-            },
-            {
-              "internalType": "string",
-              "name": "weight",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct WeightedVoteOption[]",
-          "name": "options",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "string",
-          "name": "metadata",
-          "type": "string"
-        }
-      ],
-      "name": "voteWeighted",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "success",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ],
-  "bytecode": "0x",
-  "deployedBytecode": "0x",
-  "linkReferences": {},
-  "deployedLinkReferences": {}
-}
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proposer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      }
+    ],
+    "name": "SubmitProposal",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "option",
+        "type": "uint8"
+      }
+    ],
+    "name": "Vote",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum VoteOption",
+            "name": "option",
+            "type": "uint8"
+          },
+          {
+            "internalType": "string",
+            "name": "weight",
+            "type": "string"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct WeightedVoteOption[]",
+        "name": "options",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "VoteWeighted",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      }
+    ],
+    "name": "getDeposit",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "proposalId",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "depositor",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "denom",
+                "type": "string"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Coin[]",
+            "name": "amount",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct DepositData",
+        "name": "deposit",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "key",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "offset",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "limit",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "countTotal",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "reverse",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PageRequest",
+        "name": "pagination",
+        "type": "tuple"
+      }
+    ],
+    "name": "getDeposits",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "proposalId",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "depositor",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "denom",
+                "type": "string"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Coin[]",
+            "name": "amount",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct DepositData[]",
+        "name": "deposits",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "nextKey",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "total",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct PageResponse",
+        "name": "pageResponse",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getTallyResult",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "yes",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "abstain",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "no",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "noWithVeto",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct TallyResultData",
+        "name": "tallyResult",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      }
+    ],
+    "name": "getVote",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "proposalId",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "voter",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum VoteOption",
+                "name": "option",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "weight",
+                "type": "string"
+              }
+            ],
+            "internalType": "struct WeightedVoteOption[]",
+            "name": "options",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "string",
+            "name": "metadata",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct WeightedVote",
+        "name": "vote",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "key",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "offset",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "limit",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "countTotal",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "reverse",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PageRequest",
+        "name": "pagination",
+        "type": "tuple"
+      }
+    ],
+    "name": "getVotes",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "proposalId",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "voter",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum VoteOption",
+                "name": "option",
+                "type": "uint8"
+              },
+              {
+                "internalType": "string",
+                "name": "weight",
+                "type": "string"
+              }
+            ],
+            "internalType": "struct WeightedVoteOption[]",
+            "name": "options",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "string",
+            "name": "metadata",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct WeightedVote[]",
+        "name": "votes",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "nextKey",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "total",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct PageResponse",
+        "name": "pageResponse",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "messages",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "denom",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Coin[]",
+        "name": "initialDeposit",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "address",
+        "name": "proposer",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "metadata",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "title",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "summary",
+        "type": "string"
+      },
+      {
+        "internalType": "bool",
+        "name": "expedited",
+        "type": "bool"
+      }
+    ],
+    "name": "submitProposal",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "enum VoteOption",
+        "name": "option",
+        "type": "uint8"
+      },
+      {
+        "internalType": "string",
+        "name": "metadata",
+        "type": "string"
+      }
+    ],
+    "name": "vote",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "proposalId",
+        "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum VoteOption",
+            "name": "option",
+            "type": "uint8"
+          },
+          {
+            "internalType": "string",
+            "name": "weight",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct WeightedVoteOption[]",
+        "name": "options",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "string",
+        "name": "metadata",
+        "type": "string"
+      }
+    ],
+    "name": "voteWeighted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/precompiles/gov/abi.json
+++ b/precompiles/gov/abi.json
@@ -1,575 +1,584 @@
-[
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "proposer",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      }
-    ],
-    "name": "SubmitProposal",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "voter",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "option",
-        "type": "uint8"
-      }
-    ],
-    "name": "Vote",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "voter",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "enum VoteOption",
-            "name": "option",
-            "type": "uint8"
-          },
-          {
-            "internalType": "string",
-            "name": "weight",
-            "type": "string"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct WeightedVoteOption[]",
-        "name": "options",
-        "type": "tuple[]"
-      }
-    ],
-    "name": "VoteWeighted",
-    "type": "event"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "internalType": "address",
-        "name": "depositor",
-        "type": "address"
-      }
-    ],
-    "name": "getDeposit",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint64",
-            "name": "proposalId",
-            "type": "uint64"
-          },
-          {
-            "internalType": "address",
-            "name": "depositor",
-            "type": "address"
-          },
-          {
-            "components": [
-              {
-                "internalType": "string",
-                "name": "denom",
-                "type": "string"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct Coin[]",
-            "name": "amount",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct DepositData",
-        "name": "deposit",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes",
-            "name": "key",
-            "type": "bytes"
-          },
-          {
-            "internalType": "uint64",
-            "name": "offset",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "limit",
-            "type": "uint64"
-          },
-          {
-            "internalType": "bool",
-            "name": "countTotal",
-            "type": "bool"
-          },
-          {
-            "internalType": "bool",
-            "name": "reverse",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct PageRequest",
-        "name": "pagination",
-        "type": "tuple"
-      }
-    ],
-    "name": "getDeposits",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint64",
-            "name": "proposalId",
-            "type": "uint64"
-          },
-          {
-            "internalType": "address",
-            "name": "depositor",
-            "type": "address"
-          },
-          {
-            "components": [
-              {
-                "internalType": "string",
-                "name": "denom",
-                "type": "string"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct Coin[]",
-            "name": "amount",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct DepositData[]",
-        "name": "deposits",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes",
-            "name": "nextKey",
-            "type": "bytes"
-          },
-          {
-            "internalType": "uint64",
-            "name": "total",
-            "type": "uint64"
-          }
-        ],
-        "internalType": "struct PageResponse",
-        "name": "pageResponse",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      }
-    ],
-    "name": "getTallyResult",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "yes",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "abstain",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "no",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "noWithVeto",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct TallyResultData",
-        "name": "tallyResult",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "internalType": "address",
-        "name": "voter",
-        "type": "address"
-      }
-    ],
-    "name": "getVote",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint64",
-            "name": "proposalId",
-            "type": "uint64"
-          },
-          {
-            "internalType": "address",
-            "name": "voter",
-            "type": "address"
-          },
-          {
-            "components": [
-              {
-                "internalType": "enum VoteOption",
-                "name": "option",
-                "type": "uint8"
-              },
-              {
-                "internalType": "string",
-                "name": "weight",
-                "type": "string"
-              }
-            ],
-            "internalType": "struct WeightedVoteOption[]",
-            "name": "options",
-            "type": "tuple[]"
-          },
-          {
-            "internalType": "string",
-            "name": "metadata",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct WeightedVote",
-        "name": "vote",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes",
-            "name": "key",
-            "type": "bytes"
-          },
-          {
-            "internalType": "uint64",
-            "name": "offset",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "limit",
-            "type": "uint64"
-          },
-          {
-            "internalType": "bool",
-            "name": "countTotal",
-            "type": "bool"
-          },
-          {
-            "internalType": "bool",
-            "name": "reverse",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct PageRequest",
-        "name": "pagination",
-        "type": "tuple"
-      }
-    ],
-    "name": "getVotes",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint64",
-            "name": "proposalId",
-            "type": "uint64"
-          },
-          {
-            "internalType": "address",
-            "name": "voter",
-            "type": "address"
-          },
-          {
-            "components": [
-              {
-                "internalType": "enum VoteOption",
-                "name": "option",
-                "type": "uint8"
-              },
-              {
-                "internalType": "string",
-                "name": "weight",
-                "type": "string"
-              }
-            ],
-            "internalType": "struct WeightedVoteOption[]",
-            "name": "options",
-            "type": "tuple[]"
-          },
-          {
-            "internalType": "string",
-            "name": "metadata",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct WeightedVote[]",
-        "name": "votes",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes",
-            "name": "nextKey",
-            "type": "bytes"
-          },
-          {
-            "internalType": "uint64",
-            "name": "total",
-            "type": "uint64"
-          }
-        ],
-        "internalType": "struct PageResponse",
-        "name": "pageResponse",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "messages",
-        "type": "string"
-      },
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "denom",
-            "type": "string"
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Coin[]",
-        "name": "initialDeposit",
-        "type": "tuple[]"
-      },
-      {
-        "internalType": "address",
-        "name": "proposer",
-        "type": "address"
-      },
-      {
-        "internalType": "string",
-        "name": "metadata",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "title",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "summary",
-        "type": "string"
-      },
-      {
-        "internalType": "bool",
-        "name": "expedited",
-        "type": "bool"
-      }
-    ],
-    "name": "submitProposal",
-    "outputs": [
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "voter",
-        "type": "address"
-      },
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "internalType": "enum VoteOption",
-        "name": "option",
-        "type": "uint8"
-      },
-      {
-        "internalType": "string",
-        "name": "metadata",
-        "type": "string"
-      }
-    ],
-    "name": "vote",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "success",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "voter",
-        "type": "address"
-      },
-      {
-        "internalType": "uint64",
-        "name": "proposalId",
-        "type": "uint64"
-      },
-      {
-        "components": [
-          {
-            "internalType": "enum VoteOption",
-            "name": "option",
-            "type": "uint8"
-          },
-          {
-            "internalType": "string",
-            "name": "weight",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct WeightedVoteOption[]",
-        "name": "options",
-        "type": "tuple[]"
-      },
-      {
-        "internalType": "string",
-        "name": "metadata",
-        "type": "string"
-      }
-    ],
-    "name": "voteWeighted",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "success",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
-]
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IGov",
+  "sourceName": "solidity/precompiles/gov/IGov.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "proposer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        }
+      ],
+      "name": "SubmitProposal",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "voter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "option",
+          "type": "uint8"
+        }
+      ],
+      "name": "Vote",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "voter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum VoteOption",
+              "name": "option",
+              "type": "uint8"
+            },
+            {
+              "internalType": "string",
+              "name": "weight",
+              "type": "string"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct WeightedVoteOption[]",
+          "name": "options",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "VoteWeighted",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "depositor",
+          "type": "address"
+        }
+      ],
+      "name": "getDeposit",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "proposalId",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "depositor",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "string",
+                  "name": "denom",
+                  "type": "string"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct Coin[]",
+              "name": "amount",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct DepositData",
+          "name": "deposit",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "key",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "offset",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "limit",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "countTotal",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "reverse",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct PageRequest",
+          "name": "pagination",
+          "type": "tuple"
+        }
+      ],
+      "name": "getDeposits",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "proposalId",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "depositor",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "string",
+                  "name": "denom",
+                  "type": "string"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "amount",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct Coin[]",
+              "name": "amount",
+              "type": "tuple[]"
+            }
+          ],
+          "internalType": "struct DepositData[]",
+          "name": "deposits",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "nextKey",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "total",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct PageResponse",
+          "name": "pageResponse",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        }
+      ],
+      "name": "getTallyResult",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "yes",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "abstain",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "no",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "noWithVeto",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct TallyResultData",
+          "name": "tallyResult",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "voter",
+          "type": "address"
+        }
+      ],
+      "name": "getVote",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "proposalId",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "voter",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum VoteOption",
+                  "name": "option",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "string",
+                  "name": "weight",
+                  "type": "string"
+                }
+              ],
+              "internalType": "struct WeightedVoteOption[]",
+              "name": "options",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct WeightedVote",
+          "name": "vote",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "key",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "offset",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "limit",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "countTotal",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "reverse",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct PageRequest",
+          "name": "pagination",
+          "type": "tuple"
+        }
+      ],
+      "name": "getVotes",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "proposalId",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "voter",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum VoteOption",
+                  "name": "option",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "string",
+                  "name": "weight",
+                  "type": "string"
+                }
+              ],
+              "internalType": "struct WeightedVoteOption[]",
+              "name": "options",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct WeightedVote[]",
+          "name": "votes",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "nextKey",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "total",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct PageResponse",
+          "name": "pageResponse",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "messages",
+          "type": "string"
+        },
+        {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "denom",
+              "type": "string"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct Coin[]",
+          "name": "initialDeposit",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "address",
+          "name": "proposer",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "summary",
+          "type": "string"
+        },
+        {
+          "internalType": "bool",
+          "name": "expedited",
+          "type": "bool"
+        }
+      ],
+      "name": "submitProposal",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "voter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "internalType": "enum VoteOption",
+          "name": "option",
+          "type": "uint8"
+        },
+        {
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
+        }
+      ],
+      "name": "vote",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "success",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "voter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "proposalId",
+          "type": "uint64"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum VoteOption",
+              "name": "option",
+              "type": "uint8"
+            },
+            {
+              "internalType": "string",
+              "name": "weight",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct WeightedVoteOption[]",
+          "name": "options",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
+        }
+      ],
+      "name": "voteWeighted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "success",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/precompiles/gov/abi.json
+++ b/precompiles/gov/abi.json
@@ -443,21 +443,9 @@
           "type": "string"
         },
         {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "denom",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct Coin[]",
+          "internalType": "uint256",
           "name": "initialDeposit",
-          "type": "tuple[]"
+          "type": "uint256"
         },
         {
           "internalType": "address",

--- a/precompiles/gov/errors.go
+++ b/precompiles/gov/errors.go
@@ -5,6 +5,10 @@ package gov
 const (
 	// ErrDifferentOrigin is raised when the origin address is not the same as the voter address.
 	ErrDifferentOrigin = "tx origin address %s does not match the voter address %s"
+	// ErrInvalidInitialDeposit is raised when the initial deposit is not valid when submit proposal.
+	ErrInvalidInitialDeposit = "invalid initial deposit: %s"
+	// ErrInvalidProposer is raised when the proposer address is not valid.
+	ErrInvalidProposer = "invalid proposer address: %s"
 	// ErrInvalidVoter is raised when the voter address is not valid.
 	ErrInvalidVoter = "invalid voter address: %s"
 	// ErrInvalidProposalID invalid proposal id.
@@ -13,8 +17,16 @@ const (
 	ErrInvalidPageRequest = "invalid page request"
 	// ErrInvalidOption invalid option.
 	ErrInvalidOption = "invalid option %s "
+	// ErrInvalidMessages invalid messages.
+	ErrInvalidMessages = "invalid messages %s"
 	// ErrInvalidMetadata invalid metadata.
 	ErrInvalidMetadata = "invalid metadata %s "
+	// ErrInvalidTitle invalid title.
+	ErrInvalidTitle = "invalid title %s "
+	// ErrInvalidSummary invalid summary.
+	ErrInvalidSummary = "invalid summary %s "
+	// ErrInvalidExpedited invalid expedited.
+	ErrInvalidExpedited = "invalid expedited %s "
 	// ErrInvalidWeightedVoteOptions invalid weighted vote options.
 	ErrInvalidWeightedVoteOptions = "invalid weighted vote options %s "
 	// ErrInvalidWeightedVoteOption invalid weighted vote option.

--- a/precompiles/gov/events.go
+++ b/precompiles/gov/events.go
@@ -14,11 +14,45 @@ import (
 )
 
 const (
+	// EventTypeSubmitProposal defines the event type for the gov SubmitProposal transaction.
+	EventTypeSubmitProposal = "SubmitProposal"
 	// EventTypeVote defines the event type for the gov VoteMethod transaction.
 	EventTypeVote = "Vote"
 	// EventTypeVoteWeighted defines the event type for the gov VoteWeightedMethod transaction.
 	EventTypeVoteWeighted = "VoteWeighted"
 )
+
+// EmitSubmitProposalEvent creates a new event emitted on a SubmitProposal transaction.
+func (p Precompile) EmitSubmitProposalEvent(ctx sdk.Context, stateDB vm.StateDB, proposerAddress common.Address, proposalId uint64) error {
+	// Prepare the event topics
+	event := p.ABI.Events[EventTypeSubmitProposal]
+	topics := make([]common.Hash, 2)
+
+	// The first topic is always the signature of the event.
+	topics[0] = event.ID
+
+	var err error
+	topics[1], err = cmn.MakeTopic(proposerAddress)
+	if err != nil {
+		return err
+	}
+
+	// Prepare the event data
+	arguments := abi.Arguments{event.Inputs[1]}
+	packed, err := arguments.Pack(proposalId)
+	if err != nil {
+		return err
+	}
+
+	stateDB.AddLog(&ethtypes.Log{
+		Address:     p.Address(),
+		Topics:      topics,
+		Data:        packed,
+		BlockNumber: uint64(ctx.BlockHeight()), //nolint:gosec // G115
+	})
+
+	return nil
+}
 
 // EmitVoteEvent creates a new event emitted on a Vote transaction.
 func (p Precompile) EmitVoteEvent(ctx sdk.Context, stateDB vm.StateDB, voterAddress common.Address, proposalID uint64, option int32) error {

--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -102,6 +102,8 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	switch method.Name {
 	// gov transactions
+	case SubmitProposalMethod:
+		bz, err = p.SubmitProposal(ctx, evm.Origin, contract, stateDB, method, args)
 	case VoteMethod:
 		bz, err = p.Vote(ctx, evm.Origin, contract, stateDB, method, args)
 	case VoteWeightedMethod:
@@ -141,11 +143,12 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 // IsTransaction checks if the given method name corresponds to a transaction or query.
 //
 // Available gov transactions are:
+//   - SubmitProposal
 //   - Vote
 //   - VoteWeighted
 func (Precompile) IsTransaction(methodName string) bool {
 	switch methodName {
-	case VoteMethod, VoteWeightedMethod:
+	case SubmitProposalMethod, VoteMethod, VoteWeightedMethod:
 		return true
 	default:
 		return false

--- a/precompiles/gov/tx.go
+++ b/precompiles/gov/tx.go
@@ -16,11 +16,47 @@ import (
 )
 
 const (
+	// SubmitProposalMethod defines the ABI method name for the gov SubmitProposal transaction.
+	SubmitProposalMethod = "submitProposal"
 	// VoteMethod defines the ABI method name for the gov Vote transaction.
 	VoteMethod = "vote"
 	// VoteWeightedMethod defines the ABI method name for the gov VoteWeighted transaction.
 	VoteWeightedMethod = "voteWeighted"
 )
+
+// SubmitProposal defines a method to create new proposal given the messages.
+func (p Precompile) SubmitProposal(
+	ctx sdk.Context,
+	origin common.Address,
+	contract *vm.Contract,
+	stateDB vm.StateDB,
+	method *abi.Method,
+	args []interface{},
+) ([]byte, error) {
+	msg, proposerHexAddr, err := NewMsgSubmitProposal(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the contract is the proposer, we don't need an origin check
+	// Otherwise check if the origin matches the proposer address
+	isContractVoter := contract.CallerAddress == proposerHexAddr && contract.CallerAddress != origin
+	if !isContractVoter && origin != proposerHexAddr {
+		return nil, fmt.Errorf(ErrDifferentOrigin, origin.String(), proposerHexAddr.String())
+	}
+
+	msgSrv := govkeeper.NewMsgServerImpl(&p.govKeeper)
+	res, err := msgSrv.SubmitProposal(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = p.EmitSubmitProposalEvent(ctx, stateDB, proposerHexAddr, res.ProposalId); err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(res.ProposalId)
+}
 
 // Vote claims the rewards accumulated by a delegator from multiple or all validators.
 func (p Precompile) Vote(

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -133,7 +133,7 @@ type TallyResultData struct {
 	NoWithVeto string
 }
 
-// NewMsgSubmitProposal creates a new MsgSubmitProposalinstance.
+// NewMsgSubmitProposal creates a new MsgSubmitProposal instance.
 func NewMsgSubmitProposal(args []interface{}) (*govv1.MsgSubmitProposal, common.Address, error) {
 	if len(args) != 7 {
 		return nil, common.Address{}, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 7, len(args))

--- a/precompiles/gov/types.go
+++ b/precompiles/gov/types.go
@@ -4,12 +4,15 @@
 package gov
 
 import (
-	"cosmossdk.io/math"
 	"encoding/json"
 	"fmt"
+	"math/big"
+
+	"cosmossdk.io/math"
+
+	"github.com/evmos/evmos/v20/types"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 	inflationtypes "github.com/evmos/evmos/v20/x/inflation/v1/types"
-	"math/big"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
@@ -213,7 +216,7 @@ func NewMsgSubmitProposal(args []interface{}) (*govv1.MsgSubmitProposal, common.
 
 	proposal, err := govv1.NewMsgSubmitProposal(
 		msgs,
-		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, math.NewIntFromBigInt(initialDeposit))},
+		sdk.Coins{sdk.NewCoin(types.BaseDenom, math.NewIntFromBigInt(initialDeposit))},
 		sdk.AccAddress(proposerAddress.Bytes()).String(),
 		metadata,
 		title,


### PR DESCRIPTION
# Description

I see that you have started working on the precompiled contracts for the gov module, but the most important **SubmitProposal** function seems to be missing. I will implement a version of it.

below is the JavaScript test file

```js
import { ethers } from 'ethers';

BigInt.prototype.toJSON = function () {
  return this.toString();
};

const abi = JSON.parse(
  `[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"proposer","type":"address"},{"indexed":false,"internalType":"uint64","name":"proposalId","type":"uint64"}],"name":"SubmitProposal","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"voter","type":"address"},{"indexed":false,"internalType":"uint64","name":"proposalId","type":"uint64"},{"indexed":false,"internalType":"uint8","name":"option","type":"uint8"}],"name":"Vote","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"voter","type":"address"},{"indexed":false,"internalType":"uint64","name":"proposalId","type":"uint64"},{"components":[{"internalType":"enum VoteOption","name":"option","type":"uint8"},{"internalType":"string","name":"weight","type":"string"}],"indexed":false,"internalType":"struct WeightedVoteOption[]","name":"options","type":"tuple[]"}],"name":"VoteWeighted","type":"event"},{"inputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"depositor","type":"address"}],"name":"getDeposit","outputs":[{"components":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"depositor","type":"address"},{"components":[{"internalType":"string","name":"denom","type":"string"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct Coin[]","name":"amount","type":"tuple[]"}],"internalType":"struct DepositData","name":"deposit","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"components":[{"internalType":"bytes","name":"key","type":"bytes"},{"internalType":"uint64","name":"offset","type":"uint64"},{"internalType":"uint64","name":"limit","type":"uint64"},{"internalType":"bool","name":"countTotal","type":"bool"},{"internalType":"bool","name":"reverse","type":"bool"}],"internalType":"struct PageRequest","name":"pagination","type":"tuple"}],"name":"getDeposits","outputs":[{"components":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"depositor","type":"address"},{"components":[{"internalType":"string","name":"denom","type":"string"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct Coin[]","name":"amount","type":"tuple[]"}],"internalType":"struct DepositData[]","name":"deposits","type":"tuple[]"},{"components":[{"internalType":"bytes","name":"nextKey","type":"bytes"},{"internalType":"uint64","name":"total","type":"uint64"}],"internalType":"struct PageResponse","name":"pageResponse","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"}],"name":"getTallyResult","outputs":[{"components":[{"internalType":"string","name":"yes","type":"string"},{"internalType":"string","name":"abstain","type":"string"},{"internalType":"string","name":"no","type":"string"},{"internalType":"string","name":"noWithVeto","type":"string"}],"internalType":"struct TallyResultData","name":"tallyResult","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"voter","type":"address"}],"name":"getVote","outputs":[{"components":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"voter","type":"address"},{"components":[{"internalType":"enum VoteOption","name":"option","type":"uint8"},{"internalType":"string","name":"weight","type":"string"}],"internalType":"struct WeightedVoteOption[]","name":"options","type":"tuple[]"},{"internalType":"string","name":"metadata","type":"string"}],"internalType":"struct WeightedVote","name":"vote","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"components":[{"internalType":"bytes","name":"key","type":"bytes"},{"internalType":"uint64","name":"offset","type":"uint64"},{"internalType":"uint64","name":"limit","type":"uint64"},{"internalType":"bool","name":"countTotal","type":"bool"},{"internalType":"bool","name":"reverse","type":"bool"}],"internalType":"struct PageRequest","name":"pagination","type":"tuple"}],"name":"getVotes","outputs":[{"components":[{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"address","name":"voter","type":"address"},{"components":[{"internalType":"enum VoteOption","name":"option","type":"uint8"},{"internalType":"string","name":"weight","type":"string"}],"internalType":"struct WeightedVoteOption[]","name":"options","type":"tuple[]"},{"internalType":"string","name":"metadata","type":"string"}],"internalType":"struct WeightedVote[]","name":"votes","type":"tuple[]"},{"components":[{"internalType":"bytes","name":"nextKey","type":"bytes"},{"internalType":"uint64","name":"total","type":"uint64"}],"internalType":"struct PageResponse","name":"pageResponse","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"messages","type":"string"},{"internalType":"uint256","name":"initialDeposit","type":"uint256"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"string","name":"metadata","type":"string"},{"internalType":"string","name":"title","type":"string"},{"internalType":"string","name":"summary","type":"string"},{"internalType":"bool","name":"expedited","type":"bool"}],"name":"submitProposal","outputs":[{"internalType":"uint64","name":"proposalId","type":"uint64"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"voter","type":"address"},{"internalType":"uint64","name":"proposalId","type":"uint64"},{"internalType":"enum VoteOption","name":"option","type":"uint8"},{"internalType":"string","name":"metadata","type":"string"}],"name":"vote","outputs":[{"internalType":"bool","name":"success","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"voter","type":"address"},{"internalType":"uint64","name":"proposalId","type":"uint64"},{"components":[{"internalType":"enum VoteOption","name":"option","type":"uint8"},{"internalType":"string","name":"weight","type":"string"}],"internalType":"struct WeightedVoteOption[]","name":"options","type":"tuple[]"},{"internalType":"string","name":"metadata","type":"string"}],"name":"voteWeighted","outputs":[{"internalType":"bool","name":"success","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]`
);

export const main = async () => {
  const rpc = 'http://127.0.0.1:8545';
  const govAddress = '0x0000000000000000000000000000000000000805';
  const provider = new ethers.JsonRpcProvider(rpc);

  // input params
  const privateKey = 'YOU_VALIDATOR_PRIVATE_KEY';
  const wallet = new ethers.Wallet(privateKey, provider);
  const gov = new ethers.Contract(govAddress, abi, wallet);

  const softwareUpgrade = {
    '@type': '/cosmos.gov.v1.MsgExecLegacyContent',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    content: {
      '@type': '/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal',
      title: 'Software upgrades',
      description: 'Software upgrades for precompile test',
      plan: {
        name: 'v20.0.0',
        info: '{"binaries":{"darwin/arm64":"https://github.com/evmos/evmos/releases/download/v20.0.0/evmos_20.0.0_Darwin_arm64.tar.gz?checksum=db85391340c5d6eaec460d355b8ca000dd0ed06b6f2338d24b20eb3ab32d745a","darwin/amd64":"https://github.com/evmos/evmos/releases/download/v20.0.0/evmos_20.0.0_Darwin_amd64.tar.gz?checksum=98c9074e81998cb939c192a9982de93119657e7f7020982eb7629e45bd951a04","linux/arm64":"https://github.com/evmos/evmos/releases/download/v20.0.0/evmos_20.0.0_Linux_arm64.tar.gz?checksum=ecfffdaadd0e05058b78a2c24bdcb763975e95236eb4a63e72c0be7a0ad30b6d","linux/amd64":"https://github.com/evmos/evmos/releases/download/v20.0.0/evmos_20.0.0_Linux_amd64.tar.gz?checksum=dc55e04c7f12768fb32beb1d06f3d113e76059b76d1ac5f13657c8fccf5fc309"}}',
        height: '120',
        time: '0001-01-01T00:00:00Z',
        upgraded_client_state: null,
      },
    },
  };

  const auth = {
    '@type': '/cosmos.auth.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      max_memo_characters: '512',
      tx_sig_limit: '7',
      tx_size_cost_per_byte: '10',
      sig_verify_cost_ed25519: '590',
      sig_verify_cost_secp256k1: '1000',
    },
  };

  const bank = {
    '@type': '/cosmos.bank.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      send_enabled: [],
      default_send_enabled: false,
    },
  };

  const consunsus = {
    '@type': '/cosmos.consensus.v1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    block: {
      max_txs: '24000',
      max_bytes: '3145728',
      max_gas: '800000000',
    },
    evidence: {
      max_age_num_blocks: '100000',
      max_age_duration: '10s',
      max_bytes: '1048576',
    },
    validator: {
      pub_key_types: ['ed25519'],
    },
  };

  const crisis = {
    '@type': '/cosmos.crisis.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    constant_fee: {
      denom: 'aevmos',
      amount: '8000000000',
    },
  };

  const distribution = {
    '@type': '/cosmos.distribution.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      community_tax: '0.020000000000000000',
      base_proposer_reward: '0.000000000000000000',
      bonus_proposer_reward: '0.000000000000000000',
      withdraw_addr_enabled: false,
    },
  };

  const govParams = {
    '@type': '/cosmos.gov.v1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      min_deposit: [
        {
          denom: 'aevmos',
          amount: '1',
        },
      ],
      max_deposit_period: '60s',
      voting_period: '10s',
      quorum: '0.334000000000000000',
      threshold: '0.500000000000000000',
      veto_threshold: '0.334000000000000000',
      min_initial_deposit_ratio: '0.000000000000000000',
      burn_vote_quorum: false,
      burn_proposal_deposit_prevote: false,
      burn_vote_veto: true,
    },
  };

  const slashing = {
    '@type': '/cosmos.slashing.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      signed_blocks_window: '100000',
      min_signed_per_window: '0.500000000000000000',
      downtime_jail_duration: '600s',
      slash_fraction_double_sign: '0.050000000000000000',
      slash_fraction_downtime: '0.010000000000000000',
    },
  };

  const staking = {
    '@type': '/cosmos.staking.v1beta1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      community_tax: '0.020000000000000000',
      base_proposer_reward: '0.000000000000000000',
      bonus_proposer_reward: '0.000000000000000000',
      withdraw_addr_enabled: false,
    },
  };

  const erc20 = {
    '@type': '/evmos.erc20.v1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      enable_erc20: false,
      enable_evm_hook: false,
    },
  };

  const evm = {
    '@type': '/ethermint.evm.v1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      evm_denom: 'aevmos',
      enable_create: true,
      enable_call: true,
      extra_eips: ['3855'],
      chain_config: {
        homestead_block: '0',
        dao_fork_block: '0',
        dao_fork_support: true,
        eip150_block: '0',
        eip150_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
        eip155_block: '0',
        eip158_block: '0',
        byzantium_block: '0',
        constantinople_block: '0',
        petersburg_block: '0',
        istanbul_block: '0',
        muir_glacier_block: '0',
        berlin_block: '0',
        london_block: '0',
        arrow_glacier_block: '0',
        gray_glacier_block: '0',
        merge_netsplit_block: '0',
        shanghai_block: '0',
        cancun_block: '0',
      },
      allow_unprotected_txs: true,
      evm_channels: [],
    },
  };

  const feemarket = {
    '@type': '/ethermint.feemarket.v1.MsgUpdateParams',
    authority: 'evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm',
    params: {
      no_base_fee: false,
      base_fee_change_denominator: 8,
      elasticity_multiplier: 2,
      enable_height: '0',
      base_fee: '10000000000',
      min_gas_price: '20000000000.000000000000000000',
      min_gas_multiplier: '0.000100000000000000',
    },
  };

  const messages = [softwareUpgrade];
  const initialDeposit = '1000000000000000000';

  let proposalId = 1;
  for (const message of messages) {
    let tx, receipt;
    const title = 'update params';
    const summary = 'use proposal test update params';
    let metadata = 'Just Test Update Params';
    const expedited = false;
    const proposer = wallet.address;
    tx = await gov.submitProposal(JSON.stringify([message]), initialDeposit, proposer, metadata, title, summary, expedited);
    receipt = await tx.wait();
    console.log(`legacy submit proposal success, blockNumber: ${receipt.blockNumber}, blockHash: ${receipt.blockHash}`);

    const voter = wallet.address;
    const option = ethers.Typed.uint8(1); // 0:Unspecified, 1:Yes, 2: Abstain, 3: No, 4:NoWithWeto
    metadata = 'hello, let vote yes';
    tx = await gov.vote(voter, proposalId, option, metadata);
    receipt = await tx.wait();
    console.log(`vote proposal success, blockNumber: ${receipt.blockNumber}, blockHash: ${receipt.blockHash}`);

    proposalId++;
    break;
  }
};

main();

```

At present, there is no issue with proposals for modifying parameters. Unfortunately, a panic occurs with software upgrade proposals. The panic happens at this line in the Cosmos SDK's gov module in the msg_server.go file: `if !k.Keeper.legacyRouter.HasRoute(content.ProposalRoute())`. When the program reaches this point, the legacyRouter is a null pointer, causing the program to panic.

And I try set softwareUpgrade below also fail
```json
{
    "@type": "/cosmos.gov.v1beta1.MsgSubmitProposal",
    "content": {
        "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
        "title": "Evmos Mainnet v19.1.0 Upgrade",
        "description": "desc",
        "plan": {
            "name": "v19.1.0",
            "time": "0001-01-01T00:00:00Z",
            "height": "22763500",
            "info": "",
            "upgraded_client_state": null
        }
    },
    "initial_deposit": [],
    "proposer": "evmos10d07y265gmmuvt4z0w9aw880jnsr700jcrztvm"
}
```

@GAtom22 @Vvaradinov 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new event `SubmitProposal` for tracking proposal submissions.
	- Added a new function `submitProposal` that allows users to create proposals with detailed metadata.
  
- **Bug Fixes**
	- Enhanced error handling for proposal submissions with new error messages for invalid inputs, ensuring better feedback for users.

These updates improve the governance proposal functionality, enabling users to submit proposals more effectively and with clearer guidance on submission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->