### PR TITLE
fix(test): Verify account balance ante fix tests

### DIFF
--- a/app/ante/evm/suite_test.go
+++ b/app/ante/evm/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/evmos/evmos/v20/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -15,16 +16,23 @@ type EvmAnteTestSuite struct {
 
 	// To make sure that every tests is run with all the tx types
 	ethTxType int
+	chainID   string
 }
 
 func TestEvmAnteTestSuite(t *testing.T) {
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.DynamicFeeTxType,
-	})
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.LegacyTxType,
-	})
-	suite.Run(t, &EvmAnteTestSuite{
-		ethTxType: gethtypes.AccessListTxType,
-	})
+	chainIDs := []string{utils.MainnetChainID + "-1", utils.SixDecChainID + "-1"}
+	for _, chainID := range chainIDs {
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.DynamicFeeTxType,
+			chainID:   chainID,
+		})
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.LegacyTxType,
+			chainID:   chainID,
+		})
+		suite.Run(t, &EvmAnteTestSuite{
+			ethTxType: gethtypes.AccessListTxType,
+			chainID:   chainID,
+		})
+	}
 }


### PR DESCRIPTION
# Description

Add support for custom decimals to account verification

## Testing

To test fixed ante:

```go
go test -v -tags=test ./app/ante/evm -run ^TestEvmAnteTestSuite$ -testify.m TestVerifyAccountBalance
```

Closes: #ENG-2689