### PR TITLE
feat(slashing): Add slashing precompile and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+- (slashing) [#2911](https://github.com/evmos/evmos/pull/2991) Add `slashing` precompile with `unjail` and `signingInfo`.
 - (gov) [#2976](https://github.com/evmos/evmos/pull/2976) Add `Proposals` and `Proposal` queries to gov precompile.
 - (testnet) [#2826](https://github.com/evmos/evmos/pull/2826) Fix command `evmosd testnet init-files` for validator_address is error.
 - (evm) [#2836](https://github.com/evmos/evmos/pull/2836) Recap the highest gas limit with account's available balance.

--- a/app/app.go
+++ b/app/app.go
@@ -539,6 +539,7 @@ func NewEvmos(
 			app.TransferKeeper,
 			app.IBCKeeper.ChannelKeeper,
 			app.GovKeeper,
+			app.SlashingKeeper,
 		),
 	)
 

--- a/precompiles/slashing/ISlashing.sol
+++ b/precompiles/slashing/ISlashing.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.17;
+
+import "../common/Types.sol";
+
+/// @dev The ISlashing contract's address.
+address constant SLASHING_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000806;
+
+/// @dev The IGov contract's instance.
+ISlashing constant SLASHING_CONTRACT = ISlashing(SLASHING_PRECOMPILE_ADDRESS);
+
+/// @dev SigningInfo defines a validator's signing info for monitoring their
+/// liveness activity.
+struct SigningInfo {
+    /// @dev Address of the validator
+    address validatorAddress;
+    /// @dev Height at which validator was first a candidate OR was unjailed
+    uint64 startHeight;
+    /// @dev Index offset into signed block bit array
+    uint64 indexOffset;
+    /// @dev Timestamp until which validator is jailed due to liveness downtime
+    uint64 jailedUntil;
+    /// @dev Whether or not a validator has been tombstoned (killed out of validator set)
+    bool tombstoned;
+    /// @dev Missed blocks counter (to avoid scanning the array every time)
+    uint64 missedBlocksCounter;
+}
+
+/// @author Evmos Team
+/// @title Slashing Precompiled Contract
+/// @dev The interface through which solidity contracts will interact with slashing.
+/// We follow this same interface including four-byte function selectors, in the precompile that
+/// wraps the pallet.
+/// @custom:address 0x0000000000000000000000000000000000000806
+interface ISlashing {
+    /// @dev Emitted when a validator is unjailed
+    /// @param validator The address of the validator
+    event ValidatorUnjailed(address indexed validator);
+
+    /// @dev GetSigningInfo returns the signing info for a specific validator.
+    /// @param consAddress The validator consensus address
+    /// @return signingInfo The validator signing info
+    function getSigningInfo(
+        address consAddress
+    ) external view returns (SigningInfo memory signingInfo);
+
+    /// @dev GetSigningInfos returns the signing info for all validators.
+    /// @param pagination Pagination configuration for the query
+    /// @return signingInfos The list of validator signing info
+    /// @return pageResponse Pagination information for the response
+    function getSigningInfos(
+        PageRequest calldata pagination
+    ) external view returns (SigningInfo[] memory signingInfos, PageResponse memory pageResponse);
+
+    /// @dev Unjail allows validators to unjail themselves after being jailed for downtime
+    /// @param validatorAddress The validator operator address to unjail
+    /// @return success true if the unjail operation was successful
+    function unjail(address validatorAddress) external returns (bool success);
+}

--- a/precompiles/slashing/ISlashing.sol
+++ b/precompiles/slashing/ISlashing.sol
@@ -6,7 +6,7 @@ import "../common/Types.sol";
 /// @dev The ISlashing contract's address.
 address constant SLASHING_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000806;
 
-/// @dev The IGov contract's instance.
+/// @dev The ISlashing contract's instance.
 ISlashing constant SLASHING_CONTRACT = ISlashing(SLASHING_PRECOMPILE_ADDRESS);
 
 /// @dev SigningInfo defines a validator's signing info for monitoring their

--- a/precompiles/slashing/ISlashing.sol
+++ b/precompiles/slashing/ISlashing.sol
@@ -26,6 +26,20 @@ struct SigningInfo {
     uint64 missedBlocksCounter;
 }
 
+/// @dev Params defines the parameters for the slashing module.
+struct Params {
+    /// @dev SignedBlocksWindow defines how many blocks the validator should have signed
+    uint64 signedBlocksWindow;
+    /// @dev MinSignedPerWindow defines the minimum blocks signed per window to avoid slashing
+    string minSignedPerWindow;
+    /// @dev DowntimeJailDuration defines how long the validator will be jailed for downtime
+    uint64 downtimeJailDuration;
+    /// @dev SlashFractionDoubleSign defines the percentage of slash for double sign
+    string slashFractionDoubleSign;
+    /// @dev SlashFractionDowntime defines the percentage of slash for downtime
+    string slashFractionDowntime;
+}
+
 /// @author Evmos Team
 /// @title Slashing Precompiled Contract
 /// @dev The interface through which solidity contracts will interact with slashing.
@@ -56,4 +70,8 @@ interface ISlashing {
     /// @param validatorAddress The validator operator address to unjail
     /// @return success true if the unjail operation was successful
     function unjail(address validatorAddress) external returns (bool success);
+
+    /// @dev GetParams returns the slashing module parameters
+    /// @return params The slashing module parameters
+    function getParams() external view returns (Params memory params);
 }

--- a/precompiles/slashing/abi.json
+++ b/precompiles/slashing/abi.json
@@ -1,0 +1,189 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "ISlashing",
+  "sourceName": "solidity/precompiles/gov/ISlashing.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "validator",
+          "type": "address"
+        }
+      ],
+      "name": "ValidatorUnjailed",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "consAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getSigningInfo",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "validatorAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "startHeight",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "indexOffset",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "jailedUntil",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "tombstoned",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint64",
+              "name": "missedBlocksCounter",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct SigningInfo",
+          "name": "signingInfo",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "key",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "offset",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "limit",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "countTotal",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "reverse",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct PageRequest",
+          "name": "pagination",
+          "type": "tuple"
+        }
+      ],
+      "name": "getSigningInfos",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "validatorAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "startHeight",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "indexOffset",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "jailedUntil",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "tombstoned",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint64",
+              "name": "missedBlocksCounter",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct SigningInfo[]",
+          "name": "signingInfos",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes",
+              "name": "nextKey",
+              "type": "bytes"
+            },
+            {
+              "internalType": "uint64",
+              "name": "total",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct PageResponse",
+          "name": "pageResponse",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "validatorAddress",
+          "type": "address"
+        }
+      ],
+      "name": "unjail",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "success",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/precompiles/slashing/abi.json
+++ b/precompiles/slashing/abi.json
@@ -17,6 +17,46 @@
       "type": "event"
     },
     {
+      "inputs": [],
+      "name": "getParams",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "signedBlocksWindow",
+              "type": "uint64"
+            },
+            {
+              "internalType": "string",
+              "name": "minSignedPerWindow",
+              "type": "string"
+            },
+            {
+              "internalType": "uint64",
+              "name": "downtimeJailDuration",
+              "type": "uint64"
+            },
+            {
+              "internalType": "string",
+              "name": "slashFractionDoubleSign",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "slashFractionDowntime",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct Params",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "address",

--- a/precompiles/slashing/abi.json
+++ b/precompiles/slashing/abi.json
@@ -1,7 +1,7 @@
 {
   "_format": "hh-sol-artifact-1",
   "contractName": "ISlashing",
-  "sourceName": "solidity/precompiles/gov/ISlashing.sol",
+  "sourceName": "solidity/precompiles/slashing/ISlashing.sol",
   "abi": [
     {
       "anonymous": false,

--- a/precompiles/slashing/events.go
+++ b/precompiles/slashing/events.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing
 
 import (

--- a/precompiles/slashing/events.go
+++ b/precompiles/slashing/events.go
@@ -1,0 +1,43 @@
+package slashing
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+)
+
+const (
+	// EventTypeValidatorUnjailed defines the event type for validator unjailing
+	EventTypeValidatorUnjailed = "ValidatorUnjailed"
+)
+
+// Add this struct after the existing constants
+type EventValidatorUnjailed struct {
+	Validator common.Address
+}
+
+// EmitValidatorUnjailedEvent emits the ValidatorUnjailed event
+func (p Precompile) EmitValidatorUnjailedEvent(ctx sdk.Context, stateDB vm.StateDB, validator common.Address) error {
+	// Prepare the event topics
+	event := p.ABI.Events[EventTypeValidatorUnjailed]
+	topics := make([]common.Hash, 2)
+
+	// The first topic is always the signature of the event
+	topics[0] = event.ID
+
+	var err error
+	topics[1], err = cmn.MakeTopic(validator)
+	if err != nil {
+		return err
+	}
+
+	stateDB.AddLog(&ethtypes.Log{
+		Address:     p.Address(),
+		Topics:      topics,
+		BlockNumber: uint64(ctx.BlockHeight()), //nolint:gosec // G115
+	})
+
+	return nil
+}

--- a/precompiles/slashing/events_test.go
+++ b/precompiles/slashing/events_test.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing_test
 
 import (

--- a/precompiles/slashing/events_test.go
+++ b/precompiles/slashing/events_test.go
@@ -1,0 +1,101 @@
+package slashing_test
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/precompiles/slashing"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+	"github.com/evmos/evmos/v20/x/evm/statedb"
+)
+
+func (s *PrecompileTestSuite) TestUnjailEvent() {
+	var (
+		stateDB *statedb.StateDB
+		ctx     sdk.Context
+		method  = s.precompile.Methods[slashing.UnjailMethod]
+	)
+
+	testCases := []struct {
+		name        string
+		malleate    func() []interface{}
+		postCheck   func()
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"success - the correct event is emitted",
+			func() []interface{} {
+				validator, err := s.network.App.StakingKeeper.GetValidator(ctx, sdk.ValAddress(s.keyring.GetAccAddr(0)))
+				s.Require().NoError(err)
+
+				consAddr, err := validator.GetConsAddr()
+				s.Require().NoError(err)
+
+				err = s.network.App.SlashingKeeper.Jail(
+					s.network.GetContext(),
+					consAddr,
+				)
+				s.Require().NoError(err)
+
+				return []interface{}{
+					s.keyring.GetAddr(0),
+				}
+			},
+			func() {
+				log := stateDB.Logs()[0]
+				s.Require().Equal(log.Address, s.precompile.Address())
+
+				// Check event signature matches the one emitted
+				event := s.precompile.ABI.Events[slashing.EventTypeValidatorUnjailed]
+				s.Require().Equal(crypto.Keccak256Hash([]byte(event.Sig)), common.HexToHash(log.Topics[0].Hex()))
+				s.Require().Equal(log.BlockNumber, uint64(ctx.BlockHeight())) //nolint:gosec // G115
+
+				// Check the validator address in the event matches
+				hash, err := cmn.MakeTopic(s.keyring.GetAddr(0))
+				s.Require().NoError(err)
+
+				s.Require().Equal(hash, log.Topics[1])
+
+				// Check the fully unpacked event matches the one emitted
+				var unjailEvent slashing.EventValidatorUnjailed
+				err = cmn.UnpackLog(s.precompile.ABI, &unjailEvent, slashing.EventTypeValidatorUnjailed, *log)
+				s.Require().NoError(err)
+				s.Require().Equal(s.keyring.GetAddr(0), unjailEvent.Validator)
+			},
+			20000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			stateDB = s.network.GetStateDB()
+			ctx = s.network.GetContext()
+
+			contract := vm.NewContract(vm.AccountRef(s.keyring.GetAddr(0)), s.precompile, big.NewInt(0), tc.gas)
+			ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+			initialGas := ctx.GasMeter().GasConsumed()
+			s.Require().Zero(initialGas)
+
+			_, err := s.precompile.Unjail(ctx, &method, stateDB, contract, tc.malleate())
+
+			if tc.expError {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), tc.errContains)
+			} else {
+				s.Require().NoError(err)
+				tc.postCheck()
+			}
+		})
+	}
+}

--- a/precompiles/slashing/query.go
+++ b/precompiles/slashing/query.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing
 
 import (

--- a/precompiles/slashing/query.go
+++ b/precompiles/slashing/query.go
@@ -1,0 +1,56 @@
+package slashing
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+)
+
+const (
+	// GetSigningInfoMethod defines the ABI method name for the slashing SigningInfo query
+	GetSigningInfoMethod = "getSigningInfo"
+	// GetSigningInfosMethod defines the ABI method name for the slashing SigningInfos query
+	GetSigningInfosMethod = "getSigningInfos"
+)
+
+// GetSigningInfo implements the query to get a validator's signing info.
+func (p *Precompile) GetSigningInfo(
+	ctx sdk.Context,
+	method *abi.Method,
+	_ *vm.Contract,
+	args []interface{},
+) ([]byte, error) {
+	req, err := ParseSigningInfoArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := p.slashingKeeper.SigningInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	out := new(SigningInfoOutput).FromResponse(res)
+	return method.Outputs.Pack(out.SigningInfo)
+}
+
+// GetSigningInfos implements the query to get signing info for all validators.
+func (p *Precompile) GetSigningInfos(
+	ctx sdk.Context,
+	method *abi.Method,
+	_ *vm.Contract,
+	args []interface{},
+) ([]byte, error) {
+	req, err := ParseSigningInfosArgs(method, args)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := p.slashingKeeper.SigningInfos(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	out := new(SigningInfosOutput).FromResponse(res)
+	return method.Outputs.Pack(out.SigningInfos, out.PageResponse)
+}

--- a/precompiles/slashing/query.go
+++ b/precompiles/slashing/query.go
@@ -5,6 +5,7 @@ package slashing
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 )
@@ -14,6 +15,8 @@ const (
 	GetSigningInfoMethod = "getSigningInfo"
 	// GetSigningInfosMethod defines the ABI method name for the slashing SigningInfos query
 	GetSigningInfosMethod = "getSigningInfos"
+	// GetParamsMethod defines the ABI method name for the slashing Params query
+	GetParamsMethod = "getParams"
 )
 
 // GetSigningInfo implements the query to get a validator's signing info.
@@ -56,4 +59,20 @@ func (p *Precompile) GetSigningInfos(
 
 	out := new(SigningInfosOutput).FromResponse(res)
 	return method.Outputs.Pack(out.SigningInfos, out.PageResponse)
+}
+
+// GetParams implements the query to get the slashing parameters.
+func (p *Precompile) GetParams(
+	ctx sdk.Context,
+	method *abi.Method,
+	_ *vm.Contract,
+	_ []interface{},
+) ([]byte, error) {
+	res, err := p.slashingKeeper.Params(ctx, &types.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	out := new(ParamsOutput).FromResponse(res)
+	return method.Outputs.Pack(out.Params)
 }

--- a/precompiles/slashing/query_test.go
+++ b/precompiles/slashing/query_test.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing_test
 
 import (

--- a/precompiles/slashing/query_test.go
+++ b/precompiles/slashing/query_test.go
@@ -1,0 +1,204 @@
+package slashing_test
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/ethereum/go-ethereum/common"
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/precompiles/slashing"
+	"github.com/evmos/evmos/v20/precompiles/testutil"
+)
+
+func (s *PrecompileTestSuite) TestGetSigningInfo() {
+	method := s.precompile.Methods[slashing.GetSigningInfoMethod]
+
+	testCases := []struct {
+		name        string
+		malleate    func() []interface{}
+		postCheck   func(signingInfo *slashing.SigningInfo)
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"fail - empty input args",
+			func() []interface{} {
+				return []interface{}{}
+			},
+			func(_ *slashing.SigningInfo) {},
+			200000,
+			true,
+			fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			"fail - invalid consensus address",
+			func() []interface{} {
+				return []interface{}{
+					common.Address{},
+				}
+			},
+			func(_ *slashing.SigningInfo) {},
+			200000,
+			true,
+			"invalid consensus address",
+		},
+		{
+			"success - get signing info for validator",
+			func() []interface{} {
+				err := s.network.App.SlashingKeeper.SetValidatorSigningInfo(
+					s.network.GetContext(),
+					types.ConsAddress(s.keyring.GetAddr(0).Bytes()),
+					slashingtypes.ValidatorSigningInfo{
+						StartHeight:         1,
+						IndexOffset:         2,
+						MissedBlocksCounter: 1,
+						Tombstoned:          false,
+					},
+				)
+				s.Require().NoError(err)
+				return []interface{}{
+					s.keyring.GetAddr(0),
+				}
+			},
+			func(signingInfo *slashing.SigningInfo) {
+				s.Require().Equal(uint64(1), signingInfo.StartHeight)
+				s.Require().Equal(uint64(2), signingInfo.IndexOffset)
+				s.Require().Equal(uint64(1), signingInfo.MissedBlocksCounter)
+				s.Require().False(signingInfo.Tombstoned)
+			},
+			200000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			contract, ctx := testutil.NewPrecompileContract(s.T(), s.network.GetContext(), s.keyring.GetAddr(0), s.precompile, tc.gas)
+
+			bz, err := s.precompile.GetSigningInfo(ctx, &method, contract, tc.malleate())
+
+			if tc.expError {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), tc.errContains)
+			} else {
+				s.Require().NoError(err)
+				var out slashing.SigningInfoOutput
+				err = s.precompile.UnpackIntoInterface(&out, slashing.GetSigningInfoMethod, bz)
+				s.Require().NoError(err)
+				tc.postCheck(&out.SigningInfo)
+			}
+		})
+	}
+}
+
+func (s *PrecompileTestSuite) TestGetSigningInfos() {
+	method := s.precompile.Methods[slashing.GetSigningInfosMethod]
+
+	testCases := []struct {
+		name        string
+		malleate    func() []interface{}
+		postCheck   func(signingInfos []slashing.SigningInfo, pageResponse *query.PageResponse)
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"fail - empty input args",
+			func() []interface{} {
+				return []interface{}{}
+			},
+			func(_ []slashing.SigningInfo, _ *query.PageResponse) {},
+			200000,
+			true,
+			fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			"success - get all signing infos",
+			func() []interface{} {
+				return []interface{}{
+					query.PageRequest{
+						Limit:      10,
+						CountTotal: true,
+					},
+				}
+			},
+			func(signingInfos []slashing.SigningInfo, pageResponse *query.PageResponse) {
+				s.Require().Len(signingInfos, 3)
+				s.Require().Equal(uint64(3), pageResponse.Total)
+
+				// Check first validator's signing info
+				s.Require().Equal(uint64(0), signingInfos[0].StartHeight)
+				s.Require().Equal(uint64(1), signingInfos[0].IndexOffset)
+				s.Require().Equal(uint64(18446744011573954816), signingInfos[0].JailedUntil)
+				s.Require().False(signingInfos[0].Tombstoned)
+
+				// Check second validator's signing info
+				s.Require().Equal(uint64(0), signingInfos[1].StartHeight)
+				s.Require().Equal(uint64(1), signingInfos[1].IndexOffset)
+				s.Require().Equal(uint64(18446744011573954816), signingInfos[1].JailedUntil)
+				s.Require().False(signingInfos[1].Tombstoned)
+
+				// Check third validator's signing info
+				s.Require().Equal(uint64(0), signingInfos[2].StartHeight)
+				s.Require().Equal(uint64(1), signingInfos[2].IndexOffset)
+				s.Require().Equal(uint64(18446744011573954816), signingInfos[2].JailedUntil)
+				s.Require().False(signingInfos[2].Tombstoned)
+			},
+			200000,
+			false,
+			"",
+		},
+		{
+			"success - get signing infos with pagination",
+			func() []interface{} {
+				return []interface{}{
+					query.PageRequest{
+						Limit:      1,
+						CountTotal: true,
+					},
+				}
+			},
+			func(signingInfos []slashing.SigningInfo, pageResponse *query.PageResponse) {
+				s.Require().Len(signingInfos, 1)
+				s.Require().Equal(uint64(3), pageResponse.Total)
+				s.Require().NotNil(pageResponse.NextKey)
+
+				// Check first validator's signing info
+				s.Require().Equal(uint64(0), signingInfos[0].StartHeight)
+				s.Require().Equal(uint64(1), signingInfos[0].IndexOffset)
+				s.Require().Equal(uint64(18446744011573954816), signingInfos[0].JailedUntil)
+				s.Require().False(signingInfos[0].Tombstoned)
+			},
+			200000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			contract, ctx := testutil.NewPrecompileContract(s.T(), s.network.GetContext(), s.keyring.GetAddr(0), s.precompile, tc.gas)
+
+			bz, err := s.precompile.GetSigningInfos(ctx, &method, contract, tc.malleate())
+
+			if tc.expError {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), tc.errContains)
+			} else {
+				s.Require().NoError(err)
+				var out slashing.SigningInfosOutput
+				err = s.precompile.UnpackIntoInterface(&out, slashing.GetSigningInfosMethod, bz)
+				s.Require().NoError(err)
+				tc.postCheck(out.SigningInfos, &out.PageResponse)
+			}
+		})
+	}
+}

--- a/precompiles/slashing/setup_test.go
+++ b/precompiles/slashing/setup_test.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing_test
 
 import (

--- a/precompiles/slashing/setup_test.go
+++ b/precompiles/slashing/setup_test.go
@@ -1,0 +1,58 @@
+package slashing_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/evmos/evmos/v20/precompiles/slashing"
+	"github.com/evmos/evmos/v20/testutil/integration/evmos/factory"
+	"github.com/evmos/evmos/v20/testutil/integration/evmos/grpc"
+	testkeyring "github.com/evmos/evmos/v20/testutil/integration/evmos/keyring"
+	"github.com/evmos/evmos/v20/testutil/integration/evmos/network"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PrecompileTestSuite struct {
+	suite.Suite
+
+	network     *network.UnitTestNetwork
+	factory     factory.TxFactory
+	grpcHandler grpc.Handler
+	keyring     testkeyring.Keyring
+
+	precompile *slashing.Precompile
+}
+
+func TestPrecompileTestSuite(t *testing.T) {
+	suite.Run(t, new(PrecompileTestSuite))
+}
+
+func (s *PrecompileTestSuite) SetupTest() {
+	keyring := testkeyring.New(3)
+	var err error
+	nw := network.NewUnitTestNetwork(
+		network.WithPreFundedAccounts(keyring.GetAllAccAddrs()...),
+		network.WithValidatorOperators([]sdk.AccAddress{
+			keyring.GetAccAddr(0),
+			keyring.GetAccAddr(1),
+			keyring.GetAccAddr(2),
+		}),
+	)
+
+	grpcHandler := grpc.NewIntegrationHandler(nw)
+	txFactory := factory.New(nw, grpcHandler)
+
+	s.network = nw
+	s.factory = txFactory
+	s.grpcHandler = grpcHandler
+	s.keyring = keyring
+
+	if s.precompile, err = slashing.NewPrecompile(
+		s.network.App.SlashingKeeper,
+		s.network.App.AuthzKeeper,
+	); err != nil {
+		panic(err)
+	}
+}

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -1,0 +1,149 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
+package slashing
+
+import (
+	"embed"
+	"fmt"
+
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
+)
+
+var _ vm.PrecompiledContract = &Precompile{}
+
+// Embed abi json file to the executable binary. Needed when importing as dependency.
+//
+//go:embed abi.json
+var f embed.FS
+
+// Precompile defines the precompiled contract for slashing.
+type Precompile struct {
+	cmn.Precompile
+	slashingKeeper slashingkeeper.Keeper
+}
+
+// LoadABI loads the slashing ABI from the embedded abi.json file
+// for the slashing precompile.
+func LoadABI() (abi.ABI, error) {
+	return cmn.LoadABI(f, "abi.json")
+}
+
+// NewPrecompile creates a new slashing Precompile instance as a
+// PrecompiledContract interface.
+func NewPrecompile(
+	slashingKeeper slashingkeeper.Keeper,
+	authzKeeper authzkeeper.Keeper,
+) (*Precompile, error) {
+	abi, err := LoadABI()
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Precompile{
+		Precompile: cmn.Precompile{
+			ABI:                  abi,
+			AuthzKeeper:          authzKeeper,
+			KvGasConfig:          storetypes.KVGasConfig(),
+			TransientKVGasConfig: storetypes.TransientGasConfig(),
+			ApprovalExpiration:   cmn.DefaultExpirationDuration, // should be configurable in the future.
+		},
+		slashingKeeper: slashingKeeper,
+	}
+
+	// SetAddress defines the address of the slashing precompiled contract.
+	p.SetAddress(common.HexToAddress(evmtypes.SlashingPrecompileAddress))
+
+	return p, nil
+}
+
+// RequiredGas calculates the precompiled contract's base gas rate.
+func (p Precompile) RequiredGas(input []byte) uint64 {
+	// NOTE: This check avoid panicking when trying to decode the method ID
+	if len(input) < 4 {
+		return 0
+	}
+	methodID := input[:4]
+
+	method, err := p.MethodById(methodID)
+	if err != nil {
+		// This should never happen since this method is going to fail during Run
+		return 0
+	}
+
+	return p.Precompile.RequiredGas(input, p.IsTransaction(method))
+}
+
+// Run executes the precompiled contract slashing methods defined in the ABI.
+func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
+	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	if err != nil {
+		return nil, err
+	}
+
+	// This handles any out of gas errors that may occur during the execution of a precompile tx or query.
+	// It avoids panics and returns the out of gas error so the EVM can continue gracefully.
+	defer cmn.HandleGasError(ctx, contract, initialGas, &err)()
+
+	if err := stateDB.Commit(); err != nil {
+		return nil, err
+	}
+
+	switch method.Name {
+	// slashing transactions
+	case UnjailMethod:
+		bz, err = p.Unjail(ctx, method, stateDB, contract, args)
+	// slashing queries
+	case GetSigningInfoMethod:
+		bz, err = p.GetSigningInfo(ctx, method, contract, args)
+	case GetSigningInfosMethod:
+		bz, err = p.GetSigningInfos(ctx, method, contract, args)
+	default:
+		return nil, fmt.Errorf(cmn.ErrUnknownMethod, method.Name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	cost := ctx.GasMeter().GasConsumed() - initialGas
+
+	if !contract.UseGas(cost) {
+		return nil, vm.ErrOutOfGas
+	}
+
+	if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
+		return nil, err
+	}
+
+	return bz, nil
+}
+
+// IsTransaction checks if the given method name corresponds to a transaction or query.
+//
+// Available slashing transactions are:
+// - Unjail
+func (Precompile) IsTransaction(method *abi.Method) bool {
+	switch method.Name {
+	case UnjailMethod:
+		return true
+	default:
+		return false
+	}
+}
+
+// Logger returns a precompile-specific logger.
+func (p Precompile) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("evm extension", "slashing")
+}

--- a/precompiles/slashing/tx.go
+++ b/precompiles/slashing/tx.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing
 
 import (

--- a/precompiles/slashing/tx.go
+++ b/precompiles/slashing/tx.go
@@ -1,0 +1,54 @@
+package slashing
+
+import (
+	"fmt"
+
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	// UnjailMethod defines the ABI method name for the slashing Unjail
+	// transaction.
+	UnjailMethod = "unjail"
+)
+
+// Unjail implements the unjail precompile transaction, which allows validators
+// to unjail themselves after being jailed for downtime.
+func (p Precompile) Unjail(
+	ctx sdk.Context,
+	method *abi.Method,
+	stateDB vm.StateDB,
+	_ *vm.Contract,
+	args []interface{},
+) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
+	}
+
+	validatorAddress, ok := args[0].(common.Address)
+	if !ok {
+		return nil, fmt.Errorf("invalid validator hex address")
+	}
+
+	msg := &types.MsgUnjail{
+		ValidatorAddr: sdk.ValAddress(validatorAddress.Bytes()).String(),
+	}
+
+	msgSrv := slashingkeeper.NewMsgServerImpl(p.slashingKeeper)
+	if _, err := msgSrv.Unjail(ctx, msg); err != nil {
+		return nil, err
+	}
+
+	if err := p.EmitValidatorUnjailedEvent(ctx, stateDB, validatorAddress); err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(true)
+}

--- a/precompiles/slashing/tx_test.go
+++ b/precompiles/slashing/tx_test.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing_test
 
 import (

--- a/precompiles/slashing/tx_test.go
+++ b/precompiles/slashing/tx_test.go
@@ -1,0 +1,138 @@
+package slashing_test
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+	"github.com/evmos/evmos/v20/precompiles/slashing"
+	"github.com/evmos/evmos/v20/precompiles/testutil"
+	utiltx "github.com/evmos/evmos/v20/testutil/tx"
+)
+
+func (s *PrecompileTestSuite) TestUnjail() {
+	method := s.precompile.Methods[slashing.UnjailMethod]
+	testCases := []struct {
+		name        string
+		malleate    func() []interface{}
+		postCheck   func()
+		gas         uint64
+		expError    bool
+		errContains string
+	}{
+		{
+			"fail - empty input args",
+			func() []interface{} {
+				return []interface{}{}
+			},
+			func() {},
+			200000,
+			true,
+			fmt.Sprintf(cmn.ErrInvalidNumberOfArgs, 1, 0),
+		},
+		{
+			"fail - invalid validator address",
+			func() []interface{} {
+				return []interface{}{
+					"",
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"invalid validator hex address",
+		},
+		{
+			"fail - invalid validator address (empty address)",
+			func() []interface{} {
+				return []interface{}{
+					common.Address{},
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"validator does not exist",
+		},
+		{
+			"fail - validator not found",
+			func() []interface{} {
+				return []interface{}{
+					utiltx.GenerateAddress(),
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"validator does not exist",
+		},
+		{
+			"fail - validator not jailed",
+			func() []interface{} {
+				return []interface{}{
+					s.keyring.GetAddr(0),
+				}
+			},
+			func() {},
+			200000,
+			true,
+			"validator not jailed",
+		},
+		{
+			"success - validator unjailed",
+			func() []interface{} {
+				validator, err := s.network.App.StakingKeeper.GetValidator(s.network.GetContext(), sdk.ValAddress(s.keyring.GetAccAddr(0)))
+				s.Require().NoError(err)
+
+				valConsAddr, err := validator.GetConsAddr()
+				s.Require().NoError(err)
+				err = s.network.App.SlashingKeeper.Jail(
+					s.network.GetContext(),
+					valConsAddr,
+				)
+				s.Require().NoError(err)
+
+				validatorAfterJail, err := s.network.App.StakingKeeper.GetValidator(s.network.GetContext(), sdk.ValAddress(s.keyring.GetAddr(0).Bytes()))
+				s.Require().NoError(err)
+				s.Require().True(validatorAfterJail.IsJailed())
+
+				return []interface{}{
+					s.keyring.GetAddr(0),
+				}
+			},
+			func() {
+				validatorAfterUnjail, err := s.network.App.StakingKeeper.GetValidator(s.network.GetContext(), sdk.ValAddress(s.keyring.GetAddr(0).Bytes()))
+				s.Require().NoError(err)
+				s.Require().False(validatorAfterUnjail.IsJailed())
+			},
+			200000,
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.network.GetContext(),
+				s.keyring.GetAddr(0),
+				s.precompile,
+				tc.gas,
+			)
+
+			res, err := s.precompile.Unjail(ctx, &method, s.network.GetStateDB(), contract, tc.malleate())
+
+			if tc.expError {
+				s.Require().ErrorContains(err, tc.errContains)
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(cmn.TrueValue, res)
+				tc.postCheck()
+			}
+		})
+	}
+}

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -1,3 +1,6 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+
 package slashing
 
 import (

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -1,0 +1,109 @@
+package slashing
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	cmn "github.com/evmos/evmos/v20/precompiles/common"
+)
+
+// SigningInfo represents the signing info for a validator
+type SigningInfo struct {
+	ValidatorAddress    common.Address `abi:"validatorAddress"`
+	StartHeight         uint64         `abi:"startHeight"`
+	IndexOffset         uint64         `abi:"indexOffset"`
+	JailedUntil         uint64         `abi:"jailedUntil"`
+	Tombstoned          bool           `abi:"tombstoned"`
+	MissedBlocksCounter uint64         `abi:"missedBlocksCounter"`
+}
+
+// SigningInfoOutput represents the output of the signing info query
+type SigningInfoOutput struct {
+	SigningInfo SigningInfo
+}
+
+// SigningInfosOutput represents the output of the signing infos query
+type SigningInfosOutput struct {
+	SigningInfos []SigningInfo      `abi:"signingInfos"`
+	PageResponse query.PageResponse `abi:"pageResponse"`
+}
+
+// SigningInfosInput represents the input for the signing infos query
+type SigningInfosInput struct {
+	Pagination query.PageRequest `abi:"pagination"`
+}
+
+// ParseSigningInfoArgs parses the arguments for the signing info query
+func ParseSigningInfoArgs(args []interface{}) (*slashingtypes.QuerySigningInfoRequest, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
+	}
+
+	hexAddr, ok := args[0].(common.Address)
+	if !ok || hexAddr == (common.Address{}) {
+		return nil, fmt.Errorf("invalid consensus address")
+	}
+
+	return &slashingtypes.QuerySigningInfoRequest{
+		ConsAddress: types.ConsAddress(hexAddr.Bytes()).String(),
+	}, nil
+}
+
+// ParseSigningInfosArgs parses the arguments for the signing infos query
+func ParseSigningInfosArgs(method *abi.Method, args []interface{}) (*slashingtypes.QuerySigningInfosRequest, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf(cmn.ErrInvalidNumberOfArgs, 1, len(args))
+	}
+
+	var input SigningInfosInput
+	if err := method.Inputs.Copy(&input, args); err != nil {
+		return nil, fmt.Errorf("error while unpacking args to SigningInfosInput: %s", err)
+	}
+
+	return &slashingtypes.QuerySigningInfosRequest{
+		Pagination: &input.Pagination,
+	}, nil
+}
+
+func (sio *SigningInfoOutput) FromResponse(res *slashingtypes.QuerySigningInfoResponse) *SigningInfoOutput {
+	sio.SigningInfo = SigningInfo{
+		ValidatorAddress:    common.BytesToAddress([]byte(res.ValSigningInfo.Address)),
+		StartHeight:         uint64(res.ValSigningInfo.StartHeight),        //nolint:gosec // G115
+		IndexOffset:         uint64(res.ValSigningInfo.IndexOffset),        //nolint:gosec // G115
+		JailedUntil:         uint64(res.ValSigningInfo.JailedUntil.Unix()), //nolint:gosec // G115
+		Tombstoned:          res.ValSigningInfo.Tombstoned,
+		MissedBlocksCounter: uint64(res.ValSigningInfo.MissedBlocksCounter), //nolint:gosec // G115
+	}
+	return sio
+}
+
+func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfosResponse) *SigningInfosOutput {
+	sio.SigningInfos = make([]SigningInfo, len(res.Info))
+	for i, info := range res.Info {
+		sio.SigningInfos[i] = SigningInfo{
+			ValidatorAddress:    common.BytesToAddress([]byte(info.Address)),
+			StartHeight:         uint64(info.StartHeight),        //nolint:gosec // G115
+			IndexOffset:         uint64(info.IndexOffset),        //nolint:gosec // G115
+			JailedUntil:         uint64(info.JailedUntil.Unix()), //nolint:gosec // G115
+			Tombstoned:          info.Tombstoned,
+			MissedBlocksCounter: uint64(info.MissedBlocksCounter), //nolint:gosec // G115
+		}
+	}
+	if res.Pagination != nil {
+		sio.PageResponse = query.PageResponse{
+			NextKey: res.Pagination.NextKey,
+			Total:   res.Pagination.Total,
+		}
+	}
+	return sio
+}
+
+// ValidatorUnjailed defines the data structure for the ValidatorUnjailed event.
+type ValidatorUnjailed struct {
+	Validator common.Address
+}

--- a/precompiles/slashing/types.go
+++ b/precompiles/slashing/types.go
@@ -110,3 +110,28 @@ func (sio *SigningInfosOutput) FromResponse(res *slashingtypes.QuerySigningInfos
 type ValidatorUnjailed struct {
 	Validator common.Address
 }
+
+// Params defines the parameters for the slashing module
+type Params struct {
+	SignedBlocksWindow      uint64 `abi:"signedBlocksWindow"`
+	MinSignedPerWindow      string `abi:"minSignedPerWindow"`
+	DowntimeJailDuration    uint64 `abi:"downtimeJailDuration"`
+	SlashFractionDoubleSign string `abi:"slashFractionDoubleSign"`
+	SlashFractionDowntime   string `abi:"slashFractionDowntime"`
+}
+
+// ParamsOutput represents the output of the params query
+type ParamsOutput struct {
+	Params Params
+}
+
+func (po *ParamsOutput) FromResponse(res *slashingtypes.QueryParamsResponse) *ParamsOutput {
+	po.Params = Params{
+		SignedBlocksWindow:      uint64(res.Params.SignedBlocksWindow), //nolint:gosec // G115
+		MinSignedPerWindow:      res.Params.MinSignedPerWindow.String(),
+		DowntimeJailDuration:    uint64(res.Params.DowntimeJailDuration.Seconds()),
+		SlashFractionDoubleSign: res.Params.SlashFractionDoubleSign.String(),
+		SlashFractionDowntime:   res.Params.SlashFractionDowntime.String(),
+	}
+	return po
+}

--- a/x/evm/keeper/static_precompiles.go
+++ b/x/evm/keeper/static_precompiles.go
@@ -12,6 +12,7 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	channelkeeper "github.com/cosmos/ibc-go/v8/modules/core/04-channel/keeper"
 	"github.com/ethereum/go-ethereum/common"
 	bankprecompile "github.com/evmos/evmos/v20/precompiles/bank"
@@ -20,6 +21,7 @@ import (
 	govprecompile "github.com/evmos/evmos/v20/precompiles/gov"
 	ics20precompile "github.com/evmos/evmos/v20/precompiles/ics20"
 	"github.com/evmos/evmos/v20/precompiles/p256"
+	slashingprecompile "github.com/evmos/evmos/v20/precompiles/slashing"
 	stakingprecompile "github.com/evmos/evmos/v20/precompiles/staking"
 	vestingprecompile "github.com/evmos/evmos/v20/precompiles/vesting"
 	erc20Keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
@@ -44,6 +46,7 @@ func NewAvailableStaticPrecompiles(
 	transferKeeper transferkeeper.Keeper,
 	channelKeeper channelkeeper.Keeper,
 	govKeeper govkeeper.Keeper,
+	slashingKeeper slashingkeeper.Keeper,
 ) map[common.Address]vm.PrecompiledContract {
 	// Clone the mapping from the latest EVM fork.
 	precompiles := maps.Clone(vm.PrecompiledContractsBerlin)
@@ -95,6 +98,11 @@ func NewAvailableStaticPrecompiles(
 		panic(fmt.Errorf("failed to instantiate gov precompile: %w", err))
 	}
 
+	slashingPrecompile, err := slashingprecompile.NewPrecompile(slashingKeeper, authzKeeper)
+	if err != nil {
+		panic(fmt.Errorf("failed to instantiate slashing precompile: %w", err))
+	}
+
 	// Stateless precompiles
 	precompiles[bech32Precompile.Address()] = bech32Precompile
 	precompiles[p256Precompile.Address()] = p256Precompile
@@ -106,6 +114,7 @@ func NewAvailableStaticPrecompiles(
 	precompiles[vestingPrecompile.Address()] = vestingPrecompile
 	precompiles[bankPrecompile.Address()] = bankPrecompile
 	precompiles[govPrecompile.Address()] = govPrecompile
+	precompiles[slashingPrecompile.Address()] = slashingPrecompile
 	return precompiles
 }
 

--- a/x/evm/types/precompiles.go
+++ b/x/evm/types/precompiles.go
@@ -15,6 +15,7 @@ const (
 	VestingPrecompileAddress      = "0x0000000000000000000000000000000000000803"
 	BankPrecompileAddress         = "0x0000000000000000000000000000000000000804"
 	GovPrecompileAddress          = "0x0000000000000000000000000000000000000805"
+	SlashingPrecompileAddress     = "0x0000000000000000000000000000000000000806"
 )
 
 // AvailableStaticPrecompiles defines the full list of all available EVM extension addresses.
@@ -30,4 +31,5 @@ var AvailableStaticPrecompiles = []string{
 	VestingPrecompileAddress,
 	BankPrecompileAddress,
 	GovPrecompileAddress,
+	SlashingPrecompileAddress,
 }


### PR DESCRIPTION
# Description

Add the slashing module precompile and tests.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced slashing precompile functionality, allowing validators to unjail themselves and query signing information.
  - Added a new interface for slashing operations, including methods for retrieving signing information and slashing parameters.

- **Improvements**
  - Enhanced governance precompile with new query capabilities.
  - Updated transaction handling and fee scaling for better performance.
  - Added support for custom base denom decimals in EVM transactions.

- **Bug Fixes**
  - Resolved issues ensuring the default denomination is used in CLI commands.

These changes significantly enhance the transaction processing and validator management capabilities within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->