### PR TITLE
fix(evm): Update the access list with the correct precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (deps) [#2967](https://github.com/evmos/evmos/pull/2967) Bump CometBFT to `v0.38.15`.
 - (precompiles) [#2943](https://github.com/evmos/evmos/pull/2943) Add WERC-20 precompile.
 - (precompiles) [#2966](https://github.com/evmos/evmos/pull/2966) Add safety check that ERC-20 precompiles cannot receive funds.
+- (evm) [#3000](https://github.com/evmos/evmos/pull/3000) Move population of access list with precompile addresses into EVM hook.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (precompiles) [#2929](https://github.com/evmos/evmos/pull/2929) Distribution: scale balance change entries to the statedb journal to support different EVM denom precision.
 - (precompiles) [#2927](https://github.com/evmos/evmos/pull/2927) Erc20: scale balance change entries to the statedb journal to support different EVM denom precision.
 - (erc20) [#2962](https://github.com/evmos/evmos/pull/2962) Register ERC-20 code hash also for native ERC-20 extensions.
+- (evm) [#3000](https://github.com/evmos/evmos/pull/3000) Move population of access list with precompile addresses into EVM hook.
 
 ### Improvements
 
@@ -68,7 +69,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (deps) [#2967](https://github.com/evmos/evmos/pull/2967) Bump CometBFT to `v0.38.15`.
 - (precompiles) [#2943](https://github.com/evmos/evmos/pull/2943) Add WERC-20 precompile.
 - (precompiles) [#2966](https://github.com/evmos/evmos/pull/2966) Add safety check that ERC-20 precompiles cannot receive funds.
-- (evm) [#3000](https://github.com/evmos/evmos/pull/3000) Move population of access list with precompile addresses into EVM hook.
 
 ### Bug Fixes
 

--- a/x/evm/keeper/precompiles.go
+++ b/x/evm/keeper/precompiles.go
@@ -57,9 +57,13 @@ func (k *Keeper) GetPrecompilesCallHook(ctx sdktypes.Context) types.CallHook {
 			return err
 		}
 
+		// If the precompile instance is created, we have to update the EVM with
+		// only the recipient precompile and add it's address to the access list.
 		if found {
 			evm.WithPrecompiles(precompiles.Map, precompiles.Addresses)
+			evm.StateDB.AddAddressToAccessList(recipient)
 		}
+
 		return nil
 	}
 }

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -308,7 +308,10 @@ func (k *Keeper) ApplyMessageWithConfig(
 	// access list preparation is moved from ante handler to here, because it's needed when `ApplyMessage` is called
 	// under contexts where ante handlers are not run, for example `eth_call` and `eth_estimateGas`.
 	if rules := cfg.ChainConfig.Rules(big.NewInt(ctx.BlockHeight()), cfg.ChainConfig.MergeNetsplitBlock != nil); rules.IsBerlin {
-		stateDB.PrepareAccessList(msg.From(), msg.To(), evm.ActivePrecompiles(rules), msg.AccessList())
+		// The access list is prepared without any precompile because it is
+		// filled with only the recipient precompile address in the EVM'hook
+		// call.
+		stateDB.PrepareAccessList(msg.From(), msg.To(), []common.Address{}, msg.AccessList())
 	}
 
 	if contractCreation {


### PR DESCRIPTION
# Description

Currently, the access list is populated with all static precompiles. This logic does not take into consideration the new EVM type, which uses hooks to populate the precompiles field just in time if a precompile is a receiver of a `Call`.

For this reason:
- all static precompiles are loaded even though they are not the target of the call
- dynamic precompiles (ERC20) are never loaded.

This PR moves the logic to add precompiled addresses in the access list into the Call hook.

## Considerations

If in the future, the `Create` EVM's method can use static precompiles, we should populate the access list with the target one. I'm not sure this is a possibility, but it is something we should keep in mind. If we don't want to think about it in the future, I could add again the logic to add to the access list all static preocmpiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `CHANGELOG.md` with new entries detailing significant changes.
	- Introduced `FeeMarketWrapper` for managing EVM coins with varying decimal precision.
	- Added a `slashing` precompile and enhanced governance queries.

- **Bug Fixes**
	- Resolved issues with default denomination in CLI commands.

- **Improvements**
	- Refined handling of EVM coins and adjusted gas limits based on account balances.
	- Updated access list preparation for Ethereum transactions to enhance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->