### PR TITLE
fix(precompiles): Remove duplicate commits in precompiles

### DIFF
--- a/precompiles/gov/gov.go
+++ b/precompiles/gov/gov.go
@@ -96,10 +96,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	// It avoids panics and returns the out of gas error so the EVM can continue gracefully.
 	defer cmn.HandleGasError(ctx, contract, initialGas, &err)()
 
-	if err := stateDB.Commit(); err != nil {
-		return nil, err
-	}
-
 	switch method.Name {
 	// gov transactions
 	case VoteMethod:

--- a/precompiles/slashing/slashing.go
+++ b/precompiles/slashing/slashing.go
@@ -96,10 +96,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	// It avoids panics and returns the out of gas error so the EVM can continue gracefully.
 	defer cmn.HandleGasError(ctx, contract, initialGas, &err)()
 
-	if err := stateDB.Commit(); err != nil {
-		return nil, err
-	}
-
 	switch method.Name {
 	// slashing transactions
 	case UnjailMethod:


### PR DESCRIPTION
# Description

Remove duplicate `Commit` from recently added precompiles.
