### PR TITLE
test(ante): Add custom decimals tests for ante handler

### DIFF
--- a/app/ante/evm/suite_test.go
+++ b/app/ante/evm/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/evmos/evmos/v20/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -15,16 +16,23 @@ type EvmAnteTestSuite struct {
 
 	// To make sure that every tests is run with all the tx types
 	ethTxType int
+	chainID   string
 }
 
 func TestEvmAnteTestSuite(t *testing.T) {
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.DynamicFeeTxType,
-	})
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.LegacyTxType,
-	})
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.AccessListTxType,
-	})
+	chainIDs := []string{utils.MainnetChainID + "-1", utils.SixDecChainID + "-1"}
+	for _, chainID := range chainIDs {
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.DynamicFeeTxType,
+			chainID:   chainID,
+		})
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.LegacyTxType,
+			chainID:   chainID,
+		})
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.AccessListTxType,
+			chainID:   chainID,
+		})
+	}
 }

--- a/testutil/integration/evmos/factory/factory.go
+++ b/testutil/integration/evmos/factory/factory.go
@@ -149,6 +149,8 @@ func (tf *IntegrationTxFactory) populateEvmTxArgsWithDefault(
 			txArgs.GasFeeCap = baseFeeResp.BaseFee.BigInt()
 		}
 	}
+	fmt.Println("GasFeeCap: ", txArgs.GasFeeCap)
+	fmt.Println("GasTipCap: ", txArgs.GasTipCap)
 
 	// If the gas limit is not set, estimate it
 	// through the /simulate endpoint.
@@ -159,6 +161,7 @@ func (tf *IntegrationTxFactory) populateEvmTxArgsWithDefault(
 		}
 		txArgs.GasLimit = gasLimit
 	}
+	fmt.Println("GasLimit: ", txArgs.GasLimit)
 
 	return txArgs, nil
 }


### PR DESCRIPTION
# Description

Update tests for ante handler to run with different decimals.

## Run a test

Example to run a single test for the test suite from the terminal:

```sh
go test -v -tags=test ./app/ante/evm -run ^TestEvmAnteTestSuite$ -testify.m TestVerifyAccountBalance
```
